### PR TITLE
test: isolate Phase 3A QA from Next request-context APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:e2e:authenticated:owner": "playwright test --project=owner-chromium --project=owner-cold-boot-chromium",
     "test:e2e:authenticated:setup": "playwright test --project=setup-auth",
     "test:e2e:authenticated:prod": "node scripts/run-playwright-qa.mjs",
-    "test:qa:phase3a": "tsx scripts/phase3a-qa.ts",
+    "test:qa:phase3a": "node ./scripts/run-phase3a.cjs",
     "test:qa:phase3b": "tsx scripts/phase3b-qa.ts",
     "test:perf": "node scripts/page-speed-check.js",
     "db:generate:local": "node scripts/generate-local-prisma-client.mjs",

--- a/scripts/phase3a-harness.cjs
+++ b/scripts/phase3a-harness.cjs
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * Phase 3A standalone harness.
+ *
+ * Phase 3A runs financial service assertions under plain `tsx` (no Next
+ * request). That import path transitively loads:
+ *   phase3a-qa → sales/returns → action-utils → auth → react.cache
+ *   phase3a-qa → sales → next/cache.unstable_cache
+ *
+ * Stock React 18.2 has no `cache`; Next's request runtime supplies it.
+ * `unstable_cache` requires Next's incremental cache and throws outside a
+ * request. Vitest already stubs both for unit tests — this harness mirrors
+ * only that framework boundary for the QA script.
+ *
+ * Important: tsx's CJS interop copies enumerable named exports. A Proxy trap
+ * alone is not enough — `cache` must be an own enumerable property.
+ *
+ * It does NOT mock Prisma, createSale, cash-drawer math, or invent results.
+ */
+
+const Module = require('module');
+
+function harnessAssert(condition, message) {
+  if (!condition) {
+    throw new Error(`[phase3a-harness] ${message}`);
+  }
+}
+
+function identityCache(fn) {
+  harnessAssert(typeof fn === 'function', 'react.cache expected a function');
+  return fn;
+}
+
+function passThroughUnstableCache(fn, _keyParts, _options) {
+  harnessAssert(typeof fn === 'function', 'unstable_cache expected a function');
+  return fn;
+}
+
+function shimReactExports(react) {
+  harnessAssert(react && typeof react === 'object', 'react module did not resolve to an object');
+  if (typeof react.cache !== 'function') {
+    Object.defineProperty(react, 'cache', {
+      value: identityCache,
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  }
+  harnessAssert(typeof react.cache === 'function', 'failed to install react.cache shim');
+}
+
+function shimNextCacheExports(nextCache) {
+  harnessAssert(
+    nextCache && typeof nextCache === 'object' && typeof nextCache.unstable_cache === 'function',
+    'next/cache must export unstable_cache (dependency/export change?)',
+  );
+  if (nextCache.unstable_cache !== passThroughUnstableCache) {
+    Object.defineProperty(nextCache, 'unstable_cache', {
+      value: passThroughUnstableCache,
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  }
+  harnessAssert(
+    typeof nextCache.unstable_cache === 'function',
+    'failed to install next/cache.unstable_cache shim',
+  );
+}
+
+const status = globalThis.__PHASE3A_HARNESS__ ?? {
+  reactCacheShimmed: false,
+  unstableCacheShimmed: false,
+  loadHookInstalled: false,
+};
+
+if (!status.loadHookInstalled) {
+  const originalLoad = Module._load;
+  Module._load = function phase3aHarnessLoad(request, parent, isMain) {
+    if (request === 'react') {
+      const react = originalLoad.apply(this, arguments);
+      shimReactExports(react);
+      status.reactCacheShimmed = true;
+      return react;
+    }
+    if (request === 'next/cache') {
+      const nextCache = originalLoad.apply(this, arguments);
+      shimNextCacheExports(nextCache);
+      status.unstableCacheShimmed = true;
+      return nextCache;
+    }
+    return originalLoad.apply(this, arguments);
+  };
+  status.loadHookInstalled = true;
+}
+
+function ensureLoadedShims() {
+  const react = require('react');
+  shimReactExports(react);
+  status.reactCacheShimmed = true;
+
+  const nextCache = require('next/cache');
+  shimNextCacheExports(nextCache);
+  status.unstableCacheShimmed = true;
+}
+
+ensureLoadedShims();
+globalThis.__PHASE3A_HARNESS__ = status;
+module.exports = { ensureLoadedShims, status };

--- a/scripts/phase3a-qa.ts
+++ b/scripts/phase3a-qa.ts
@@ -76,6 +76,14 @@ async function closeOpenShiftsForTill(tillId: string) {
 }
 
 async function run() {
+  const harness = (globalThis as { __PHASE3A_HARNESS__?: { reactCacheShimmed: boolean; unstableCacheShimmed: boolean } })
+    .__PHASE3A_HARNESS__;
+  if (!harness?.reactCacheShimmed || !harness?.unstableCacheShimmed) {
+    throw new Error(
+      'Phase 3A standalone harness is not active. Run via `npm run test:qa:phase3a` (loads scripts/phase3a-harness.cjs).',
+    );
+  }
+
   const report = {
     momo: {
       initiatePending: false,
@@ -477,7 +485,14 @@ async function run() {
       userId: owner.id,
     });
 
-    const riskAfter = await prisma.riskAlert.count({ where: { businessId: business.id } });
+    // Service-layer risk detection is intentionally fire-and-forget; wait for
+    // the expected alert row instead of a fixed sleep.
+    const riskDeadline = Date.now() + 5000;
+    let riskAfter = await prisma.riskAlert.count({ where: { businessId: business.id } });
+    while (riskAfter <= riskBefore && Date.now() < riskDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      riskAfter = await prisma.riskAlert.count({ where: { businessId: business.id } });
+    }
     assert(riskAfter > riskBefore, 'Risk alerts did not increment for fraud controls.');
     report.fraud.riskAlertsIncrement = true;
 

--- a/scripts/run-phase3a.cjs
+++ b/scripts/run-phase3a.cjs
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Phase 3A entrypoint for CI/local standalone runs.
+ *
+ * Loads the request-context harness, registers tsx's CJS TypeScript loader,
+ * then executes scripts/phase3a-qa.ts. The tsx CLI entry can bypass a
+ * preloaded Module._load hook; the CJS API keeps the shim active.
+ */
+
+const harness = require('./phase3a-harness.cjs');
+
+const { register } = require('tsx/cjs/api');
+register();
+
+// Re-apply after register in case any loader refreshed module exports.
+harness.ensureLoadedShims();
+
+if (!harness.status.reactCacheShimmed || !harness.status.unstableCacheShimmed) {
+  throw new Error(
+    `[phase3a-runner] harness incomplete: ${JSON.stringify(harness.status)}`,
+  );
+}
+
+require('./phase3a-qa.ts');


### PR DESCRIPTION
## Summary
- Phase 3A under plain `tsx` imported `lib/auth` → `react.cache` and `sales` → `next/cache.unstable_cache`, which are unavailable outside a Next request and crashed CI run 30304678068 before any financial assertions ran.
- Adds a harness-only shim (`scripts/phase3a-harness.cjs` + `scripts/run-phase3a.cjs`) that models only the missing framework boundary (identity `react.cache`, pass-through `unstable_cache`) without mocking accounting services.
- Polls for fire-and-forget risk-alert rows so the fraud assertion remains state-based and still fails when alerts never appear.

## Test plan
- [x] Reproduce original `react.cache is not a function` failure (pre-fix)
- [x] `npm run test:qa:phase3a` ×3 on fresh disposable SQLite DBs — all financial report flags true
- [x] False-pass: sabotage cash-math expectation → fails with `expectedCashMath: false` (not committed)
- [x] `npm run test:e2e:smoke`, `test:perf`, `test:e2e:deep`
- [x] Focused C11 + full `npm test`, `npm run lint`, `npx tsc --noEmit`, `npm run build`
- [ ] CI green on this stacked PR (do not merge / no auto-merge)

Stacked on: #59 (`fix/deep-e2e-current-pos`)