### PR TITLE
test(ci): temporary P0-A Deployment Check failure fixture — DO NOT MERGE

### DIFF
--- a/lib/deploy/p0a-deployment-checks-empirical-fixture.test.ts
+++ b/lib/deploy/p0a-deployment-checks-empirical-fixture.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * TEMPORARY P0-A Stage 1 fixture — DO NOT MERGE AS A PRODUCT CHANGE.
+ *
+ * Purpose: produce a deterministic GitHub `unit` check failure so Stage 2 can
+ * prove Vercel Production Deployment Checks withhold canonical aliases.
+ *
+ * Isolation: assertion-only; no app imports, no DB, no network, no schema.
+ * Removal of this file fully restores the unit suite.
+ */
+describe('P0-A TEMPORARY deployment-checks empirical fixture', () => {
+  it('fails deterministically so the unit Deployment Check stays unsatisfied', () => {
+    expect(
+      false,
+      'P0-A TEMPORARY FIXTURE: intentional unit failure for Deployment Check alias-hold proof. Remove this file after Stage 5 cleanup.',
+    ).toBe(true);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "buildCommand": "npm run build:vercel",
   "git": {
     "deploymentEnabled": {
-      "ci/p0b-prisma-migration-lock": false
+      "ci/p0b-prisma-migration-lock": false,
+      "ci/p0a-deployment-checks-empirical": false
     }
   },
   "regions": ["iad1"],


### PR DESCRIPTION
## Purpose

Temporary P0-A Stage 1 fixture for a later Stage 2 negative alias-hold proof.

## Changes

- Disable Vercel auto-deploy for `ci/p0a-deployment-checks-empirical` (preserve existing P0-B disable).
- Add disposable unit assertion that fails deterministically (`unit` only).

## Explicit non-goals

- Do **not** merge as a product change.
- No Prisma schema/migration changes.
- No application behaviour changes.
- Stage 1 does **not** authorise Production CLI deploy or alias testing.

## Expected CI

| Check | Result |
|---|---|
| lint | Success |
| unit | **Failure** (disposable fixture assertion) |
| typecheck | Success |
| build | Success |
| pos-safety | Success |

## Cleanup

Remove the fixture file and branch disable in Stage 5 after empirical evidence is collected.

Made with [Cursor](https://cursor.com)