### PR TITLE
fix(deploy): restore Prisma advisory lock for Vercel migrations (P0-B)

### DIFF
--- a/VERCEL_DEPLOY.md
+++ b/VERCEL_DEPLOY.md
@@ -99,6 +99,8 @@ npm run build:vercel
 
 That script includes `prisma migrate deploy --schema=prisma/schema.postgres.prisma`, so committed migrations are applied automatically during deployment.
 
+Prisma Migrate uses PostgreSQL advisory locks by default so concurrent Vercel builds cannot apply migrations at the same time. Migrations must use the **direct** (non-pooled) URL via `directUrl` / `POSTGRES_URL_NON_POOLING`. Do **not** set `PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK=1` on hosted builds — that flag is for clustered MySQL/MariaDB setups, not Neon, and removes migration serialization.
+
 ---
 
 ## Step 5 — Deploy
@@ -191,6 +193,7 @@ CLI deploys (`vercel deploy --prod`) are a fallback only. They attach local git 
 | `DEPLOYMENT_NOT_FOUND` | Make sure the project is deployed and the URL matches. |
 | Build fails with `POSTGRES_PRISMA_URL` error | Add the env vars in Step 3. |
 | `prisma migrate deploy` fails | Check that `POSTGRES_URL_NON_POOLING` uses the direct (non-pooled) URL and that the migration files are committed. |
+| Build hangs or times out on migrate | Confirm migrations use the direct URL (not the pooler). A second concurrent deploy may be waiting on Prisma’s advisory lock — wait for it or cancel the duplicate build. Do not disable advisory locking. |
 | Login doesn't work | Ensure `NEXTAUTH_SECRET` and `NEXTAUTH_URL` are set. |
 | Login lockout is inconsistent across instances | Ensure `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are set. |
 | EOD summary falls back to manual review | Check Meta env vars and `/settings/notifications` diagnostics. |

--- a/VERCEL_DEPLOY.md
+++ b/VERCEL_DEPLOY.md
@@ -99,7 +99,11 @@ npm run build:vercel
 
 That script includes `prisma migrate deploy --schema=prisma/schema.postgres.prisma`, so committed migrations are applied automatically during deployment.
 
-Prisma Migrate uses PostgreSQL advisory locks by default so concurrent Vercel builds cannot apply migrations at the same time. Migrations must use the **direct** (non-pooled) URL via `directUrl` / `POSTGRES_URL_NON_POOLING`. Do **not** set `PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK=1` on hosted builds — that flag is for clustered MySQL/MariaDB setups, not Neon, and removes migration serialization.
+Prisma Migrate uses PostgreSQL advisory locks by default so concurrent builds that target the **same database** cannot apply migrations at the same time. Migrations must use the **direct** (non-pooled) URL via `directUrl` / `POSTGRES_URL_NON_POOLING`.
+
+Do **not** set `PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK=1` on TillFlow hosted builds. Prisma documents that flag for compatibility with specific multi-primary cluster setups — **Percona XtraDB Cluster** and **MariaDB Galera Cluster** — not for Neon PostgreSQL. Disabling the lock removes migration serialization and is not a TillFlow recovery shortcut.
+
+**Control boundary:** advisory locking only serializes migration execution against one database. It does **not** authenticate or authorise who may start a Production deployment. Release authorisation remains Gate 3 (protected master), P0-A Deployment Checks (alias gating), and Owner break-glass controls.
 
 ---
 
@@ -193,7 +197,7 @@ CLI deploys (`vercel deploy --prod`) are a fallback only. They attach local git 
 | `DEPLOYMENT_NOT_FOUND` | Make sure the project is deployed and the URL matches. |
 | Build fails with `POSTGRES_PRISMA_URL` error | Add the env vars in Step 3. |
 | `prisma migrate deploy` fails | Check that `POSTGRES_URL_NON_POOLING` uses the direct (non-pooled) URL and that the migration files are committed. |
-| Build hangs or times out on migrate | Confirm migrations use the direct URL (not the pooler). A second concurrent deploy may be waiting on Prisma’s advisory lock — wait for it or cancel the duplicate build. Do not disable advisory locking. |
+| Build hangs or times out on migrate | Confirm migrations use `POSTGRES_URL_NON_POOLING` / `directUrl` (not the pooler). Stop or cancel the affected release where safe; prevent concurrent Production releases; identify any stuck migration/lock holder only under separate operational authorisation. Do **not** restore `PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK=1` as normal rollback — that requires a separate emergency, database-specific risk decision. |
 | Login doesn't work | Ensure `NEXTAUTH_SECRET` and `NEXTAUTH_URL` are set. |
 | Login lockout is inconsistent across instances | Ensure `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are set. |
 | EOD summary falls back to manual review | Check Meta env vars and `/settings/notifications` diagnostics. |

