### PR TITLE
ci(p0a): disposable native-Git negative unit fixture (supersedes #64)

### DIFF
--- a/lib/deploy/p0a-native-git-negative-fixture.test.ts
+++ b/lib/deploy/p0a-native-git-negative-fixture.test.ts
@@ -1,0 +1,46 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * TEMPORARY P0-A native-Git negative control — DO NOT MERGE AS A PRODUCT CHANGE.
+ *
+ * Gate 3 / PR execution: must pass (pull_request is not master push).
+ * Post-merge master push: must fail unit so Vercel Deployment Checks can hold
+ * Production aliases on the native-Git Production SHA.
+ *
+ * Activation requires ALL of:
+ * - GITHUB_EVENT_NAME === 'push'
+ * - GITHUB_REF === 'refs/heads/master'
+ * - tracked marker lib/deploy/p0a-native-git-negative.marker present
+ *
+ * Removal of this file and the marker fully restores the unit suite.
+ */
+const MARKER_PATH = path.join(
+  process.cwd(),
+  'lib',
+  'deploy',
+  'p0a-native-git-negative.marker',
+);
+
+function isApprovedMasterPushNegativeControl(): boolean {
+  return (
+    process.env.GITHUB_EVENT_NAME === 'push' &&
+    process.env.GITHUB_REF === 'refs/heads/master' &&
+    existsSync(MARKER_PATH)
+  );
+}
+
+describe('P0-A TEMPORARY native-Git negative Deployment Check control', () => {
+  it('fails only on approved master-push unit execution when the marker is present', () => {
+    if (!isApprovedMasterPushNegativeControl()) {
+      expect(true).toBe(true);
+      return;
+    }
+
+    expect(
+      false,
+      'P0-A_NATIVE_GIT_NEGATIVE_CONTROL: approved master-push unit failure',
+    ).toBe(true);
+  });
+});

--- a/lib/deploy/p0a-native-git-negative.marker
+++ b/lib/deploy/p0a-native-git-negative.marker
@@ -1,0 +1,3 @@
+P0-A native-Git negative control marker.
+Present only while the disposable P0-A fixture is active.
+Does not contain secrets or executable behaviour.

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "buildCommand": "npm run build:vercel",
   "git": {
     "deploymentEnabled": {
-      "ci/p0b-prisma-migration-lock": false
+      "ci/p0b-prisma-migration-lock": false,
+      "ci/p0a-native-git-negative": false
     }
   },
   "regions": ["iad1"],


### PR DESCRIPTION
## Summary

Disposable **P0-A native-Git negative control fixture** for Gate 4 Deployment Checks proof.

- Adds a tracked marker and a conditional Vitest assertion that fails **only** when all of:
  - `GITHUB_EVENT_NAME === \"push\"`
  - `GITHUB_REF === \"refs/heads/master\"`
  - marker `lib/deploy/p0a-native-git-negative.marker` is present
- Disables Vercel Preview deployments for branch `ci/p0a-native-git-negative` only (preserves existing `vercel.json` config).
- **No application, runtime, schema, migration, dependency, workflow, or Production setting change.**

## Expected check behaviour

| Context | `unit` expectation |
|---|---|
| **This PR** (`pull_request`) | **green** — fixture no-ops |
| **Post-merge `push` to `master`** | **intentionally fails** with `P0-A_NATIVE_GIT_NEGATIVE_CONTROL: approved master-push unit failure` |

Ordinary PR required checks (all must succeed on this PR):

- lint
- unit
- typecheck
- build
- pos-safety

## Authority / supersession

- Supersedes draft PR #64 (CLI-era always-fail fixture) — **do not merge #64**.
- **Merging this PR requires separate explicit authority** (native-Git negative merge and observation).
- **Positive correction** (removing the fixture/marker so Production can promote) requires separate authority.
- Do **not** mark ready for review or merge under this preparation stage.

## Test plan

- [x] Local unit suite passes without GitHub master-push variables
- [x] Partial activation conditions do not fail the fixture
- [x] Full activation fails only the approved assertion
- [x] lint / typecheck / build / pos-safety:unit succeed locally
- [ ] Ordinary PR checks green (lint, unit, typecheck, build, pos-safety)
- [ ] Confirm no Preview Production impact; canonical aliases unchanged

Made with [Cursor](https://cursor.com)