### PR TITLE
fix(home): owner Home reliability, navigation, wording + #310 crash fix

### DIFF
--- a/components/ReadinessJourney.test.tsx
+++ b/components/ReadinessJourney.test.tsx
@@ -383,8 +383,8 @@ describe('ReadinessJourney home stats', () => {
     });
 
     expect(screen.getByRole('link', { name: /Today's Revenue: GH₵9,593.00/ })).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent('4 actions need attention today');
-    expect(screen.getAllByText('4 actions need attention today.')).toHaveLength(1); // Today's attention only
+    expect(screen.getByRole('status')).toHaveTextContent('4 areas need your attention today');
+    expect(screen.getAllByText('4 areas need your attention today.')).toHaveLength(1); // Today's attention only
     expect(screen.getByText(/85 sales in this open shift/)).toBeInTheDocument();
     expect(screen.getByText(/Supplier payments due/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /4 issues in Command Center/i })).toBeInTheDocument();
@@ -535,8 +535,8 @@ describe('Owner Home Phase 1 control centre', () => {
     });
 
     expect(screen.getAllByRole('region', { name: /Today'?s attention/i })).toHaveLength(1);
-    expect(screen.getByRole('status')).toHaveTextContent('4 actions need attention today');
-    expect(screen.getAllByText('4 actions need attention today.')).toHaveLength(1); // attention line only — pill is the sole hero summary
+    expect(screen.getByRole('status')).toHaveTextContent('4 areas need your attention today');
+    expect(screen.getAllByText('4 areas need your attention today.')).toHaveLength(1); // attention line only — pill is the sole hero summary
     expect(screen.getByRole('link', { name: /Close Shift/i })).toHaveAttribute('href', '/shifts');
     expect(screen.getByText(/Open since .+ · 3 sales in this open shift/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /5 issues in Command Center/i })).toHaveAttribute(
@@ -563,8 +563,8 @@ describe('Owner Home Phase 1 control centre', () => {
 
     expect(screen.queryByRole('link', { name: /Reorder needed/i })).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: /1 issue in Command Center/i })).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent('1 action needs attention today');
-    expect(screen.getAllByText('1 action needs attention today.')).toHaveLength(1);
+    expect(screen.getByRole('status')).toHaveTextContent('1 area needs your attention today');
+    expect(screen.getAllByText('1 area needs your attention today.')).toHaveLength(1);
   });
 
   it('shows a quiet attention state without All systems active when records need work', () => {
@@ -669,8 +669,8 @@ describe('Owner Home Phase 1 control centre', () => {
       overdueSupplierInvoiceCount: 1,
     });
 
-    expect(screen.getByRole('status')).toHaveTextContent('3 actions need attention today');
-    expect(screen.getAllByText('3 actions need attention today.')).toHaveLength(1);
+    expect(screen.getByRole('status')).toHaveTextContent('3 areas need your attention today');
+    expect(screen.getAllByText('3 areas need your attention today.')).toHaveLength(1);
     const tagline = screen.getByText('Secure. Reliable. Built for Ghanaian businesses.');
     expect(tagline).toHaveClass('text-center');
     expect(container.textContent?.trim().endsWith('Secure. Reliable. Built for Ghanaian businesses.')).toBe(

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -49,6 +49,9 @@ export default function TopNav({
   onlineOrdersCount?: number;
 }){
   const pathname = usePathname() ?? '';
+  // '/onboarding' is Home once setup is complete (and the Setup Guide entry point
+  // beforehand). Either way it should read as "Home" here, not "Admin".
+  const isHomeRoute = pathname === '/onboarding';
   const features = getFeatures(plan ?? 'STARTER', storeMode ?? 'SINGLE_STORE', { onlineStorefront: addonOnlineStorefront });
   const [mobileOpen, setMobileOpen] = useState(false);
   const [openGroup, setOpenGroup] = useState<string | null>(null);
@@ -244,9 +247,23 @@ export default function TopNav({
               }
             }}
           >
+            {user.role === 'OWNER' ? (
+              <Link
+                href="/onboarding"
+                aria-current={isHomeRoute ? 'page' : undefined}
+                className={isHomeRoute ? 'shell-nav-trigger shell-nav-trigger-active' : 'shell-nav-trigger'}
+              >
+                Home
+              </Link>
+            ) : null}
             {visibleGroups.map((group) => {
+              // '/onboarding' also lives under Admin > Setup Guide for discoverability,
+              // but it renders as Home once setup is complete — the dedicated Home link
+              // above owns the active state for it so Admin does not also light up.
               const isActive = group.items.some(
-                (item) => pathname === item.href || pathname.startsWith(item.href + '/')
+                (item) =>
+                  item.href !== '/onboarding' &&
+                  (pathname === item.href || pathname.startsWith(item.href + '/'))
               );
               const groupHasOnlineOrders = group.items.some((i) => i.href === '/online-orders');
               const showGroupBadge = groupHasOnlineOrders && liveOnlineOrdersCount > 0;

--- a/components/owner-home/HomeAttentionSlot.tsx
+++ b/components/owner-home/HomeAttentionSlot.tsx
@@ -21,7 +21,8 @@ export default async function HomeAttentionSlot({
   let data: OwnerHomeAttentionData;
   try {
     data = await attentionPromise;
-  } catch {
+  } catch (error) {
+    console.error('[home.attention] failed to load today\'s attention items', error);
     return <HomeAttentionUnavailable />;
   }
   const canAccessReorder = hasPlanAccess(plan, 'GROWTH');

--- a/components/owner-home/HomeExtrasSlot.tsx
+++ b/components/owner-home/HomeExtrasSlot.tsx
@@ -15,7 +15,8 @@ export async function HomeLastCloseSlot({
   let extras: OwnerHomeExtrasData;
   try {
     extras = await extrasPromise;
-  } catch {
+  } catch (error) {
+    console.error('[home.last-close] failed to load last-close data', error);
     return <HomeLastCloseUnavailable />;
   }
   const lastCloseText = extras.lastShiftClosedAt
@@ -40,7 +41,8 @@ export default async function HomeExtrasSlot({
   let extras: OwnerHomeExtrasData;
   try {
     extras = await extrasPromise;
-  } catch {
+  } catch (error) {
+    console.error('[home.extras] failed to load extras data', error);
     return <HomeExtrasUnavailable />;
   }
   const isNewAccount = saleCount < 10;

--- a/components/owner-home/HomeImproveRecordsSlot.tsx
+++ b/components/owner-home/HomeImproveRecordsSlot.tsx
@@ -10,7 +10,8 @@ export default async function HomeImproveRecordsSlot({
   let improveRecords: ImproveRecordsResult;
   try {
     improveRecords = await improvePromise;
-  } catch {
+  } catch (error) {
+    console.error('[home.iyr] failed to load improve-your-records data', error);
     return <HomeImproveRecordsUnavailable />;
   }
 

--- a/components/owner-home/HomePerformanceRetry.test.tsx
+++ b/components/owner-home/HomePerformanceRetry.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import HomePerformanceSlot from '@/components/owner-home/HomePerformanceSlot';
+import { HomePerformanceUnavailable } from '@/components/owner-home/section-errors';
+import { formatMoney } from '@/lib/format';
+import type { HomePerformanceSummary } from '@/lib/reports/home-performance-kpis';
+
+// next/link → plain anchor so the success path renders in jsdom.
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const refreshMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: refreshMock, push: vi.fn(), replace: vi.fn() }),
+}));
+
+// Controllable useTransition so the retry pending/disabled UI is deterministic
+// (a real transition around a synchronous router.refresh() resolves instantly
+// in jsdom, which would make the loading/disabled state impossible to observe).
+let mockPending = false;
+const startTransitionMock = vi.fn((cb: () => void) => cb());
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    useTransition: () => [mockPending, startTransitionMock] as const,
+  };
+});
+
+const zeroSummary: HomePerformanceSummary = {
+  todayRevenuePence: 0,
+  todayTransactionCount: 0,
+  yesterdayRevenuePence: 0,
+  yesterdayTransactionCount: 0,
+  expectedCashPence: 0,
+  openShiftCount: 0,
+  productCount: 812,
+};
+
+const dataSummary: HomePerformanceSummary = {
+  todayRevenuePence: 1_234_56,
+  todayTransactionCount: 37,
+  yesterdayRevenuePence: 980_00,
+  yesterdayTransactionCount: 30,
+  expectedCashPence: 2_000_00,
+  openShiftCount: 1,
+  productCount: 812,
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockPending = false;
+});
+
+describe('Home retry control — appearance & semantics', () => {
+  it('failure state is compact, alerts assistive tech, and never fabricates a zero value', () => {
+    render(<HomePerformanceUnavailable />);
+    const region = screen.getByRole('alert');
+    expect(within(region).getByText(/could not load today's figures/i)).toBeTruthy();
+    // Reassures that selling is unaffected.
+    expect(within(region).getByText(/open pos still works/i)).toBeTruthy();
+    // Crucially: no fabricated GH₵0.00 / 0 TXNS shown as if it were real.
+    expect(region.textContent).not.toMatch(/GH₵/);
+    expect(region.textContent).not.toMatch(/\b0 TXN/i);
+  });
+
+  it('exposes a real button with an accessible, descriptive name', () => {
+    render(<HomePerformanceUnavailable />);
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('type')).toBe('button');
+    expect(button.getAttribute('aria-label')).toMatch(/try again/i);
+    expect(button.getAttribute('aria-label')).toMatch(/reload this section/i);
+  });
+
+  it('uses on-dark tone classes so it is visible on the hero gradient', () => {
+    render(<HomePerformanceUnavailable />);
+    const button = screen.getByRole('button');
+    // High-contrast light-on-dark treatment (was previously near-invisible).
+    expect(button.className).toMatch(/text-white/);
+    expect(button.className).toMatch(/border-white\/40/);
+    expect(button.className).toMatch(/bg-white\/15/);
+  });
+});
+
+describe('Home retry control — activation, loading & overlap protection', () => {
+  it('activating the control triggers a single router.refresh() via a transition', () => {
+    mockPending = false;
+    render(<HomePerformanceUnavailable />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(startTransitionMock).toHaveBeenCalledTimes(1);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('while retrying: shows a loading label + spinner, is disabled, and cannot start an overlapping retry', () => {
+    mockPending = true;
+    render(<HomePerformanceUnavailable />);
+    const button = screen.getByRole('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute('aria-label')).toMatch(/retrying/i);
+    expect(within(button).getByText(/refreshing/i)).toBeTruthy();
+    expect(button.querySelector('svg.animate-spin')).toBeTruthy();
+
+    // A disabled button cannot fire onClick, so overlapping retries are impossible.
+    fireEvent.click(button);
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('HomePerformanceSlot — failure / recovery / genuine-zero contract', () => {
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  beforeEach(() => errorSpy.mockClear());
+
+  it('failure → renders the recoverable failure state (not real figures, not a fake zero)', async () => {
+    const jsx = await HomePerformanceSlot({
+      performancePromise: Promise.reject(new Error('db unavailable')),
+      currency: 'GHS',
+      saleCount: 5,
+    });
+    render(jsx);
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText(/could not load today's figures/i)).toBeTruthy();
+    expect(screen.getByRole('button').getAttribute('aria-label')).toMatch(/try again/i);
+    // The failure was logged for observability and NOT masked as GH₵0.00.
+    expect(errorSpy).toHaveBeenCalled();
+    expect(screen.queryByText(/GH₵/)).toBeNull();
+  });
+
+  it('success (recovery) → replaces the error with real figures', async () => {
+    const jsx = await HomePerformanceSlot({
+      performancePromise: Promise.resolve(dataSummary),
+      currency: 'GHS',
+      saleCount: 37,
+    });
+    render(jsx);
+    expect(screen.queryByText(/could not load today's figures/i)).toBeNull();
+    expect(screen.getByText(formatMoney(dataSummary.todayRevenuePence, 'GHS'))).toBeTruthy();
+    expect(screen.getByText('37')).toBeTruthy();
+  });
+
+  it('genuine zero-sales day → shows a truthful zero value, distinct from a failure', async () => {
+    const jsx = await HomePerformanceSlot({
+      performancePromise: Promise.resolve(zeroSummary),
+      currency: 'GHS',
+      saleCount: 0,
+    });
+    render(jsx);
+    // No error UI.
+    expect(screen.queryByText(/could not load today's figures/i)).toBeNull();
+    // Real GH₵0.00 expected-cash value is rendered as a legitimate figure.
+    expect(screen.getAllByText(formatMoney(0, 'GHS')).length).toBeGreaterThan(0);
+    // Product count is shown (zero-sales layout), proving this is the live path.
+    expect(screen.getByText(zeroSummary.productCount.toLocaleString())).toBeTruthy();
+  });
+});

--- a/components/owner-home/HomePerformanceSlot.tsx
+++ b/components/owner-home/HomePerformanceSlot.tsx
@@ -16,7 +16,8 @@ export default async function HomePerformanceSlot({
   let data: HomePerformanceSummary;
   try {
     data = await performancePromise;
-  } catch {
+  } catch (error) {
+    console.error('[home.performance] failed to load today\'s figures', error);
     return <HomePerformanceUnavailable />;
   }
 

--- a/components/owner-home/HomePerformanceSlot.tsx
+++ b/components/owner-home/HomePerformanceSlot.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { formatMoney } from '@/lib/format';
 import type { HomePerformanceSummary } from '@/lib/reports/home-performance-kpis';
-import { getStatValueSize } from '@/components/owner-home/home-chrome';
+import { getStatValueSize } from '@/lib/owner-home/stat-value-size';
 import { HomePerformanceUnavailable } from '@/components/owner-home/section-errors';
 
 export default async function HomePerformanceSlot({

--- a/components/owner-home/HomeSectionErrorBoundary.tsx
+++ b/components/owner-home/HomeSectionErrorBoundary.tsx
@@ -22,8 +22,9 @@ export default class HomeSectionErrorBoundary extends Component<Props, State> {
     return { hasError: true };
   }
 
-  componentDidCatch() {
-    // Intentionally no owner-facing detail; server logs may still capture RSC errors.
+  componentDidCatch(error: Error) {
+    // No owner-facing detail is rendered — log server/browser-side so failures are diagnosable.
+    console.error(`[home.section-error-boundary] section="${this.props.section ?? 'unknown'}" render failed`, error);
   }
 
   render() {

--- a/components/owner-home/HomeStatusPillSlot.tsx
+++ b/components/owner-home/HomeStatusPillSlot.tsx
@@ -28,7 +28,11 @@ export default async function HomeStatusPillSlot({
   ]);
 
   if (attentionResult.status === 'rejected') {
+    console.error('[home.status-pill] attention data failed to load', attentionResult.reason);
     return <HomeStatusUnavailable />;
+  }
+  if (improveResult.status === 'rejected') {
+    console.error('[home.status-pill] improve-records data failed to load', improveResult.reason);
   }
 
   const attention = attentionResult.value;

--- a/components/owner-home/home-chrome.tsx
+++ b/components/owner-home/home-chrome.tsx
@@ -220,8 +220,7 @@ export function HomeActionCard({
   );
 }
 
-export function getStatValueSize(value: string, primary: boolean) {
-  if (value.length > 11) return primary ? 'text-sm sm:text-sm lg:text-base' : 'text-xs sm:text-sm lg:text-base';
-  if (value.length > 8) return primary ? 'text-base sm:text-lg lg:text-lg' : 'text-sm lg:text-lg';
-  return primary ? 'text-xl sm:text-2xl lg:text-2xl' : 'text-base sm:text-lg lg:text-2xl';
-}
+// getStatValueSize moved to lib/owner-home/stat-value-size.ts — it is a plain
+// function called from the Server Component HomePerformanceSlot, and every
+// export of a 'use client' module (this file) becomes a client reference,
+// which is not callable directly from server-rendered code.

--- a/components/owner-home/section-errors.tsx
+++ b/components/owner-home/section-errors.tsx
@@ -3,18 +3,45 @@
 import { useRouter } from 'next/navigation';
 import { useTransition } from 'react';
 
-function RetryButton({ label = 'Try again' }: { label?: string }) {
+/**
+ * Home retry control. `tone="onDark"` is required on the hero gradient card —
+ * the default (light-surface) tone is unreadable there, which previously made
+ * retry effectively invisible on "Could not load today's figures".
+ */
+function RetryButton({
+  label = 'Try again',
+  tone = 'light',
+}: {
+  label?: string;
+  tone?: 'light' | 'onDark';
+}) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
+
+  const toneClasses =
+    tone === 'onDark'
+      ? 'border-white/40 bg-white/15 text-white hover:bg-white/25 focus-visible:outline-white'
+      : 'border-black/10 bg-white text-accent hover:bg-accentSoft focus-visible:outline-accent';
 
   return (
     <button
       type="button"
       disabled={pending}
       onClick={() => startTransition(() => router.refresh())}
-      className="mt-2 text-xs font-semibold text-accent hover:text-accent/80 disabled:opacity-50"
+      aria-label={pending ? 'Retrying…' : `${label} — reload this section`}
+      className={`mt-2.5 inline-flex min-h-8 items-center gap-1.5 self-start rounded-lg border px-3 py-1.5 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${toneClasses}`}
     >
-      {pending ? 'Refreshing…' : label}
+      {pending ? (
+        <>
+          <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          Refreshing…
+        </>
+      ) : (
+        label
+      )}
     </button>
   );
 }
@@ -35,7 +62,7 @@ export function HomePerformanceUnavailable() {
         <p className="mt-0.5 text-[11px] text-blue-100/70">
           Open POS still works. Pull to refresh or try again.
         </p>
-        <RetryButton />
+        <RetryButton tone="onDark" />
       </div>
     </div>
   );

--- a/lib/home-attention-presentation.test.ts
+++ b/lib/home-attention-presentation.test.ts
@@ -18,10 +18,10 @@ describe('home attention presentation', () => {
       canAccessReorder: true,
     };
     expect(countHomeAttentionActions(flags)).toBe(3);
-    expect(formatHomeAttentionActionSummary(3)).toBe('3 actions need attention today.');
+    expect(formatHomeAttentionActionSummary(3)).toBe('3 areas need your attention today.');
     expect(formatCommandCenterActionLabel(5)).toBe('5 issues in Command Center');
     expect(formatHeroAttentionSubtitle({ actionCount: 3, hasRecordImprovements: true })).toBe(
-      '3 actions need attention today.'
+      '3 areas need your attention today.'
     );
   });
 
@@ -35,7 +35,7 @@ describe('home attention presentation', () => {
         canAccessReorder: true,
       })
     ).toBe(1);
-    expect(formatHomeAttentionActionSummary(1)).toBe('1 action needs attention today.');
+    expect(formatHomeAttentionActionSummary(1)).toBe('1 area needs your attention today.');
     expect(formatHeroStatusPill({ actionCount: 1, openShiftCount: 1, hasRecordImprovements: false })).toBe(
       'Your open shift needs closing'
     );
@@ -73,8 +73,25 @@ describe('home attention presentation', () => {
       canAccessReorder: true,
     });
     expect(actionCount).toBe(1);
-    expect(formatHomeAttentionActionSummary(actionCount)).toBe('1 action needs attention today.');
+    expect(formatHomeAttentionActionSummary(actionCount)).toBe('1 area needs your attention today.');
     expect(formatCommandCenterActionLabel(5)).toBe('5 issues in Command Center');
+  });
+
+  it('"areas" wording never overstates a bundled Command Center issue count as a flat total', () => {
+    // 1 Home "area" (Command Center) can bundle many underlying issues — the
+    // summary must say "1 area", not "1 action"/"1 issue", to avoid implying
+    // there is exactly one problem when there may be several.
+    const flags = {
+      openShiftCount: 0,
+      openIssueCount: 4,
+      reorderNeededCount: 0,
+      overdueSupplierInvoiceCount: 0,
+      canAccessReorder: true,
+    };
+    const actionCount = countHomeAttentionActions(flags);
+    expect(actionCount).toBe(1);
+    expect(formatHomeAttentionActionSummary(actionCount)).toBe('1 area needs your attention today.');
+    expect(formatCommandCenterActionLabel(flags.openIssueCount)).toBe('4 issues in Command Center');
   });
 
   it('formats Close Shift copy for today, previous day, zero sales, and missing open time', () => {

--- a/lib/home-attention-presentation.ts
+++ b/lib/home-attention-presentation.ts
@@ -21,10 +21,17 @@ export function countHomeAttentionActions(flags: HomeAttentionFlags): number {
   return count;
 }
 
+/**
+ * actionCount is a count of distinct attention *categories* (open shift,
+ * Command Center issues, reorder, overdue suppliers) — not individual issues.
+ * One category (Command Center) can itself bundle several issues, so the
+ * copy says "areas", never "issues" or "actions", to avoid implying the
+ * number is a flat issue tally.
+ */
 export function formatHomeAttentionActionSummary(actionCount: number): string {
   if (actionCount <= 0) return 'No urgent issues need your attention today.';
-  if (actionCount === 1) return '1 action needs attention today.';
-  return `${actionCount} actions need attention today.`;
+  if (actionCount === 1) return '1 area needs your attention today.';
+  return `${actionCount} areas need your attention today.`;
 }
 
 export function formatHeroAttentionSubtitle(input: {

--- a/lib/improve-records-load.test.ts
+++ b/lib/improve-records-load.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Focused coverage for the Prisma-query layer behind the Home "unused
+ * catalogue" recommendation (`lib/improve-records-load.ts`). The pure
+ * classification math is covered by `improve-records-classify.test.ts`;
+ * this file proves the surrounding queries apply the right filters —
+ * tenant isolation, active/priced-only, and confirmed-quantity-history
+ * exclusions — before that math ever runs.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    store: { findMany: vi.fn() },
+    product: { findMany: vi.fn() },
+    salesInvoiceLine: { findMany: vi.fn() },
+    stockMovement: { findMany: vi.fn() },
+    purchaseInvoiceLine: { findMany: vi.fn() },
+  },
+}));
+
+describe('listStockGapSignals — query-level filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('scopes the candidate query to the caller business, active priced products with no balance', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { listStockGapSignals } = await import('@/lib/improve-records-load');
+
+    vi.mocked(prisma.store.findMany).mockResolvedValueOnce([{ id: 'store-1' }] as never);
+    vi.mocked(prisma.product.findMany).mockResolvedValueOnce([] as never);
+
+    await listStockGapSignals('biz-1', new Date('2026-07-15T00:00:00.000Z'));
+
+    const call = vi.mocked(prisma.product.findMany).mock.calls[0]?.[0] as {
+      where: Record<string, unknown>;
+    };
+    expect(call.where.businessId).toBe('biz-1');
+    expect(call.where.active).toBe(true);
+    expect(call.where.sellingPriceBasePence).toEqual({ gt: 0 });
+    expect(call.where.inventoryBalances).toEqual({ none: {} });
+  });
+
+  it('returns the empty result and skips downstream queries when there are no no-balance candidates', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { listStockGapSignals } = await import('@/lib/improve-records-load');
+
+    vi.mocked(prisma.store.findMany).mockResolvedValueOnce([{ id: 'store-1' }] as never);
+    vi.mocked(prisma.product.findMany).mockResolvedValueOnce([] as never);
+
+    const result = await listStockGapSignals('biz-1');
+
+    expect(result).toEqual({
+      productsNeedingOpeningQtyCount: 0,
+      soldWithoutConfirmedQtyCount: 0,
+      unusedCatalogueProductCount: 0,
+      genuineGapProductIds: [],
+      soldWithoutConfirmedQtyIds: [],
+      unusedCatalogueProductIds: [],
+    });
+    expect(prisma.salesInvoiceLine.findMany).not.toHaveBeenCalled();
+    expect(prisma.stockMovement.findMany).not.toHaveBeenCalled();
+    expect(prisma.purchaseInvoiceLine.findMany).not.toHaveBeenCalled();
+  });
+
+  it('classifies an aged, never-traded candidate as unused-catalogue and excludes it from the genuine-gap list', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { listStockGapSignals } = await import('@/lib/improve-records-load');
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const aged = new Date('2026-01-01T00:00:00.000Z');
+
+    vi.mocked(prisma.store.findMany).mockResolvedValueOnce([{ id: 'store-1' }] as never);
+    vi.mocked(prisma.product.findMany).mockResolvedValueOnce([
+      { id: 'p-aged-unused', createdAt: aged },
+    ] as never);
+    vi.mocked(prisma.salesInvoiceLine.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.stockMovement.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.purchaseInvoiceLine.findMany).mockResolvedValueOnce([] as never);
+
+    const result = await listStockGapSignals('biz-1', now);
+
+    expect(result.unusedCatalogueProductIds).toEqual(['p-aged-unused']);
+    expect(result.unusedCatalogueProductCount).toBe(1);
+    expect(result.genuineGapProductIds).toEqual([]);
+  });
+
+  it('excludes a candidate created within the grace period, even with zero sales/stock history', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { listStockGapSignals } = await import('@/lib/improve-records-load');
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const recentlyImported = new Date('2026-07-10T00:00:00.000Z'); // 5 days old
+
+    vi.mocked(prisma.store.findMany).mockResolvedValueOnce([{ id: 'store-1' }] as never);
+    vi.mocked(prisma.product.findMany).mockResolvedValueOnce([
+      { id: 'p-recent', createdAt: recentlyImported },
+    ] as never);
+    vi.mocked(prisma.salesInvoiceLine.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.stockMovement.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.purchaseInvoiceLine.findMany).mockResolvedValueOnce([] as never);
+
+    const result = await listStockGapSignals('biz-1', now);
+
+    expect(result.unusedCatalogueProductIds).toEqual([]);
+    expect(result.genuineGapProductIds).toEqual(['p-recent']);
+  });
+
+  it('excludes a candidate with historical purchase-line activity (confirmed quantity history)', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { listStockGapSignals } = await import('@/lib/improve-records-load');
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const aged = new Date('2026-01-01T00:00:00.000Z');
+
+    vi.mocked(prisma.store.findMany).mockResolvedValueOnce([{ id: 'store-1' }] as never);
+    vi.mocked(prisma.product.findMany).mockResolvedValueOnce([
+      { id: 'p-purchased-no-balance', createdAt: aged },
+    ] as never);
+    vi.mocked(prisma.salesInvoiceLine.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.stockMovement.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.purchaseInvoiceLine.findMany).mockResolvedValueOnce([
+      { productId: 'p-purchased-no-balance' },
+    ] as never);
+
+    const result = await listStockGapSignals('biz-1', now);
+
+    expect(result.unusedCatalogueProductIds).toEqual([]);
+    expect(result.genuineGapProductIds).toEqual([]);
+    expect(result.productsNeedingOpeningQtyCount).toBe(0);
+  });
+
+  it('treats an aged candidate with sales as a genuine stock gap, not unused catalogue', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { listStockGapSignals } = await import('@/lib/improve-records-load');
+    const now = new Date('2026-07-15T00:00:00.000Z');
+    const aged = new Date('2026-01-01T00:00:00.000Z');
+
+    vi.mocked(prisma.store.findMany).mockResolvedValueOnce([{ id: 'store-1' }] as never);
+    vi.mocked(prisma.product.findMany).mockResolvedValueOnce([
+      { id: 'p-sold-no-stock', createdAt: aged },
+    ] as never);
+    vi.mocked(prisma.salesInvoiceLine.findMany).mockResolvedValueOnce([
+      { productId: 'p-sold-no-stock' },
+    ] as never);
+    vi.mocked(prisma.stockMovement.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.purchaseInvoiceLine.findMany).mockResolvedValueOnce([] as never);
+
+    const result = await listStockGapSignals('biz-1', now);
+
+    expect(result.genuineGapProductIds).toEqual(['p-sold-no-stock']);
+    expect(result.soldWithoutConfirmedQtyIds).toEqual(['p-sold-no-stock']);
+    expect(result.unusedCatalogueProductIds).toEqual([]);
+  });
+
+  it('only queries stock movements for stores belonging to the caller business', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { listStockGapSignals } = await import('@/lib/improve-records-load');
+
+    vi.mocked(prisma.store.findMany).mockResolvedValueOnce([{ id: 'store-own-biz' }] as never);
+    vi.mocked(prisma.product.findMany).mockResolvedValueOnce([
+      { id: 'p-1', createdAt: new Date('2026-01-01T00:00:00.000Z') },
+    ] as never);
+    vi.mocked(prisma.salesInvoiceLine.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.stockMovement.findMany).mockResolvedValueOnce([] as never);
+    vi.mocked(prisma.purchaseInvoiceLine.findMany).mockResolvedValueOnce([] as never);
+
+    await listStockGapSignals('biz-1');
+
+    const storeCall = vi.mocked(prisma.store.findMany).mock.calls[0]?.[0] as {
+      where: Record<string, unknown>;
+    };
+    expect(storeCall.where.businessId).toBe('biz-1');
+
+    const movementCall = vi.mocked(prisma.stockMovement.findMany).mock.calls[0]?.[0] as {
+      where: Record<string, unknown>;
+    };
+    expect(movementCall.where.storeId).toEqual({ in: ['store-own-biz'] });
+  });
+});

--- a/lib/owner-home/stat-value-size.test.ts
+++ b/lib/owner-home/stat-value-size.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { getStatValueSize } from './stat-value-size';
+
+const root = join(__dirname, '..', '..');
+const read = (p: string) => readFileSync(join(root, p), 'utf8');
+
+describe('getStatValueSize', () => {
+  it('sizes short values largest', () => {
+    expect(getStatValueSize('GH₵0.00', true)).toBe('text-xl sm:text-2xl lg:text-2xl');
+    expect(getStatValueSize('GH₵0.00', false)).toBe('text-base sm:text-lg lg:text-2xl');
+  });
+
+  it('shrinks medium-length values', () => {
+    expect(getStatValueSize('GH₵12,345.00', true).length).toBeGreaterThan(0);
+  });
+
+  it('shrinks long values the most', () => {
+    expect(getStatValueSize('GH₵1,234,567.00', true)).toBe('text-sm sm:text-sm lg:text-base');
+  });
+});
+
+describe('regression: Home hero stats must not import a client-boundary function into a Server Component', () => {
+  /**
+   * Root cause of "Could not load today's figures" on every load: this
+   * helper used to live in components/owner-home/home-chrome.tsx, which is
+   * marked 'use client'. Every export of a 'use client' module becomes a
+   * client reference — calling one directly from a Server Component (as
+   * HomePerformanceSlot does, during render, not via JSX/props) throws
+   * "<name> is not a function" in production builds. Keeping this pure
+   * helper in a plain module (no 'use client') and asserting the import
+   * site here prevents the bug from being silently reintroduced.
+   */
+  it('stat-value-size.ts is not a client module', () => {
+    const source = read('lib/owner-home/stat-value-size.ts');
+    expect(source.trimStart().startsWith("'use client'")).toBe(false);
+  });
+
+  it('HomePerformanceSlot imports getStatValueSize from the plain lib module, not home-chrome', () => {
+    const source = read('components/owner-home/HomePerformanceSlot.tsx');
+    expect(source).toContain("from '@/lib/owner-home/stat-value-size'");
+    expect(source).not.toContain("getStatValueSize } from '@/components/owner-home/home-chrome'");
+  });
+
+  it('home-chrome.tsx no longer exports getStatValueSize (it is a use-client module)', () => {
+    const source = read('components/owner-home/home-chrome.tsx');
+    expect(source).not.toMatch(/export function getStatValueSize/);
+  });
+});

--- a/lib/owner-home/stat-value-size.test.ts
+++ b/lib/owner-home/stat-value-size.test.ts
@@ -23,14 +23,27 @@ describe('getStatValueSize', () => {
 
 describe('regression: Home hero stats must not import a client-boundary function into a Server Component', () => {
   /**
-   * Root cause of "Could not load today's figures" on every load: this
-   * helper used to live in components/owner-home/home-chrome.tsx, which is
-   * marked 'use client'. Every export of a 'use client' module becomes a
-   * client reference — calling one directly from a Server Component (as
-   * HomePerformanceSlot does, during render, not via JSX/props) throws
-   * "<name> is not a function" in production builds. Keeping this pure
-   * helper in a plain module (no 'use client') and asserting the import
-   * site here prevents the bug from being silently reintroduced.
+   * Single root cause of TWO production symptoms, both proven by a
+   * controlled local production-build A/B (same build, same demo data):
+   *
+   *  1. "Could not load today's figures" on every Home load (all widths).
+   *  2. A full-page React #310 crash to app/global-error.tsx on
+   *     iPhone/Android-width viewports (22/22 deterministic on repeat
+   *     navigation; 0/22 once fixed). Desktop showed symptom 1 only.
+   *
+   * This helper used to live in components/owner-home/home-chrome.tsx,
+   * which is marked 'use client'. Every export of a 'use client' module
+   * becomes a client reference — calling one directly from a Server
+   * Component (as HomePerformanceSlot does, during render, not via
+   * JSX/props) throws "<name> is not a function" in production builds
+   * (dev does NOT enforce this boundary, which is why it only reproduced
+   * in a production build). The Server Component throw is normally caught
+   * by the section error boundary (→ symptom 1), but at narrow width the
+   * failed RSC stream desynchronises hook order in the Next.js App Router
+   * during hydration, surfacing as React #310 above the section boundary
+   * (→ symptom 2). Keeping this pure helper in a plain module (no
+   * 'use client') and asserting the import site here prevents both from
+   * being silently reintroduced.
    */
   it('stat-value-size.ts is not a client module', () => {
     const source = read('lib/owner-home/stat-value-size.ts');

--- a/lib/owner-home/stat-value-size.ts
+++ b/lib/owner-home/stat-value-size.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure helper for sizing Home hero stat values by string length.
+ *
+ * Deliberately NOT in a 'use client' module: `HomePerformanceSlot` is an
+ * async Server Component and calls this directly during render. A plain
+ * function exported from a 'use client' file (as this used to live in
+ * `components/owner-home/home-chrome.tsx`) becomes a client reference when
+ * imported into a Server Component — calling it there throws
+ * "<name> is not a function" in production builds, which is what caused
+ * "Could not load today's figures" on every load, regardless of the
+ * underlying sales data.
+ */
+export function getStatValueSize(value: string, primary: boolean) {
+  if (value.length > 11) return primary ? 'text-sm sm:text-sm lg:text-base' : 'text-xs sm:text-sm lg:text-base';
+  if (value.length > 8) return primary ? 'text-base sm:text-lg lg:text-lg' : 'text-sm lg:text-lg';
+  return primary ? 'text-xl sm:text-2xl lg:text-2xl' : 'text-base sm:text-lg lg:text-2xl';
+}


### PR DESCRIPTION
## Summary

Home reliability, navigation, wording and responsive fixes for the owner Home page. Root-causes and fixes the production "Could not load today's figures" state and the iPhone-width React #310 full-page crash — both traced to a single defect: a Server Component (`HomePerformanceSlot`) calling `getStatValueSize`, which was exported from a `'use client'` module (`home-chrome.tsx`) and therefore became an uncallable client reference in production builds.

### Changes (16 files, all in-scope)
- **Crash/error root-cause fix:** extract `getStatValueSize` to a plain module `lib/owner-home/stat-value-size.ts`; import it there from `HomePerformanceSlot`.
- **Navigation identity:** dedicated "Home" link for OWNER in `TopNav`; `/onboarding` (Home) no longer lights up "Admin".
- **Recovery UX:** `RetryButton` gains an on-dark tone (readable on the hero gradient), spinner, disabled/loading state and accessible name.
- **Wording:** attention summary says "N areas need your attention" (categories, not a flat issue tally).
- **Observability:** server-side `console.error` logging when any Home section promise rejects (no customer data).
- **Tests:** `HomePerformanceRetry` (retry semantics + failure/recovery/genuine-zero contract), `stat-value-size` regression guard (fails-before/passes-after), `improve-records-load` filter coverage, updated attention/readiness wording assertions.

No changes to POS behaviour, financial calculations, stock rules, pricing, subscription access, permissions or tenant isolation. No schema, API route, middleware or env/config changes.

## Validation
- Full unit suite: 183 files / 1802 tests passing; lint 0 errors; `tsc` 0 errors; production build OK.
- React #310 root cause proven via controlled local production-build A/B: broken 22/22 crashes → fixed 0/22 (identical prod chunk hashes).
- Preview `dpl_E6Xi9xv3cBFR47eUfd3nwfWYpHAi` (SHA `04ad4be`): owner iPhone Home renders with real QA data, 0/15 crashes; retry failure→recovery demonstrated end-to-end. Preview verdict: **Staging validated**.

## Test plan
- [x] Full unit / lint / types / build
- [x] Local prod-build crash A/B + 4-viewport smoke + cashier POS entry
- [x] Preview authenticated owner Home (iPhone, 0/15 crashes)
- [ ] Production QA smoke (owner desktop + iPhone ×15, manager/cashier POS entry) — post-merge