--- a/lib/deploy/build-vercel-migration-lock.test.ts
+++ b/lib/deploy/build-vercel-migration-lock.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * P0-B: Production/Preview Vercel builds must use Prisma's default advisory
+ * lock during `prisma migrate deploy`. Disabling the lock allows concurrent
+ * builds to race migration application.
+ *
+ * Migrations use `directUrl` (POSTGRES_URL_NON_POOLING) from
+ * prisma/schema.postgres.prisma — not the pooled runtime URL.
+ */
+describe('P0-B build:vercel migration lock contract', () => {
+  const packageJsonPath = path.join(process.cwd(), 'package.json');
+  const schemaPath = path.join(process.cwd(), 'prisma', 'schema.postgres.prisma');
+  const vercelJsonPath = path.join(process.cwd(), 'vercel.json');
+
+  it('does not disable Prisma advisory locking in build:vercel', () => {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    const buildVercel = pkg.scripts?.['build:vercel'] ?? '';
+
+    expect(buildVercel).toContain('prisma migrate deploy');
+    expect(buildVercel).toContain('--schema=prisma/schema.postgres.prisma');
+    expect(buildVercel).not.toMatch(/PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK\s*=\s*1/);
+    expect(buildVercel).not.toContain('PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK');
+  });
+
+  it('keeps migrate deploy before next build so migration failure fails the release', () => {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    const buildVercel = pkg.scripts?.['build:vercel'] ?? '';
+    const migrateIdx = buildVercel.indexOf('prisma migrate deploy');
+    const nextBuildIdx = buildVercel.indexOf('next build');
+
+    expect(migrateIdx).toBeGreaterThanOrEqual(0);
+    expect(nextBuildIdx).toBeGreaterThan(migrateIdx);
+  });
+
+  it('configures Postgres schema with pooled url and directUrl for migrations', () => {
+    const schema = readFileSync(schemaPath, 'utf8');
+    expect(schema).toMatch(/url\s*=\s*env\("POSTGRES_PRISMA_URL"\)/);
+    expect(schema).toMatch(/directUrl\s*=\s*env\("POSTGRES_URL_NON_POOLING"\)/);
+  });
+
+  it('disables Vercel auto-deploy for the P0-B remediation branch only', () => {
+    const vercel = JSON.parse(readFileSync(vercelJsonPath, 'utf8')) as {
+      git?: { deploymentEnabled?: Record<string, boolean> };
+    };
+    expect(vercel.git?.deploymentEnabled?.['ci/p0b-prisma-migration-lock']).toBe(false);
+  });
+});

--- a/lib/deploy/build-vercel-migration-lock.test.ts
+++ b/lib/deploy/build-vercel-migration-lock.test.ts
@@ -5,10 +5,13 @@ import { describe, expect, it } from 'vitest';
 /**
  * P0-B: Production/Preview Vercel builds must use Prisma's default advisory
  * lock during `prisma migrate deploy`. Disabling the lock allows concurrent
- * builds to race migration application.
+ * builds against the same database to race migration application.
  *
  * Migrations use `directUrl` (POSTGRES_URL_NON_POOLING) from
  * prisma/schema.postgres.prisma — not the pooled runtime URL.
+ *
+ * Boundary: advisory locking serializes migrate deploy only. It does not
+ * authorise Production releases — that remains Gate 3 / P0-A / Owner controls.
  */
 describe('P0-B build:vercel migration lock contract', () => {
   const packageJsonPath = path.join(process.cwd(), 'package.json');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "node scripts/start-local-dev.mjs",
     "dev:prepare": "npm run db:generate:local && npm run db:setup",
     "build": "cross-env NODE_ENV=production next build",
-    "build:vercel": "prisma generate --schema=prisma/schema.postgres.prisma && cross-env PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK=1 prisma migrate deploy --schema=prisma/schema.postgres.prisma && cross-env NODE_ENV=production next build",
+    "build:vercel": "prisma generate --schema=prisma/schema.postgres.prisma && prisma migrate deploy --schema=prisma/schema.postgres.prisma && cross-env NODE_ENV=production next build",
     "db:migrate:create": "prisma migrate dev --schema=prisma/schema.postgres.prisma --create-only",
     "db:migrate:deploy": "prisma migrate deploy --schema=prisma/schema.postgres.prisma",
     "postinstall": "prisma generate --schema=prisma/schema.postgres.prisma",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "buildCommand": "npm run build:vercel",
+  "git": {
+    "deploymentEnabled": {
+      "ci/p0b-prisma-migration-lock": false
+    }
+  },
   "regions": ["iad1"],
   "crons": [
     {


### PR DESCRIPTION
## Summary
- Restore Prisma default advisory locking on `build:vercel` by removing `PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK=1`.
- Rely on existing `directUrl` (`POSTGRES_URL_NON_POOLING`) so migrate deploy serializes on Neon’s direct connection, not the pooler.
- Disable Vercel auto-deploy for branch `ci/p0b-prisma-migration-lock` so this PR cannot Preview-migrate a database during review.
- Add contract tests and document the lock/direct-URL requirement.

## Control boundary
Prisma advisory locking **only serializes migration execution** against the same database. It does **not** authenticate or authorise who may initiate a Production deployment. Release authorisation remains:
- Gate 3 (protected master + five required checks)
- P0-A Production Deployment Checks (alias gating)
- Owner break-glass controls (Force Promote, Instant Rollback, CLI/API)

## Gate context
- Closes the P0-B migration-concurrency gap that blocked P0-A empirical testing.
- Does **not** run migrate against Production or Preview.
- Does **not** merge to master.

## Test plan
- [x] `vitest run lib/deploy/build-vercel-migration-lock.test.ts`
- [x] lint / unit / typecheck / build / pos-safety (local re-run after review corrections)
- [x] Confirm Vercel created **no** Preview deployment for this branch
- [ ] Gate 3 + Postgres Smoke on updated head (CI)
- [ ] Review: no Production/Preview migrate executed by this PR
- [ ] After merge (separate auth): first Production deploy may migrate only pending files; concurrent builds should wait on advisory lock

## Rollback / migrate hang response
**Do not** restore `PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK=1` as the normal rollback.

If migrate hangs or times out after this change:
1. Stop or cancel the affected release where safely possible.
2. Confirm migrations use `POSTGRES_URL_NON_POOLING` / `directUrl` (not the pooler).
3. Identify the active or stuck migration/lock holder only through **separately authorised** operational inspection.
4. Prevent concurrent Production releases.
5. Escalate for database investigation if the lock cannot be explained.
6. Any exceptional reintroduction of the bypass requires a **separate emergency, database-specific risk decision** and is **not** pre-authorised by this PR.

Application Instant Rollback does not reverse database migrations.
