### PR TITLE
fix(home): unused-catalogue wording, All-branches scope label, Home nav align

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -627,7 +627,9 @@ html:has(input:focus, textarea:focus, select:focus) .safe-floating-bottom {
   }
 
   .shell-nav-trigger {
-    @apply h-9 rounded-xl px-3 py-0 text-sm font-semibold text-gray-600;
+    /* inline-flex + items-center keeps <a Home> and <button> group labels on the
+       same vertical centre — links were display:block and sat high in the pill. */
+    @apply inline-flex h-9 items-center justify-center rounded-xl px-3 py-0 text-sm font-semibold leading-none text-gray-600;
     transition: color var(--motion-fast) ease, background-color var(--motion-fast) ease, box-shadow var(--motion-base) var(--ease-executive), transform var(--motion-fast) ease;
   }
 

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -19,6 +19,7 @@ import NavMobileMenu from './NavMobileMenu';
 import NavIcon from './navigation/NavIcon';
 import { OPEN_MOBILE_NAV_EVENT } from './BottomTabBar';
 import { NAV_KPI_REFRESH_EVENT, type NavKpiRefreshDetail } from '@/lib/navigation/nav-kpi-events';
+import { mobileReportingScopeLabel } from '@/lib/navigation/mobile-scope-label';
 
 export type TopNavUser = {
   name: string;
@@ -115,6 +116,13 @@ export default function TopNav({
 
   const showMobileSalesPulse = Boolean(liveTodaySales) && !pathname.startsWith('/onboarding');
   const mobileSales = showMobileSalesPulse ? liveTodaySales : undefined;
+  // Home KPIs are always business-wide. Never show the operational store name
+  // as if it filtered Home ("Main Branch" beside "Today · All branches").
+  const mobileScopeLabel = mobileReportingScopeLabel({
+    pathname,
+    storeName,
+    showingBusinessWideSalesPulse: Boolean(mobileSales),
+  });
 
   useEffect(() => {
     setLiveTodaySales(todaySales);
@@ -503,9 +511,16 @@ export default function TopNav({
 
         <div className="border-t border-slate-200/60 bg-white/80 px-4 py-2 lg:hidden sm:px-6">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="metric-chip">
+            <span
+              className="metric-chip"
+              title={
+                mobileScopeLabel === 'All branches'
+                  ? 'Figures shown in this header are across all branches'
+                  : 'Operational branch for this session'
+              }
+            >
               <span className="h-2 w-2 rounded-full bg-accent" aria-hidden="true" />
-              {mobileSales ? 'All branches' : (storeName || 'Main branch')}
+              {mobileScopeLabel}
             </span>
             <span className={isOnline ? 'status-badge-online' : 'status-badge-offline'}>
               {isOnline ? 'Sync ready' : 'Offline mode'}

--- a/lib/improve-records-classify.test.ts
+++ b/lib/improve-records-classify.test.ts
@@ -48,6 +48,17 @@ describe('classifyNoBalanceProduct', () => {
     ).toBe('unused-catalogue');
   });
 
+  it('keeps confirmed-zero / balance-present products out of this classifier entirely', () => {
+    // InventoryBalance rows (including qty 0) are excluded by the loader candidate query
+    // (inventoryBalances: { none: {} }). This classifier only sees no-balance products.
+    expect(
+      classifyNoBalanceProduct(
+        { createdAt: aged, hasSales: false, hasConfirmedQuantityHistory: false },
+        now
+      )
+    ).not.toBe('exclude');
+  });
+
   it('uses the named age threshold', () => {
     const cutoff = catalogueCutoffDate(now);
     const justInside = new Date(cutoff.getTime() + 60_000);

--- a/lib/improve-records-issues.ts
+++ b/lib/improve-records-issues.ts
@@ -42,9 +42,9 @@ export const IMPROVE_RECORDS_ISSUE_DEFS: Record<
     key: 'UNUSED_CATALOGUE',
     heading: 'Unused catalogue products',
     explanation:
-      'These products have never been stocked or sold. Review whether you still intend to carry them.',
+      'These active products are older than 14 days, have no confirmed stock quantity and no sales. Review whether you still intend to carry them.',
     href: '/products?issue=UNUSED_CATALOGUE',
-    recordStatusLabel: 'Never stocked or sold',
+    recordStatusLabel: 'No stock quantity or sales',
     homeReturnHref: HOME_RETURN,
   },
   MISSING_COST: {

--- a/lib/improve-records-load.ts
+++ b/lib/improve-records-load.ts
@@ -7,6 +7,14 @@
  * stocked if ANY store has an InventoryBalance row. Multi-branch: stocking at
  * any valid branch prevents “never stocked” classification. The UI does not
  * name a branch because the signal is business-scoped.
+ *
+ * Two mutually exclusive no-balance buckets (same candidate query):
+ * - genuine-gap → Home “confirmed stock quantity” wording (recent and/or sold)
+ * - unused-catalogue → Home “no confirmed stock quantity and no sales” wording
+ *   (aged > UNUSED_CATALOGUE_AGE_DAYS, never sold, no confirmed quantity history)
+ *
+ * Confirmed-zero stock (InventoryBalance with qty 0) is NOT a candidate — the
+ * product already has a balance row.
  */
 
 import { prisma } from '@/lib/prisma';

--- a/lib/improve-records.test.ts
+++ b/lib/improve-records.test.ts
@@ -164,9 +164,43 @@ describe('Improve Your Records recommendation engine', () => {
     );
     expect(result.primary?.key).toBe('unused-catalogue');
     expect(result.primary?.title).toBe('Review unused catalogue products');
-    expect(result.primary?.explanation).toContain('never been stocked or sold');
+    expect(result.primary?.explanation).toContain('no confirmed stock quantity and no sales');
+    expect(result.primary?.explanation).toContain('older than 14 days');
+    expect(result.primary?.explanation).not.toContain('never been stocked or sold');
     expect(result.primary?.explanation).not.toContain('opening quantity');
     expect(result.primary?.href).toBe('/products?issue=UNUSED_CATALOGUE');
+  });
+
+  it('Preview-vs-production card split: recent no-balance → stock-completeness; aged → unused-catalogue', () => {
+    // Same conceptual population (active priced, no InventoryBalance) lands in
+    // different Home cards based on age/sales — explaining why Preview showed
+    // "600 … confirmed stock quantity" while production showed an unused-catalogue count.
+    const recentGap = computeImproveRecords(
+      base({
+        productsNeedingOpeningQtyCount: 600,
+        unusedCatalogueProductCount: 0,
+        openingBalancesStatus: 'complete',
+        purchasesNeedingSupplierCount: 0,
+        purchaseCount: 10,
+      })
+    );
+    expect(recentGap.primary?.key).toBe('stock-completeness');
+    expect(recentGap.primary?.explanation).toContain(
+      '600 active products still need a confirmed stock quantity'
+    );
+
+    const agedUnused = computeImproveRecords(
+      base({
+        productsNeedingOpeningQtyCount: 0,
+        unusedCatalogueProductCount: 592,
+        openingBalancesStatus: 'complete',
+        purchasesNeedingSupplierCount: 0,
+        purchaseCount: 10,
+      })
+    );
+    expect(agedUnused.primary?.key).toBe('unused-catalogue');
+    expect(agedUnused.primary?.explanation).toContain('592 active products older than 14 days');
+    expect(agedUnused.primary?.explanation).toContain('no confirmed stock quantity and no sales');
   });
 
   it('EL-SHADDAI-shaped: unused catalogue does not outrank genuine unpaid supplier', () => {

--- a/lib/improve-records.ts
+++ b/lib/improve-records.ts
@@ -7,6 +7,7 @@
 import type { OpeningBalancesStatus } from '@/lib/opening-balances-status';
 import { openingBalancesNeedsAttention } from '@/lib/opening-balances-status';
 import { IMPROVE_RECORDS_ISSUE_DEFS } from '@/lib/improve-records-issues';
+import { UNUSED_CATALOGUE_AGE_DAYS } from '@/lib/improve-records-constants';
 
 export type ImproveRecordsRole = 'OWNER' | 'MANAGER' | 'CASHIER';
 export type ImproveRecordsPlan = 'STARTER' | 'GROWTH' | 'PRO';
@@ -224,7 +225,11 @@ export function buildImproveRecordsCandidates(
     items.push({
       key: 'unused-catalogue',
       title: 'Review unused catalogue products',
-      explanation: `${n} product${n === 1 ? ' has' : 's have'} never been stocked or sold. Confirm whether you still intend to carry ${n === 1 ? 'it' : 'them'}.`,
+      // Wording matches the proven loader rule: active + priced + no InventoryBalance
+      // anywhere + no confirmed quantity history + no non-voided sales + older than
+      // UNUSED_CATALOGUE_AGE_DAYS. Do not say "never stocked" alone — that overclaims
+      // relative to "no confirmed stock quantity recorded".
+      explanation: `${n} active product${n === 1 ? '' : 's'} older than ${UNUSED_CATALOGUE_AGE_DAYS} days ${n === 1 ? 'has' : 'have'} no confirmed stock quantity and no sales. Confirm whether you still intend to carry ${n === 1 ? 'it' : 'them'}.`,
       actionLabel: 'Review catalogue',
       href: IMPROVE_RECORDS_ISSUE_DEFS.UNUSED_CATALOGUE.href,
       priority: 45,

--- a/lib/navigation/mobile-scope-label.test.ts
+++ b/lib/navigation/mobile-scope-label.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { mobileReportingScopeLabel } from '@/lib/navigation/mobile-scope-label';
+
+describe('mobileReportingScopeLabel', () => {
+  it('always shows All branches on Home, even when a store name exists and KPIs have not loaded', () => {
+    expect(
+      mobileReportingScopeLabel({
+        pathname: '/onboarding',
+        storeName: 'Main Branch',
+        showingBusinessWideSalesPulse: false,
+      }),
+    ).toBe('All branches');
+  });
+
+  it('shows All branches on nested Home paths', () => {
+    expect(
+      mobileReportingScopeLabel({
+        pathname: '/onboarding/setup',
+        storeName: 'Main',
+        showingBusinessWideSalesPulse: false,
+      }),
+    ).toBe('All branches');
+  });
+
+  it('shows All branches off Home when the business-wide sales pulse is visible', () => {
+    expect(
+      mobileReportingScopeLabel({
+        pathname: '/sales',
+        storeName: 'Main Branch',
+        showingBusinessWideSalesPulse: true,
+      }),
+    ).toBe('All branches');
+  });
+
+  it('shows the operational store name off Home when the sales pulse is hidden', () => {
+    expect(
+      mobileReportingScopeLabel({
+        pathname: '/pos',
+        storeName: 'Main Branch',
+        showingBusinessWideSalesPulse: false,
+      }),
+    ).toBe('Main Branch');
+  });
+
+  it('falls back to Main branch when no store name is available off Home', () => {
+    expect(
+      mobileReportingScopeLabel({
+        pathname: '/pos',
+        storeName: null,
+        showingBusinessWideSalesPulse: false,
+      }),
+    ).toBe('Main branch');
+  });
+});

--- a/lib/navigation/mobile-scope-label.ts
+++ b/lib/navigation/mobile-scope-label.ts
@@ -1,0 +1,23 @@
+/**
+ * Mobile header chip label for reporting/operational scope.
+ *
+ * Home (`/onboarding`) always reports business-wide KPIs ("Today · All branches").
+ * The chip must not show the operational store name there — that previously made
+ * "Main Branch" appear beside "All branches" on the same screen.
+ *
+ * Off Home, when the business-wide today-sales pulse is showing, the chip also
+ * says "All branches". Otherwise it shows the user's operational store identity.
+ */
+export function mobileReportingScopeLabel(input: {
+  pathname: string;
+  storeName?: string | null;
+  showingBusinessWideSalesPulse: boolean;
+}): string {
+  const path = input.pathname || '';
+  const isHome = path === '/onboarding' || path.startsWith('/onboarding/');
+  if (isHome || input.showingBusinessWideSalesPulse) {
+    return 'All branches';
+  }
+  const name = input.storeName?.trim();
+  return name || 'Main branch';
+}

--- a/lib/reports/dashboard-clarity.test.ts
+++ b/lib/reports/dashboard-clarity.test.ts
@@ -305,6 +305,8 @@ describe('Reports navigation clarity', () => {
     expect(styles).toContain('.shell-nav-card-link');
     expect(styles).toContain('.shell-nav-icon-badge');
     expect(styles).toContain('.shell-nav-trigger-active:hover');
+    // Home is an <a>; group labels are <button>. Shared flex centering keeps text baselines aligned.
+    expect(styles).toMatch(/\.shell-nav-trigger\s*\{[\s\S]*?inline-flex[\s\S]*?items-center/);
     expect(styles).toContain('text-blue-900');
     expect(styles).toContain('@media (prefers-reduced-motion: reduce)');
   });

--- a/lib/reports/mobile-dashboard-consistency.test.ts
+++ b/lib/reports/mobile-dashboard-consistency.test.ts
@@ -38,7 +38,8 @@ describe('Mobile dashboard sales consistency', () => {
 
     expect(commandCenter).toContain('All branches');
     expect(commandCenter).not.toContain("store?.name ?? 'Main branch'");
-    expect(topNav).toContain("mobileSales ? 'All branches'");
+    expect(topNav).toContain('mobileReportingScopeLabel');
+    expect(topNav).toContain('mobileScopeLabel');
     expect(mobileMenu).not.toContain('Today sales · all branches');
     expect(mobileMenu).not.toContain('Transactions · all branches');
     expect(mobileMenu).toContain('Quick actions');


### PR DESCRIPTION
## Summary
- Align unused-catalogue Home/issue wording with the proven eligibility rule (active, >14 days, no confirmed stock quantity, no sales) — replaces overclaiming \"never been stocked or sold\".
- Keep Home chip on \"All branches\" so it matches business-wide hero KPIs (no more Main Branch vs All branches mismatch).
- CSS-only: centre desktop Home trigger text with sibling nav labels via shared `inline-flex items-center`.

## Test plan
- [x] Unit suite / targeted improve-records + scope-label tests
- [x] Preview smoke: Home chip + hero both All branches; stock-gap wording correct
- [ ] Production smoke after merge: scope labels, unused wording if shown, manager/cashier POS, no #310

Approved data-quality candidate: `3df9746`
Nav-align follow-up (this PR tip): `81dbfc2`