### PR TITLE
feat(inventory): lean Phase 1 quantity-decrease

### DIFF
--- a/app/(protected)/inventory/StockAdjustmentClient.tsx
+++ b/app/(protected)/inventory/StockAdjustmentClient.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import SubmitButton from '@/components/SubmitButton';
 import { createStockAdjustmentAction } from '@/app/actions/inventory';
 import { formatMixedUnit, getPrimaryPackagingUnit } from '@/lib/units';
+import type { InventoryDecreaseReasonCode } from '@/lib/services/inventory-decrease';
 
 type UnitDto = {
   id: string;
@@ -20,21 +21,44 @@ type ProductDto = {
   onHandBase: number;
 };
 
+const REASON_OPTIONS: { code: InventoryDecreaseReasonCode; label: string }[] = [
+  { code: 'WASTAGE', label: 'Wastage' },
+  { code: 'EXPIRED', label: 'Expired' },
+  { code: 'DAMAGED', label: 'Damaged' },
+  { code: 'THEFT', label: 'Theft' },
+  { code: 'STOCKTAKE_SHORTFALL', label: 'Stocktake shortfall' },
+  { code: 'AUTHORISED_QUANTITY_CORRECTION', label: 'Authorised quantity correction' },
+];
+
+function newIdempotencyKey() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `adj-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 export default function StockAdjustmentClient({
   storeId,
-  products
+  products,
+  phase1Enabled,
 }: {
   storeId: string;
   products: ProductDto[];
+  phase1Enabled: boolean;
 }) {
   const [productId, setProductId] = useState(products[0]?.id ?? '');
   const [unitId, setUnitId] = useState(products[0]?.units[0]?.id ?? '');
   const [qtyInput, setQtyInput] = useState('1');
-  const [direction, setDirection] = useState<'INCREASE' | 'DECREASE'>('DECREASE');
-  const [reason, setReason] = useState('');
+  const [reasonCode, setReasonCode] = useState<InventoryDecreaseReasonCode>('WASTAGE');
+  const [reason, setReason] = useState('Wastage');
   const [productSearch, setProductSearch] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
+  const [idempotencyKey, setIdempotencyKey] = useState(newIdempotencyKey);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setIdempotencyKey(newIdempotencyKey());
+  }, [productId, unitId, qtyInput, reasonCode, reason]);
 
   const selectProduct = useCallback((id: string) => {
     setProductId(id);
@@ -58,8 +82,6 @@ export default function StockAdjustmentClient({
   const unitsForProduct = selectedProduct?.units ?? [];
   const selectedUnit = unitsForProduct.find((unit) => unit.id === unitId);
   const qtyNumber = Math.max(0, Math.floor(Number(qtyInput) || 0));
-  const directionTone = direction === 'DECREASE' ? 'border-rose-200 bg-rose-50' : 'border-emerald-200 bg-emerald-50';
-  const directionText = direction === 'DECREASE' ? 'Stock will be reduced from on-hand balance.' : 'Stock will be added back to on-hand balance.';
 
   const onHandLabel = useMemo(() => {
     if (!selectedProduct) return '';
@@ -77,14 +99,33 @@ export default function StockAdjustmentClient({
     });
   }, [selectedProduct]);
 
+  if (!phase1Enabled) {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-5 text-sm text-amber-900">
+        <div className="font-semibold">Inventory decreases are not enabled</div>
+        <p className="mt-1 text-amber-800/80">
+          Phase 1 quantity decreases are gated behind the rollout flag. Adjustments are unavailable
+          until that flag is enabled — legacy unhardened adjustments cannot be used as a bypass.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <form action={createStockAdjustmentAction} className="space-y-5">
       <input type="hidden" name="storeId" value={storeId} />
       <input type="hidden" name="productId" value={productId} />
+      <input type="hidden" name="direction" value="DECREASE" />
+      <input type="hidden" name="reasonCode" value={reasonCode} />
+      <input type="hidden" name="idempotencyKey" value={idempotencyKey} />
+
       <div className="rounded-2xl border border-black/5 bg-black/[0.02] p-4 sm:p-5">
         <div className="mb-4">
-          <div className="text-xs uppercase tracking-[0.2em] text-black/40">Adjustment details</div>
-          <div className="mt-1 text-sm text-black/60">Choose the product, unit, and quantity to record stock found or stock lost.</div>
+          <div className="text-xs uppercase tracking-[0.2em] text-black/40">Decrease details</div>
+          <div className="mt-1 text-sm text-black/60">
+            Record wastage, damage, theft, expiry, stocktake shortfall, or an authorised quantity
+            correction. Quantity increases are not available in Phase 1.
+          </div>
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
@@ -100,7 +141,6 @@ export default function StockAdjustmentClient({
                 setShowDropdown(true);
               }}
               onBlur={() => {
-                // Delay so click on dropdown item registers before close
                 setTimeout(() => setShowDropdown(false), 200);
               }}
               onChange={(event) => {
@@ -148,7 +188,7 @@ export default function StockAdjustmentClient({
             ) : null}
           </div>
           <div>
-            <label className="label">Quantity</label>
+            <label className="label">Quantity to remove</label>
             <input
               className="input"
               name="qtyInUnit"
@@ -167,64 +207,59 @@ export default function StockAdjustmentClient({
               </div>
             ) : null}
           </div>
-          <div>
-            <label className="label">Direction</label>
-            <select
-              className="input"
-              name="direction"
-              value={direction}
-              onChange={(event) => setDirection(event.target.value as 'INCREASE' | 'DECREASE')}
-            >
-              <option value="DECREASE">Decrease (shrinkage)</option>
-              <option value="INCREASE">Increase (found stock)</option>
-            </select>
-          </div>
-          <div className="sm:col-span-2 xl:col-span-2">
-            <label className="label">Reason</label>
-            {direction === 'DECREASE' && (
-              <div className="mb-2 flex flex-wrap gap-1.5">
-                {['Wastage', 'Expired', 'Damaged', 'Theft', 'Stocktake correction'].map((label) => (
-                  <button
-                    key={label}
-                    type="button"
-                    onClick={() => setReason(label)}
-                    className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition ${
-                      reason === label
-                        ? 'border-rose-400 bg-rose-100 text-rose-700'
-                        : 'border-black/10 bg-white text-black/60 hover:border-rose-300 hover:text-rose-600'
-                    }`}
-                  >
-                    {label}
-                  </button>
-                ))}
-              </div>
-            )}
+          <div className="sm:col-span-2 xl:col-span-3">
+            <label className="label">Reason code</label>
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {REASON_OPTIONS.map((option) => (
+                <button
+                  key={option.code}
+                  type="button"
+                  onClick={() => {
+                    setReasonCode(option.code);
+                    setReason(option.label);
+                  }}
+                  className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition ${
+                    reasonCode === option.code
+                      ? 'border-rose-400 bg-rose-100 text-rose-700'
+                      : 'border-black/10 bg-white text-black/60 hover:border-rose-300 hover:text-rose-600'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
             <input
               className="input"
               name="reason"
               value={reason}
               onChange={(event) => setReason(event.target.value)}
-              placeholder={direction === 'DECREASE' ? 'Reason (or select above)' : 'Optional reason'}
+              placeholder="Describe the loss (required)"
+              required
+              minLength={3}
             />
           </div>
         </div>
       </div>
 
-      <div className={`rounded-2xl border p-4 ${directionTone}`}>
-        <div className="text-sm font-semibold text-ink">Adjustment summary</div>
-        <div className="mt-1 text-sm text-black/65">{directionText}</div>
+      <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4">
+        <div className="text-sm font-semibold text-ink">Decrease summary</div>
+        <div className="mt-1 text-sm text-black/65">
+          Stock will be reduced from the on-hand balance at the locked average cost. The journal
+          debits Inventory Loss &amp; Shrinkage (5100) and credits Inventory (1200).
+        </div>
         {selectedUnit && qtyNumber > 0 ? (
           <div className="mt-3 text-sm">
-            You are about to <span className="font-semibold">{direction === 'DECREASE' ? 'remove' : 'add'}</span>{' '}
+            You are about to <span className="font-semibold">remove</span>{' '}
             <span className="font-semibold">{qtyNumber * selectedUnit.conversionToBase}</span> base units of{' '}
-            <span className="font-semibold">{selectedProduct?.name ?? 'this product'}</span>.
+            <span className="font-semibold">{selectedProduct?.name ?? 'this product'}</span>
+            {' '}({REASON_OPTIONS.find((o) => o.code === reasonCode)?.label ?? reasonCode}).
           </div>
         ) : null}
       </div>
 
       <div className="flex flex-col gap-3 rounded-2xl border border-black/5 bg-white p-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="text-sm text-black/60">Record the adjustment once the details and reason look correct.</div>
-        <SubmitButton className="btn-primary" loadingText="Recording…">Record adjustment</SubmitButton>
+        <div className="text-sm text-black/60">Record the decrease once the details and reason look correct.</div>
+        <SubmitButton className="btn-primary" loadingText="Recording…">Record decrease</SubmitButton>
       </div>
     </form>
   );

--- a/app/(protected)/inventory/adjustments/ReverseStockAdjustmentForm.tsx
+++ b/app/(protected)/inventory/adjustments/ReverseStockAdjustmentForm.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import SubmitButton from '@/components/SubmitButton';
-import { reverseStockAdjustmentAction } from '@/app/actions/inventory';
-
+/**
+ * Automated reversal is unavailable in inventory-decrease Phase 1.
+ * Component retained so historical links/tests do not 404; it never submits a reverse.
+ */
 export default function ReverseStockAdjustmentForm({
-  adjustmentId,
   disabled,
 }: {
   adjustmentId: string;
@@ -15,25 +15,8 @@ export default function ReverseStockAdjustmentForm({
   }
 
   return (
-    <form
-      action={reverseStockAdjustmentAction}
-      className="flex flex-col gap-2 sm:flex-row sm:items-center"
-      onSubmit={(event) => {
-        if (!window.confirm('Reverse this stock adjustment? This creates an opposite audited stock entry.')) {
-          event.preventDefault();
-        }
-      }}
-    >
-      <input type="hidden" name="adjustmentId" value={adjustmentId} />
-      <input
-        className="input h-9 min-w-[12rem] text-xs"
-        name="reason"
-        placeholder="Correction note"
-        maxLength={180}
-      />
-      <SubmitButton className="btn-secondary h-9 px-3 text-xs" loadingText="Reversing...">
-        Reverse
-      </SubmitButton>
-    </form>
+    <span className="text-xs text-black/45">
+      Automated reversal unavailable (Phase 1 decreases only)
+    </span>
   );
 }

--- a/app/(protected)/inventory/adjustments/page.tsx
+++ b/app/(protected)/inventory/adjustments/page.tsx
@@ -4,8 +4,8 @@ import { prisma } from '@/lib/prisma';
 import { requireBusinessStore } from '@/lib/auth';
 import { formatMixedUnit, getPrimaryPackagingUnit } from '@/lib/units';
 import { formatDateTime } from '@/lib/format';
+import { isInventoryDecreasePhase1Enabled } from '@/lib/inventory-decrease-flag';
 import StockAdjustmentClient from '../StockAdjustmentClient';
-import ReverseStockAdjustmentForm from './ReverseStockAdjustmentForm';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,10 +13,6 @@ const PAGE_SIZE = 30;
 
 function isIncreaseDirection(direction: string) {
   return direction === 'INCREASE' || direction === 'IN';
-}
-
-function isReversal(reason?: string | null) {
-  return Boolean(reason?.includes('Reversal of adjustment'));
 }
 
 function AdjustmentsEmptyState({ q }: { q?: string }) {
@@ -28,7 +24,7 @@ function AdjustmentsEmptyState({ q }: { q?: string }) {
       <div className="mt-1 text-sm text-black/55">
         {q
           ? 'Try a different search term.'
-          : 'When stock needs correcting, record an adjustment so TillFlow keeps a clear audit trail.'}
+          : 'When stock needs correcting, record a decrease so TillFlow keeps a clear audit trail.'}
       </div>
     </div>
   );
@@ -39,13 +35,13 @@ export default async function StockAdjustmentsPage({
 }: {
   searchParams?: { page?: string; reversed?: string; error?: string };
 }) {
-  const { user, business, store } = await requireBusinessStore(['MANAGER', 'OWNER']);
+  const { business, store } = await requireBusinessStore(['MANAGER', 'OWNER']);
   if (!business || !store) {
     return <div className="card p-6">Seed data missing.</div>;
   }
 
   const page = Math.max(1, parseInt(searchParams?.page ?? '1', 10) || 1);
-  const canReverseAdjustments = user.role === 'OWNER';
+  const phase1Enabled = isInventoryDecreasePhase1Enabled();
 
   const [products, adjustmentCount, adjustments] = await Promise.all([
     prisma.product.findMany({
@@ -79,6 +75,7 @@ export default async function StockAdjustmentsPage({
         qtyBase: true,
         direction: true,
         reason: true,
+        reasonCode: true,
         product: {
           select: {
             name: true,
@@ -127,14 +124,9 @@ export default async function StockAdjustmentsPage({
     <div className="space-y-4 sm:space-y-5">
       <PageHeader title="Stock Adjustments" subtitle="Correct stock safely and keep a clear audit trail." />
 
-      {searchParams?.reversed === '1' ? (
-        <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-800">
-          Stock adjustment reversed with an audited opposite entry.
-        </div>
-      ) : null}
       {searchParams?.error ? (
         <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-800">
-          Could not reverse adjustment: {searchParams.error.replace(/-/g, ' ')}.
+          {decodeURIComponent(searchParams.error)}
         </div>
       ) : null}
 
@@ -147,7 +139,7 @@ export default async function StockAdjustmentsPage({
         <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 shadow-card">
           <div className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-700/70">Added</div>
           <div className="mt-2 text-2xl font-bold tabular-nums text-emerald-700">{countIn}</div>
-          <div className="mt-1 text-xs text-emerald-600/70">{isPaginated ? 'On this page' : 'Stock increases'}</div>
+          <div className="mt-1 text-xs text-emerald-600/70">{isPaginated ? 'On this page' : 'Historical increases'}</div>
         </div>
         <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 shadow-card">
           <div className="text-xs font-semibold uppercase tracking-[0.14em] text-rose-700/70">Removed</div>
@@ -159,6 +151,7 @@ export default async function StockAdjustmentsPage({
       <div className="card p-4 sm:p-6">
         <StockAdjustmentClient
           storeId={store.id}
+          phase1Enabled={phase1Enabled}
           products={products.map((product) => ({
             id: product.id,
             name: product.name,
@@ -178,12 +171,14 @@ export default async function StockAdjustmentsPage({
         <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h2 className="text-lg font-display font-semibold">Recent adjustments</h2>
-            <p className="mt-1 text-sm text-black/55">Every adjustment is permanently recorded. Owners can reverse any entry, which adds an audited opposite entry.</p>
+            <p className="mt-1 text-sm text-black/55">
+              Every Phase 1 decrease is permanently recorded with inventory, journal, and audit in
+              one transaction. Automated reversal is unavailable in Phase 1.
+            </p>
           </div>
           <div className="text-xs text-black/45 sm:flex-shrink-0">{adjustmentCount} total records</div>
         </div>
 
-        {/* Mobile cards */}
         <div className="space-y-3 lg:hidden">
           {adjustmentRows.length === 0 ? (
             <AdjustmentsEmptyState />
@@ -213,24 +208,17 @@ export default async function StockAdjustmentsPage({
                   </div>
                   <div className="col-span-2">
                     <div className="text-xs uppercase tracking-[0.16em] text-black/40">Reason</div>
-                    <div className="mt-1 text-black/70">{adjustment.reason ?? 'No reason provided'}</div>
+                    <div className="mt-1 text-black/70">
+                      {adjustment.reasonCode ? `${adjustment.reasonCode}: ` : ''}
+                      {adjustment.reason ?? 'No reason provided'}
+                    </div>
                   </div>
                 </div>
-                {canReverseAdjustments ? (
-                  <div className="mt-4 border-t border-black/5 pt-3">
-                    <div className="mb-2 text-xs uppercase tracking-[0.16em] text-black/40">Owner action</div>
-                    <ReverseStockAdjustmentForm
-                      adjustmentId={adjustment.id}
-                      disabled={isReversal(adjustment.reason)}
-                    />
-                  </div>
-                ) : null}
               </div>
             ))
           )}
         </div>
 
-        {/* Desktop table */}
         <div className="responsive-table-shell mt-4 hidden lg:block">
           <table className="table w-full border-separate border-spacing-y-2">
             <thead>
@@ -241,13 +229,12 @@ export default async function StockAdjustmentsPage({
                 <th>Direction</th>
                 <th>Reason</th>
                 <th>User</th>
-                {canReverseAdjustments ? <th>Owner action</th> : null}
               </tr>
             </thead>
             <tbody>
               {adjustmentRows.length === 0 ? (
                 <tr>
-                  <td colSpan={canReverseAdjustments ? 7 : 6} className="px-3 py-12 text-center">
+                  <td colSpan={6} className="px-3 py-12 text-center">
                     <AdjustmentsEmptyState />
                   </td>
                 </tr>
@@ -265,16 +252,11 @@ export default async function StockAdjustmentsPage({
                         {adjustment.direction}
                       </span>
                     </td>
-                    <td className="px-3 py-3 text-sm">{adjustment.reason ?? '-'}</td>
+                    <td className="px-3 py-3 text-sm">
+                      {adjustment.reasonCode ? `${adjustment.reasonCode}: ` : ''}
+                      {adjustment.reason ?? '-'}
+                    </td>
                     <td className="px-3 py-3 text-sm">{adjustment.user.name ?? 'Unknown'}</td>
-                    {canReverseAdjustments ? (
-                      <td className="px-3 py-3 text-sm">
-                        <ReverseStockAdjustmentForm
-                          adjustmentId={adjustment.id}
-                          disabled={isReversal(adjustment.reason)}
-                        />
-                      </td>
-                    ) : null}
                   </tr>
                 ))
               )}

--- a/app/(protected)/inventory/stocktake/StocktakeClient.tsx
+++ b/app/(protected)/inventory/stocktake/StocktakeClient.tsx
@@ -163,14 +163,28 @@ export default function StocktakeClient({ stocktakeId, lines: initialLines, star
   const stats = useMemo(() => {
     let counted = 0;
     let variances = 0;
+    let shortfalls = 0;
+    let surpluses = 0;
     for (const l of initialLines) {
       const c = counts[l.id];
       if (c && c !== '') {
         counted++;
-        if (Number(c) !== l.expectedBase) variances++;
+        const n = Number(c);
+        if (n !== l.expectedBase) {
+          variances++;
+          if (n < l.expectedBase) shortfalls++;
+          if (n > l.expectedBase) surpluses++;
+        }
       }
     }
-    return { total: initialLines.length, counted, uncounted: initialLines.length - counted, variances };
+    return {
+      total: initialLines.length,
+      counted,
+      uncounted: initialLines.length - counted,
+      variances,
+      shortfalls,
+      surpluses,
+    };
   }, [initialLines, counts]);
 
   const activeLine = activeLineId ? initialLines.find((l) => l.id === activeLineId) : null;
@@ -222,6 +236,12 @@ export default function StocktakeClient({ stocktakeId, lines: initialLines, star
         reason: varianceReason.trim(),
       });
       if (completeResult.success) {
+        const surplus = completeResult.data?.surplusPendingReview ?? 0;
+        if (surplus > 0) {
+          setSaveMsg(
+            `Stocktake completed. ${surplus} surplus line(s) saved as pending review — authoritative on-hand balance was not increased.`,
+          );
+        }
         router.push('/inventory/stocktake');
         router.refresh();
       } else {
@@ -252,6 +272,9 @@ export default function StocktakeClient({ stocktakeId, lines: initialLines, star
             {stats.variances > 0 && (
               <span className="ml-2 font-semibold text-amber-600">
                 {stats.variances} variance{stats.variances > 1 ? 's' : ''}
+                {stats.surpluses > 0
+                  ? ` (${stats.surpluses} surplus pending review — balance unchanged)`
+                  : ''}
               </span>
             )}
           </span>
@@ -600,10 +623,11 @@ export default function StocktakeClient({ stocktakeId, lines: initialLines, star
               confirmComplete ? (
                 <div className="w-full space-y-3 rounded-xl border border-amber-200 bg-amber-50/70 p-3 sm:max-w-xl">
                   <p className="text-sm text-amber-900">
-                    You are about to adjust <span className="font-semibold">{stats.variances}</span> product
-                    {stats.variances === 1 ? '' : 's'} based on this stocktake.
+                    Shortfalls ({stats.shortfalls}) will reduce on-hand stock via Phase 1 inventory
+                    decrease. Surpluses ({stats.surpluses}) are saved as pending review and will{' '}
+                    <span className="font-semibold">not</span> change the authoritative balance yet.
                     {stats.variances > 0
-                      ? ' Please enter a reason for the variance adjustment.'
+                      ? ' Please enter a reason before completing.'
                       : ' No quantity changes will be posted.'}
                   </p>
                   {stats.variances > 0 ? (

--- a/app/actions/inventory.ts
+++ b/app/actions/inventory.ts
@@ -1,18 +1,36 @@
 'use server';
 
-import { createStockAdjustment } from '@/lib/services/inventory';
 import { redirect } from 'next/navigation';
 import { revalidatePath, revalidateTag } from 'next/cache';
 import { formString, formInt } from '@/lib/form-helpers';
-import { StockDirectionEnum } from '@/lib/validation/enums';
-import { withBusinessStoreContext, formAction, type ActionResult } from '@/lib/action-utils';
-import { audit } from '@/lib/audit';
+import { withBusinessStoreContext, formAction, UserError } from '@/lib/action-utils';
 import { checkAndSendLowStockAlert } from '@/app/actions/stock-alerts';
-import { prisma } from '@/lib/prisma';
 import { revalidateOwnerDashboardCache } from '@/lib/reports/cache-revalidation';
+import { isInventoryDecreasePhase1Enabled } from '@/lib/inventory-decrease-flag';
+import {
+  createInventoryDecrease,
+  InventoryDecreaseError,
+  isInventoryDecreaseReasonCode,
+  INVENTORY_DECREASE_ERROR,
+} from '@/lib/services/inventory-decrease';
 
+function mapDecreaseError(error: unknown): never {
+  if (error instanceof InventoryDecreaseError) {
+    throw new UserError(error.message);
+  }
+  throw error;
+}
+
+/**
+ * Phase 1 quantity-decrease only. Does not call legacy createStockAdjustment.
+ * Authoritative audit is written inside the decrease service transaction.
+ */
 export async function createStockAdjustmentAction(formData: FormData): Promise<void> {
   return formAction(async () => {
+    if (!isInventoryDecreasePhase1Enabled()) {
+      throw new UserError('Inventory adjustments are temporarily unavailable.');
+    }
+
     const { user, businessId, storeId: defaultStoreId } =
       await withBusinessStoreContext(['MANAGER', 'OWNER']);
 
@@ -20,32 +38,45 @@ export async function createStockAdjustmentAction(formData: FormData): Promise<v
     const productId = formString(formData, 'productId');
     const unitId = formString(formData, 'unitId');
     const qtyInUnit = formInt(formData, 'qtyInUnit');
-    const direction = (formString(formData, 'direction') || 'DECREASE') as 'INCREASE' | 'DECREASE';
-    const dirValidation = StockDirectionEnum.safeParse(direction);
-    if (!dirValidation.success) {
-      redirect('/inventory?error=invalid-direction');
-    }
-    const reason = formString(formData, 'reason') || null;
+    const direction = (formString(formData, 'direction') || 'DECREASE').toUpperCase();
+    const reasonCodeRaw = formString(formData, 'reasonCode');
+    const reason = formString(formData, 'reason') || '';
+    const idempotencyKey = formString(formData, 'idempotencyKey');
 
-    const adjustment = await createStockAdjustment({
-      businessId,
-      storeId,
-      productId,
-      unitId,
-      qtyInUnit,
-      direction,
-      reason,
-      userId: user.id
-    });
+    if (direction !== 'DECREASE') {
+      throw new UserError('Only quantity decreases are supported.');
+    }
+    if (!isInventoryDecreaseReasonCode(reasonCodeRaw)) {
+      throw new UserError('Select a valid adjustment reason code.');
+    }
+    if (!idempotencyKey) {
+      throw new UserError('Missing idempotency key. Refresh and try again.');
+    }
+
+    let adjustment;
+    try {
+      adjustment = await createInventoryDecrease({
+        businessId,
+        storeId,
+        productId,
+        unitId,
+        qtyInUnit,
+        reasonCode: reasonCodeRaw,
+        reason,
+        idempotencyKey,
+        userId: user.id,
+        userName: user.name ?? 'Unknown',
+        userRole: user.role,
+      });
+    } catch (error) {
+      mapDecreaseError(error);
+    }
 
     void checkAndSendLowStockAlert({
       businessId,
       storeId,
       productIds: [adjustment.productId],
     }).catch(() => {});
-
-    // Fire-and-forget: don't block the user on audit logging
-    audit({ businessId, userId: user.id, userName: user.name, userRole: user.role, action: 'INVENTORY_ADJUST', entity: 'Product', entityId: productId, details: { direction, qtyInUnit, unitId, reason } }).catch(() => {});
 
     revalidateTag('pos-products');
     revalidateTag('reports');
@@ -54,107 +85,20 @@ export async function createStockAdjustmentAction(formData: FormData): Promise<v
     revalidateImproveRecordsHome();
 
     redirect('/inventory/adjustments');
-  }, '/inventory');
-}
-
-export async function reverseStockAdjustmentAction(formData: FormData): Promise<void> {
-  return formAction(async () => {
-    const { user, businessId } = await withBusinessStoreContext(['OWNER']);
-
-    const adjustmentId = formString(formData, 'adjustmentId');
-    const ownerReason = formString(formData, 'reason') || null;
-    if (!adjustmentId) {
-      redirect('/inventory/adjustments?error=missing-adjustment');
-    }
-
-    const adjustment = await prisma.stockAdjustment.findFirst({
-      where: {
-        id: adjustmentId,
-        store: { businessId },
-      },
-      select: {
-        id: true,
-        storeId: true,
-        productId: true,
-        unitId: true,
-        qtyInUnit: true,
-        qtyBase: true,
-        direction: true,
-        reason: true,
-        product: { select: { name: true } },
-      },
-    });
-
-    if (!adjustment) {
-      redirect('/inventory/adjustments?error=adjustment-not-found');
-    }
-
-    const existingReversal = await prisma.stockAdjustment.findFirst({
-      where: {
-        storeId: adjustment.storeId,
-        productId: adjustment.productId,
-        reason: { contains: `Reversal of adjustment ${adjustment.id}` },
-      },
-      select: { id: true },
-    });
-
-    if (existingReversal) {
-      redirect('/inventory/adjustments?error=already-reversed');
-    }
-
-    const wasIncrease = adjustment.direction === 'INCREASE' || adjustment.direction === 'IN';
-    const reverseDirection = wasIncrease ? 'DECREASE' : 'INCREASE';
-    const reason = [
-      `Reversal of adjustment ${adjustment.id}`,
-      ownerReason ? ownerReason : null,
-      adjustment.reason ? `Original reason: ${adjustment.reason}` : null,
-    ].filter(Boolean).join(' | ');
-
-    const reversal = await createStockAdjustment({
-      businessId,
-      storeId: adjustment.storeId,
-      productId: adjustment.productId,
-      unitId: adjustment.unitId,
-      qtyInUnit: adjustment.qtyInUnit,
-      direction: reverseDirection,
-      reason,
-      userId: user.id,
-    });
-
-    void checkAndSendLowStockAlert({
-      businessId,
-      storeId: adjustment.storeId,
-      productIds: [adjustment.productId],
-    }).catch(() => {});
-
-    audit({
-      businessId,
-      userId: user.id,
-      userName: user.name,
-      userRole: user.role,
-      action: 'INVENTORY_ADJUST',
-      entity: 'StockAdjustment',
-      entityId: adjustment.id,
-      details: {
-        correctionType: 'REVERSAL',
-        productId: adjustment.productId,
-        productName: adjustment.product.name,
-        originalDirection: adjustment.direction,
-        originalQtyBase: adjustment.qtyBase,
-        reversalAdjustmentId: reversal.id,
-        reversalDirection: reverseDirection,
-        reason: ownerReason,
-      },
-    }).catch(() => {});
-
-    revalidateTag('pos-products');
-    revalidateTag('reports');
-    revalidateOwnerDashboardCache();
-    revalidatePath('/inventory');
-    revalidatePath('/inventory/adjustments');
-    const { revalidateImproveRecordsHome } = await import('@/lib/improve-records-revalidate');
-    revalidateImproveRecordsHome();
-
-    redirect('/inventory/adjustments?reversed=1');
   }, '/inventory/adjustments');
 }
+
+/**
+ * Automated reversal is unavailable in Phase 1 (increases deferred; payload-safe
+ * compensating entries are a later design).
+ */
+export async function reverseStockAdjustmentAction(_formData: FormData): Promise<void> {
+  return formAction(async () => {
+    await withBusinessStoreContext(['OWNER']);
+    throw new UserError(
+      'Automated adjustment reversal is unavailable. Phase 1 supports decreases only.',
+    );
+  }, '/inventory/adjustments');
+}
+
+export { INVENTORY_DECREASE_ERROR };

--- a/app/actions/inventory.ts
+++ b/app/actions/inventory.ts
@@ -11,7 +11,6 @@ import {
   createInventoryDecrease,
   InventoryDecreaseError,
   isInventoryDecreaseReasonCode,
-  INVENTORY_DECREASE_ERROR,
 } from '@/lib/services/inventory-decrease';
 
 function mapDecreaseError(error: unknown): never {
@@ -100,5 +99,3 @@ export async function reverseStockAdjustmentAction(_formData: FormData): Promise
     );
   }, '/inventory/adjustments');
 }
-
-export { INVENTORY_DECREASE_ERROR };

--- a/app/actions/stocktake.ts
+++ b/app/actions/stocktake.ts
@@ -12,7 +12,7 @@ import {
   InventoryDecreaseError,
 } from '@/lib/services/inventory-decrease';
 
-export const STOCKTAKE_SURPLUS_PENDING_REVIEW = 'SURPLUS_PENDING_REVIEW';
+const STOCKTAKE_SURPLUS_PENDING_REVIEW = 'SURPLUS_PENDING_REVIEW';
 
 async function assertGrowthStocktake(businessId: string): Promise<{ allowed: true } | { allowed: false; error: string }> {
   const business = await prisma.business.findUnique({

--- a/app/actions/stocktake.ts
+++ b/app/actions/stocktake.ts
@@ -3,10 +3,16 @@
 import { prisma } from '@/lib/prisma';
 import { revalidateTag } from 'next/cache';
 import { withBusinessStoreContext, safeAction, type ActionResult } from '@/lib/action-utils';
-import { createStockAdjustment } from '@/lib/services/inventory';
 import { audit } from '@/lib/audit';
 import { checkAndSendLowStockAlert } from '@/app/actions/stock-alerts';
 import { getFeatures } from '@/lib/features';
+import { isInventoryDecreasePhase1Enabled } from '@/lib/inventory-decrease-flag';
+import {
+  createInventoryDecrease,
+  InventoryDecreaseError,
+} from '@/lib/services/inventory-decrease';
+
+export const STOCKTAKE_SURPLUS_PENDING_REVIEW = 'SURPLUS_PENDING_REVIEW';
 
 async function assertGrowthStocktake(businessId: string): Promise<{ allowed: true } | { allowed: false; error: string }> {
   const business = await prisma.business.findUnique({
@@ -34,7 +40,6 @@ export async function createStocktakeAction(): Promise<ActionResult<{ id: string
     const plan = await assertGrowthStocktake(businessId);
     if (!plan.allowed) return { success: false, error: plan.error };
 
-    // Prevent multiple in-progress stocktakes
     const existing = await prisma.stocktake.findFirst({
       where: { storeId, status: 'IN_PROGRESS' },
     });
@@ -121,14 +126,15 @@ export async function saveStocktakeCountsAction(data: {
 }
 
 /**
- * Complete a stocktake — apply variances as stock adjustments.
- * When any variance exists, a non-empty reason is required.
+ * Complete a stocktake.
+ * - Shortfalls: Phase 1 inventory decrease (requires rollout flag).
+ * - Surpluses: persisted as SURPLUS_PENDING_REVIEW — no inventory/GL post.
  */
 export async function completeStocktakeAction(data: {
   stocktakeId: string;
   counts: { lineId: string; countedBase: number }[];
   reason?: string;
-}): Promise<ActionResult> {
+}): Promise<ActionResult<{ surplusPendingReview: number; shortfallsAdjusted: number }>> {
   return safeAction(async () => {
     const { user, businessId, storeId } =
       await withBusinessStoreContext(['MANAGER', 'OWNER']);
@@ -137,77 +143,142 @@ export async function completeStocktakeAction(data: {
 
     const stocktake = await prisma.stocktake.findUnique({
       where: { id: data.stocktakeId },
-      include: { lines: { include: { product: { select: { id: true, name: true, productUnits: { where: { isBaseUnit: true }, select: { unitId: true } } } } } } },
+      include: {
+        lines: {
+          include: {
+            product: {
+              select: {
+                id: true,
+                name: true,
+                productUnits: {
+                  where: { isBaseUnit: true },
+                  select: { unitId: true },
+                },
+              },
+            },
+          },
+        },
+      },
     });
     if (!stocktake || stocktake.status !== 'IN_PROGRESS') {
       return { success: false, error: 'Stocktake not found or already completed.' };
     }
 
-    const varianceCount = data.counts.reduce((sum, count) => {
+    let shortfallCount = 0;
+    let surplusCount = 0;
+    for (const count of data.counts) {
       const line = stocktake.lines.find((l) => l.id === count.lineId);
-      if (!line || line.adjusted) return sum;
-      return count.countedBase - line.expectedBase !== 0 ? sum + 1 : sum;
-    }, 0);
+      if (!line || line.adjusted || line.reviewStatus === STOCKTAKE_SURPLUS_PENDING_REVIEW) continue;
+      const variance = count.countedBase - line.expectedBase;
+      if (variance < 0) shortfallCount += 1;
+      if (variance > 0) surplusCount += 1;
+    }
 
-    const reasonText = (data.reason ?? '').trim();
-    if (varianceCount > 0 && reasonText.length < 3) {
+    if (shortfallCount > 0 && !isInventoryDecreasePhase1Enabled()) {
       return {
         success: false,
-        error: 'Enter a reason for the variance adjustment before completing this stocktake.',
+        error:
+          'Stocktake shortfalls require inventory decrease Phase 1. Surplus counts can be saved only after Phase 1 is enabled for shortfall posting, or clear shortfall lines first.',
+      };
+    }
+
+    const reasonText = (data.reason ?? '').trim();
+    if ((shortfallCount > 0 || surplusCount > 0) && reasonText.length < 3) {
+      return {
+        success: false,
+        error: 'Enter a reason for the variance before completing this stocktake.',
       };
     }
 
     const adjustmentReason =
       reasonText.length >= 3
         ? `Stocktake: ${reasonText.slice(0, 200)}`
-        : 'Stocktake count adjustment';
+        : 'Stocktake shortfall';
 
-    // Wrap all mutations in a single transaction so a mid-loop crash cannot
-    // leave inventory in a partially-adjusted state.  On retry the idempotency
-    // guard (line.adjusted check) ensures already-processed lines are skipped.
-    let adjustedCount = 0;
+    let shortfallsAdjusted = 0;
+    let surplusPendingReview = 0;
     const affectedProductIds = new Set<string>();
+
     await prisma.$transaction(
       async (tx) => {
         for (const count of data.counts) {
           const line = stocktake.lines.find((l) => l.id === count.lineId);
           if (!line) continue;
-
-          // Idempotency guard: skip lines already adjusted in a previous partial run.
-          if (line.adjusted) continue;
+          if (line.adjusted || line.reviewStatus === STOCKTAKE_SURPLUS_PENDING_REVIEW) continue;
 
           const variance = count.countedBase - line.expectedBase;
+
+          if (variance === 0) {
+            await tx.stocktakeLine.update({
+              where: { id: count.lineId },
+              data: {
+                countedBase: count.countedBase,
+                varianceBase: 0,
+                adjusted: false,
+                reviewStatus: null,
+              },
+            });
+            continue;
+          }
+
+          if (variance > 0) {
+            // Persist surplus for review — do not post inventory or journal.
+            await tx.stocktakeLine.update({
+              where: { id: count.lineId },
+              data: {
+                countedBase: count.countedBase,
+                varianceBase: variance,
+                adjusted: false,
+                reviewStatus: STOCKTAKE_SURPLUS_PENDING_REVIEW,
+              },
+            });
+            surplusPendingReview += 1;
+            continue;
+          }
+
+          // Shortfall: Phase 1 decrease.
+          const baseUnitId = line.product.productUnits[0]?.unitId;
+          if (!baseUnitId) {
+            throw new Error(`No base unit configured for ${line.product.name}`);
+          }
+
+          const qtyInUnit = Math.abs(variance);
+          try {
+            await createInventoryDecrease(
+              {
+                businessId,
+                storeId,
+                productId: line.productId,
+                unitId: baseUnitId,
+                qtyInUnit,
+                reasonCode: 'STOCKTAKE_SHORTFALL',
+                reason: adjustmentReason,
+                idempotencyKey: `stocktake:${data.stocktakeId}:line:${count.lineId}`,
+                userId: user.id,
+                userName: user.name ?? 'Unknown',
+                userRole: user.role,
+              },
+              tx,
+            );
+          } catch (error) {
+            if (error instanceof InventoryDecreaseError) {
+              throw new Error(`${line.product.name}: ${error.message}`);
+            }
+            throw error;
+          }
 
           await tx.stocktakeLine.update({
             where: { id: count.lineId },
             data: {
               countedBase: count.countedBase,
               varianceBase: variance,
-              adjusted: variance !== 0,
+              adjusted: true,
+              reviewStatus: null,
             },
           });
 
-          // Create stock adjustment for non-zero variances
-          if (variance !== 0) {
-            const baseUnitId = line.product.productUnits[0]?.unitId;
-            if (baseUnitId) {
-              await createStockAdjustment(
-                {
-                  businessId,
-                  storeId,
-                  productId: line.productId,
-                  unitId: baseUnitId,
-                  qtyInUnit: Math.abs(variance),
-                  direction: variance > 0 ? 'INCREASE' : 'DECREASE',
-                  reason: adjustmentReason,
-                  userId: user.id,
-                },
-                tx,
-              );
-              affectedProductIds.add(line.productId);
-              adjustedCount++;
-            }
-          }
+          affectedProductIds.add(line.productId);
+          shortfallsAdjusted += 1;
         }
 
         await tx.stocktake.update({
@@ -222,7 +293,6 @@ export async function completeStocktakeAction(data: {
       { timeout: 30000, maxWait: 5000 },
     );
 
-    // Audit log and cache invalidation are fire-and-forget; keep outside the tx.
     audit({
       businessId,
       userId: user.id,
@@ -233,7 +303,8 @@ export async function completeStocktakeAction(data: {
       entityId: data.stocktakeId,
       details: {
         totalLines: stocktake.lines.length,
-        adjustedLines: adjustedCount,
+        shortfallsAdjusted,
+        surplusPendingReview,
         reason: reasonText || null,
       },
     });
@@ -250,7 +321,10 @@ export async function completeStocktakeAction(data: {
       }).catch(() => {});
     }
 
-    return { success: true };
+    return {
+      success: true,
+      data: { surplusPendingReview, shortfallsAdjusted },
+    };
   });
 }
 

--- a/app/api/seed-once/route.ts
+++ b/app/api/seed-once/route.ts
@@ -172,29 +172,9 @@ export async function GET(request: Request) {
     }
     results.push('Seeded units');
 
-    // 8. Accounts (basic chart of accounts)
-    const accountData = [
-      { code: '1000', name: 'Cash', type: 'ASSET' },
-      { code: '1100', name: 'Bank', type: 'ASSET' },
-      { code: '1200', name: 'Inventory', type: 'ASSET' },
-      { code: '1300', name: 'Mobile Money', type: 'ASSET' },
-      { code: '2000', name: 'Accounts Payable', type: 'LIABILITY' },
-      { code: '3000', name: 'Owner Equity', type: 'EQUITY' },
-      { code: '4000', name: 'Sales Revenue', type: 'REVENUE' },
-      { code: '5000', name: 'Cost of Goods Sold', type: 'EXPENSE' },
-      { code: '5100', name: 'Operating Expenses', type: 'EXPENSE' },
-      { code: '5200', name: 'VAT Collected', type: 'LIABILITY' },
-    ];
-    for (const a of accountData) {
-      const existing = await prisma.account.findFirst({
-        where: { businessId: business.id, code: a.code },
-      });
-      if (!existing) {
-        await prisma.account.create({
-          data: { businessId: business.id, ...a },
-        });
-      }
-    }
+    // 8. Accounts — align with canonical CHART_OF_ACCOUNTS (lib/accounting.ts)
+    const { ensureChartOfAccounts } = await import('@/lib/accounting');
+    await ensureChartOfAccounts(business.id);
     results.push('Seeded accounts');
 
     return NextResponse.json({

--- a/lib/accounting-inventory-loss-5100.test.ts
+++ b/lib/accounting-inventory-loss-5100.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  INVENTORY_LOSS_5100_NAME,
+  LEGACY_5100_OPERATING_EXPENSES_NAME,
+  assertAccount5100SafeForInventoryLoss,
+  inspectAccount5100Usage,
+  renameLegacyUnusedOperatingExpenses5100,
+} from './accounting-inventory-loss-5100';
+
+describe('5100 inventory-loss remediation migration SQL', () => {
+  const sql = readFileSync(
+    join(process.cwd(), 'prisma/migrations/20260802120000_inventory_decrease_phase1/migration.sql'),
+    'utf8',
+  );
+
+  it('renames only unused legacy Operating Expenses on code 5100', () => {
+    expect(sql).toContain("SET \"name\" = 'Inventory Loss & Shrinkage'");
+    expect(sql).toContain("\"code\" = '5100'");
+    expect(sql).toContain("\"name\" = 'Operating Expenses'");
+    expect(sql).toContain('NOT EXISTS');
+    expect(sql).toContain('"JournalLine"');
+  });
+
+  it('does not drop or recreate Account rows (preserves journal FKs)', () => {
+    expect(sql).not.toMatch(/DELETE\s+FROM\s+"Account"/i);
+    expect(sql).not.toMatch(/DROP\s+TABLE\s+"Account"/i);
+  });
+});
+
+describe('inspectAccount5100Usage / renameLegacyUnusedOperatingExpenses5100', () => {
+  const client = {
+    account: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    journalLine: {
+      groupBy: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('classifies unused legacy, posted legacy, correct, and custom names', async () => {
+    client.account.findMany.mockResolvedValue([
+      { id: 'a1', businessId: 'b1', name: LEGACY_5100_OPERATING_EXPENSES_NAME },
+      { id: 'a2', businessId: 'b2', name: LEGACY_5100_OPERATING_EXPENSES_NAME },
+      { id: 'a3', businessId: 'b3', name: INVENTORY_LOSS_5100_NAME },
+      { id: 'a4', businessId: 'b4', name: 'Custom Loss' },
+    ]);
+    client.journalLine.groupBy.mockResolvedValue([
+      { accountId: 'a2', _count: { _all: 3 }, _sum: { debitPence: 1500, creditPence: 0 } },
+    ]);
+
+    const result = await inspectAccount5100Usage(client as any);
+    expect(result.legacyUnused).toEqual([
+      expect.objectContaining({ businessId: 'b1', journalLineCount: 0 }),
+    ]);
+    expect(result.legacyWithPostings).toEqual([
+      expect.objectContaining({
+        businessId: 'b2',
+        journalLineCount: 3,
+        debitPence: 1500,
+      }),
+    ]);
+    expect(result.alreadyCorrect).toHaveLength(1);
+    expect(result.customNamed).toHaveLength(1);
+  });
+
+  it('renames only unused legacy accounts and is idempotent when none remain', async () => {
+    client.account.findMany.mockResolvedValue([
+      { id: 'a1', businessId: 'b1', name: LEGACY_5100_OPERATING_EXPENSES_NAME },
+    ]);
+    client.journalLine.groupBy.mockResolvedValue([]);
+    client.account.updateMany.mockResolvedValue({ count: 1 });
+
+    const first = await renameLegacyUnusedOperatingExpenses5100(client as any);
+    expect(first.renamed).toBe(1);
+    expect(client.account.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          name: LEGACY_5100_OPERATING_EXPENSES_NAME,
+          journalLines: { none: {} },
+        }),
+        data: { name: INVENTORY_LOSS_5100_NAME },
+      }),
+    );
+
+    client.account.findMany.mockResolvedValue([
+      { id: 'a1', businessId: 'b1', name: INVENTORY_LOSS_5100_NAME },
+    ]);
+    const second = await renameLegacyUnusedOperatingExpenses5100(client as any);
+    expect(second.renamed).toBe(0);
+  });
+
+  it('does not rename legacy accounts that already have journal postings', async () => {
+    client.account.findMany.mockResolvedValue([
+      { id: 'a2', businessId: 'b2', name: LEGACY_5100_OPERATING_EXPENSES_NAME },
+    ]);
+    client.journalLine.groupBy.mockResolvedValue([
+      { accountId: 'a2', _count: { _all: 2 }, _sum: { debitPence: 900, creditPence: 0 } },
+    ]);
+
+    const result = await renameLegacyUnusedOperatingExpenses5100(client as any);
+    expect(result.renamed).toBe(0);
+    expect(client.account.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('assertAccount5100SafeForInventoryLoss', () => {
+  const client = {
+    account: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    journalLine: {
+      groupBy: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows missing account (seed will create correct name)', async () => {
+    client.account.findMany.mockResolvedValue([]);
+    await expect(assertAccount5100SafeForInventoryLoss(client as any, 'b1')).resolves.toBeUndefined();
+  });
+
+  it('allows correctly named account', async () => {
+    client.account.findMany.mockResolvedValue([{ id: 'a1', name: INVENTORY_LOSS_5100_NAME }]);
+    await expect(assertAccount5100SafeForInventoryLoss(client as any, 'b1')).resolves.toBeUndefined();
+  });
+
+  it('renames unused legacy Operating Expenses opportunistically', async () => {
+    client.account.findMany.mockResolvedValue([
+      { id: 'a1', name: LEGACY_5100_OPERATING_EXPENSES_NAME },
+    ]);
+    client.journalLine.groupBy.mockResolvedValue([]);
+    client.account.updateMany.mockResolvedValue({ count: 1 });
+    await assertAccount5100SafeForInventoryLoss(client as any, 'b1');
+    expect(client.account.updateMany).toHaveBeenCalled();
+  });
+
+  it('refuses posted legacy Operating Expenses without renaming', async () => {
+    client.account.findMany.mockResolvedValue([
+      { id: 'a1', name: LEGACY_5100_OPERATING_EXPENSES_NAME },
+    ]);
+    client.journalLine.groupBy.mockResolvedValue([{ accountId: 'a1', _count: { _all: 4 } }]);
+    await expect(assertAccount5100SafeForInventoryLoss(client as any, 'b1')).rejects.toThrow(
+      /Do not rename it silently/,
+    );
+    expect(client.account.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('refuses customised non-approved 5100 names', async () => {
+    client.account.findMany.mockResolvedValue([{ id: 'a1', name: 'Owner Special Expense' }]);
+    await expect(assertAccount5100SafeForInventoryLoss(client as any, 'b1')).rejects.toThrow(
+      /customised or conflicting account/,
+    );
+  });
+});

--- a/lib/accounting-inventory-loss-5100.ts
+++ b/lib/accounting-inventory-loss-5100.ts
@@ -1,0 +1,184 @@
+import type { PrismaClient } from '@prisma/client';
+import { ACCOUNT_CODES } from '@/lib/accounting';
+
+export const LEGACY_5100_OPERATING_EXPENSES_NAME = 'Operating Expenses';
+export const INVENTORY_LOSS_5100_NAME = 'Inventory Loss & Shrinkage';
+
+export type Account5100Conflict = {
+  businessId: string;
+  accountId: string;
+  name: string;
+  journalLineCount: number;
+  debitPence: number;
+  creditPence: number;
+};
+
+type TxLike = {
+  account: {
+    findMany: (args: any) => Promise<any[]>;
+    updateMany: (args: any) => Promise<{ count: number }>;
+  };
+  journalLine: {
+    groupBy: (args: any) => Promise<any[]>;
+  };
+  $executeRaw?: (...args: any[]) => Promise<number>;
+};
+
+/**
+ * Inspect every account coded 5100.
+ * Used for pre-deploy evidence and runtime conflict detection.
+ */
+export async function inspectAccount5100Usage(
+  client: TxLike | PrismaClient,
+): Promise<{
+  totalAccounts: number;
+  legacyUnused: Account5100Conflict[];
+  legacyWithPostings: Account5100Conflict[];
+  alreadyCorrect: Account5100Conflict[];
+  customNamed: Account5100Conflict[];
+}> {
+  const accounts = await client.account.findMany({
+    where: { code: ACCOUNT_CODES.inventoryLoss },
+    select: { id: true, businessId: true, name: true },
+  });
+
+  if (accounts.length === 0) {
+    return {
+      totalAccounts: 0,
+      legacyUnused: [],
+      legacyWithPostings: [],
+      alreadyCorrect: [],
+      customNamed: [],
+    };
+  }
+
+  const totals = await client.journalLine.groupBy({
+    by: ['accountId'],
+    where: { accountId: { in: accounts.map((a) => a.id) } },
+    _count: { _all: true },
+    _sum: { debitPence: true, creditPence: true },
+  });
+  const totalsByAccount = new Map(
+    totals.map((row) => [
+      row.accountId as string,
+      {
+        journalLineCount: row._count._all as number,
+        debitPence: (row._sum.debitPence as number | null) ?? 0,
+        creditPence: (row._sum.creditPence as number | null) ?? 0,
+      },
+    ]),
+  );
+
+  const legacyUnused: Account5100Conflict[] = [];
+  const legacyWithPostings: Account5100Conflict[] = [];
+  const alreadyCorrect: Account5100Conflict[] = [];
+  const customNamed: Account5100Conflict[] = [];
+
+  for (const account of accounts) {
+    const usage = totalsByAccount.get(account.id) ?? {
+      journalLineCount: 0,
+      debitPence: 0,
+      creditPence: 0,
+    };
+    const row: Account5100Conflict = {
+      businessId: account.businessId,
+      accountId: account.id,
+      name: account.name,
+      ...usage,
+    };
+
+    if (account.name === INVENTORY_LOSS_5100_NAME) {
+      alreadyCorrect.push(row);
+      continue;
+    }
+    if (account.name === LEGACY_5100_OPERATING_EXPENSES_NAME) {
+      if (row.journalLineCount === 0) legacyUnused.push(row);
+      else legacyWithPostings.push(row);
+      continue;
+    }
+    customNamed.push(row);
+  }
+
+  return {
+    totalAccounts: accounts.length,
+    legacyUnused,
+    legacyWithPostings,
+    alreadyCorrect,
+    customNamed,
+  };
+}
+
+/**
+ * Idempotent, tenant-safe rename:
+ * only code 5100 + exact legacy name "Operating Expenses" + zero journal lines.
+ * Never touches custom names or posted accounts.
+ */
+export async function renameLegacyUnusedOperatingExpenses5100(
+  client: TxLike | PrismaClient,
+): Promise<{ renamed: number }> {
+  const inspection = await inspectAccount5100Usage(client);
+  if (inspection.legacyUnused.length === 0) {
+    return { renamed: 0 };
+  }
+
+  const result = await client.account.updateMany({
+    where: {
+      code: ACCOUNT_CODES.inventoryLoss,
+      name: LEGACY_5100_OPERATING_EXPENSES_NAME,
+      id: { in: inspection.legacyUnused.map((row) => row.accountId) },
+      journalLines: { none: {} },
+    },
+    data: { name: INVENTORY_LOSS_5100_NAME },
+  });
+
+  return { renamed: result.count };
+}
+
+/**
+ * Runtime / pre-deploy gate: refuse inventory-loss posting when 5100 is still
+ * the legacy Operating Expenses label (especially if it has historic lines).
+ */
+export async function assertAccount5100SafeForInventoryLoss(
+  client: TxLike | PrismaClient,
+  businessId: string,
+): Promise<void> {
+  const accounts = await client.account.findMany({
+    where: { businessId, code: ACCOUNT_CODES.inventoryLoss },
+    select: { id: true, name: true },
+  });
+  if (accounts.length === 0) return; // ensureChartOfAccounts will create the correct name
+
+  const account = accounts[0];
+  if (account.name === INVENTORY_LOSS_5100_NAME) return;
+
+  if (account.name === LEGACY_5100_OPERATING_EXPENSES_NAME) {
+    const usage = await client.journalLine.groupBy({
+      by: ['accountId'],
+      where: { accountId: account.id },
+      _count: { _all: true },
+    });
+    const lineCount = usage[0]?._count._all ?? 0;
+    if (lineCount > 0) {
+      throw new Error(
+        `Account 5100 is still named "${LEGACY_5100_OPERATING_EXPENSES_NAME}" and has ${lineCount} journal line(s). ` +
+          'Do not rename it silently. Use a dedicated inventory-loss account or an explicit reclassification plan.',
+      );
+    }
+    // Unused legacy name should have been renamed by migration; fix opportunistically.
+    await client.account.updateMany({
+      where: {
+        id: account.id,
+        code: ACCOUNT_CODES.inventoryLoss,
+        name: LEGACY_5100_OPERATING_EXPENSES_NAME,
+        journalLines: { none: {} },
+      },
+      data: { name: INVENTORY_LOSS_5100_NAME },
+    });
+    return;
+  }
+
+  throw new Error(
+    `Account 5100 is named "${account.name}" and is not the approved Inventory Loss & Shrinkage account. ` +
+      'Refusing to post inventory decreases to a customised or conflicting account.',
+  );
+}

--- a/lib/accounting.ts
+++ b/lib/accounting.ts
@@ -16,6 +16,8 @@ export const ACCOUNT_CODES = {
   openingBalanceEquity: '3200',
   sales: '4000',
   cogs: '5000',
+  /** Inventory write-offs / shrinkage (Phase 1 decreases). Not interchangeable with COGS. */
+  inventoryLoss: '5100',
   operatingExpenses: '6000'
 };
 
@@ -30,9 +32,10 @@ export const CHART_OF_ACCOUNTS = [
   { code: '2100', name: 'VAT Payable',            type: 'LIABILITY' as const },
   { code: '3000', name: 'Retained Earnings',      type: 'EQUITY' as const },
   { code: '3200', name: 'Opening Balance Equity', type: 'EQUITY' as const },
-  { code: '4000', name: 'Sales Revenue',          type: 'INCOME' as const },
-  { code: '5000', name: 'Cost of Goods Sold',     type: 'EXPENSE' as const },
-  { code: '6000', name: 'Operating Expenses',     type: 'EXPENSE' as const },
+  { code: '4000', name: 'Sales Revenue',              type: 'INCOME' as const },
+  { code: '5000', name: 'Cost of Goods Sold',         type: 'EXPENSE' as const },
+  { code: '5100', name: 'Inventory Loss & Shrinkage', type: 'EXPENSE' as const },
+  { code: '6000', name: 'Operating Expenses',         type: 'EXPENSE' as const },
   { code: '6100', name: 'Rent',                   type: 'EXPENSE' as const },
   { code: '6200', name: 'Utilities',              type: 'EXPENSE' as const },
   { code: '6300', name: 'Salaries',               type: 'EXPENSE' as const },

--- a/lib/inventory-decrease-flag.test.ts
+++ b/lib/inventory-decrease-flag.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { isInventoryDecreasePhase1Enabled } from './inventory-decrease-flag';
+
+describe('isInventoryDecreasePhase1Enabled', () => {
+  const previous = process.env.TILLFLOW_INVENTORY_ADJUST_PHASE1;
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.TILLFLOW_INVENTORY_ADJUST_PHASE1;
+    else process.env.TILLFLOW_INVENTORY_ADJUST_PHASE1 = previous;
+  });
+
+  it('is enabled only when env is exactly 1', () => {
+    expect(isInventoryDecreasePhase1Enabled({} as unknown as NodeJS.ProcessEnv)).toBe(false);
+    expect(
+      isInventoryDecreasePhase1Enabled({
+        TILLFLOW_INVENTORY_ADJUST_PHASE1: '0',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toBe(false);
+    expect(
+      isInventoryDecreasePhase1Enabled({
+        TILLFLOW_INVENTORY_ADJUST_PHASE1: '1',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toBe(true);
+  });
+});

--- a/lib/inventory-decrease-flag.ts
+++ b/lib/inventory-decrease-flag.ts
@@ -1,0 +1,10 @@
+/**
+ * Rollout gate for lean inventory-decrease Phase 1.
+ * When disabled, creation UI/actions must hide or reject — never fall back to
+ * the legacy unhardened `createStockAdjustment` mutation.
+ */
+export function isInventoryDecreasePhase1Enabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.TILLFLOW_INVENTORY_ADJUST_PHASE1 === '1';
+}

--- a/lib/reports/reorder-suggestions-clarity.test.ts
+++ b/lib/reports/reorder-suggestions-clarity.test.ts
@@ -96,6 +96,8 @@ describe('Reorder Suggestions clarity pass', () => {
     expect(reorderAction).toContain("revalidatePath('/reports/reorder-suggestions')");
     expect(purchases).toContain("stockMovementType?: 'OPENING' | 'PURCHASE'");
     expect(products).toContain('preferredSupplierId?: string | null');
-    expect(inventory).toContain("type: 'ADJUSTMENT'");
+    // Phase 1: legacy createStockAdjustment is disabled; ADJUSTMENT posts live in inventory-decrease.
+    expect(inventory).toContain('Legacy unhardened stock adjustment — permanently disabled');
+    expect(readSource('lib/services/inventory-decrease.ts')).toContain("type: 'ADJUSTMENT'");
   });
 });

--- a/lib/reports/stock-movements-clarity.test.ts
+++ b/lib/reports/stock-movements-clarity.test.ts
@@ -105,7 +105,9 @@ describe('Stock Movements clarity and mobile polish', () => {
     const transfers = readSource('lib/services/stock-transfers.ts');
     const exports = readSource('lib/exports/csv-writers.ts');
 
-    expect(inventory).toContain("type: 'ADJUSTMENT'");
+    // Phase 1: legacy createStockAdjustment is disabled; ADJUSTMENT posts live in inventory-decrease.
+    expect(inventory).toContain('Legacy unhardened stock adjustment — permanently disabled');
+    expect(readSource('lib/services/inventory-decrease.ts')).toContain("type: 'ADJUSTMENT'");
     expect(sales).toContain("type: 'SALE' as const");
     expect(purchases).toContain("stockMovementType?: 'OPENING' | 'PURCHASE'");
     expect(returns).toContain("type: 'PURCHASE_RETURN'");

--- a/lib/services/adjustments-page-polish.test.ts
+++ b/lib/services/adjustments-page-polish.test.ts
@@ -14,7 +14,6 @@ describe('inventory adjustments page polish', () => {
 
   it('uses owner-friendly subtitle', () => {
     expect(src).toContain('Correct stock safely and keep a clear audit trail.');
-    expect(src).not.toContain('Record shrinkage, found stock, and corrections.');
   });
 
   it('stat card labels are present', () => {
@@ -25,7 +24,7 @@ describe('inventory adjustments page polish', () => {
 
   it('stat cards have helper text', () => {
     expect(src).toContain('Total adjustments');
-    expect(src).toContain('Stock increases');
+    expect(src).toContain('Historical increases');
     expect(src).toContain('Stock decreases');
   });
 
@@ -35,53 +34,41 @@ describe('inventory adjustments page polish', () => {
   });
 
   it('audit trail copy is present in history section', () => {
-    expect(src).toContain('Every adjustment is permanently recorded');
-    expect(src).toContain('audited opposite entry');
+    expect(src).toContain('Every Phase 1 decrease is permanently recorded');
+    expect(src).toContain('Automated reversal is unavailable in Phase 1');
   });
 
   it('adjustment form component remains present', () => {
     expect(src).toContain('StockAdjustmentClient');
     expect(src).toContain('storeId={store.id}');
+    expect(src).toContain('phase1Enabled={phase1Enabled}');
   });
 
   it('adjustment form references createStockAdjustmentAction', () => {
     expect(formSrc).toContain('createStockAdjustmentAction');
   });
 
-  it('adjustment form input names are unchanged', () => {
+  it('decrease-only form posts required Phase 1 fields', () => {
     expect(formSrc).toContain('name="storeId"');
     expect(formSrc).toContain('name="productId"');
     expect(formSrc).toContain('name="unitId"');
     expect(formSrc).toContain('name="qtyInUnit"');
     expect(formSrc).toContain('name="direction"');
+    expect(formSrc).toContain('value="DECREASE"');
     expect(formSrc).toContain('name="reason"');
+    expect(formSrc).toContain('name="reasonCode"');
+    expect(formSrc).toContain('name="idempotencyKey"');
+    expect(formSrc).not.toContain('Increase (found stock)');
   });
 
   it('recent adjustments history section is present', () => {
     expect(src).toContain('Recent adjustments');
   });
 
-  it('reversal action remains available', () => {
-    expect(src).toContain('ReverseStockAdjustmentForm');
-    expect(src).toContain('canReverseAdjustments');
-  });
-
-  it('owner-only reversal gating is unchanged', () => {
-    expect(src).toContain("user.role === 'OWNER'");
-    expect(reverseSrc).toContain('reverseStockAdjustmentAction');
-  });
-
-  it('reversal form input name is unchanged', () => {
-    expect(reverseSrc).toContain('name="adjustmentId"');
-    expect(reverseSrc).toContain('name="reason"');
-  });
-
-  it('isReversal helper logic is unchanged', () => {
-    expect(src).toContain("reason?.includes('Reversal of adjustment')");
-  });
-
-  it('isIncreaseDirection logic is unchanged', () => {
-    expect(src).toContain("direction === 'INCREASE' || direction === 'IN'");
+  it('automated reversal UI is unavailable', () => {
+    expect(src).not.toContain('ReverseStockAdjustmentForm');
+    expect(reverseSrc).toContain('Automated reversal unavailable');
+    expect(reverseSrc).not.toContain('reverseStockAdjustmentAction');
   });
 
   it('desktop table has row hover polish', () => {
@@ -104,12 +91,12 @@ describe('inventory adjustments page polish', () => {
 
   it('empty state copy is owner-friendly', () => {
     expect(src).toContain('No stock adjustments yet.');
-    expect(src).toContain('When stock needs correcting, record an adjustment so TillFlow keeps a clear audit trail.');
+    expect(src).toContain('When stock needs correcting, record a decrease so TillFlow keeps a clear audit trail.');
   });
 
   it('desktop table has an empty state', () => {
     expect(src).toContain('AdjustmentsEmptyState');
-    expect(src).toContain('colSpan={canReverseAdjustments ? 7 : 6}');
+    expect(src).toContain('colSpan={6}');
   });
 
   it('does not add pointer or touch handlers', () => {

--- a/lib/services/inventory-decrease-actions.test.ts
+++ b/lib/services/inventory-decrease-actions.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('inventory decrease Phase 1 actions', () => {
+  const inventoryAction = readFileSync(join(process.cwd(), 'app/actions/inventory.ts'), 'utf8');
+  const stocktakeAction = readFileSync(join(process.cwd(), 'app/actions/stocktake.ts'), 'utf8');
+  const legacyService = readFileSync(join(process.cwd(), 'lib/services/inventory.ts'), 'utf8');
+
+  it('create action uses Phase 1 decrease and never calls legacy createStockAdjustment', () => {
+    expect(inventoryAction).toContain('createInventoryDecrease');
+    expect(inventoryAction).toContain('isInventoryDecreasePhase1Enabled');
+    expect(inventoryAction).not.toContain("from '@/lib/services/inventory'");
+    expect(inventoryAction).toContain("direction !== 'DECREASE'");
+  });
+
+  it('requires reasonCode and idempotencyKey on create', () => {
+    expect(inventoryAction).toContain('reasonCode');
+    expect(inventoryAction).toContain('idempotencyKey');
+    expect(inventoryAction).toContain('isInventoryDecreaseReasonCode');
+  });
+
+  it('blocks automated reversal', () => {
+    expect(inventoryAction).toContain('Automated adjustment reversal is unavailable');
+    expect(inventoryAction).not.toContain('createStockAdjustment({');
+  });
+
+  it('legacy createStockAdjustment is permanently disabled', () => {
+    expect(legacyService).toContain('Legacy stock adjustments are disabled');
+    expect(legacyService).toContain('Promise<never>');
+    expect(legacyService).not.toContain('postJournalEntry');
+  });
+
+  it('stocktake posts shortfalls via Phase 1 and marks surplus pending review', () => {
+    expect(stocktakeAction).toContain('createInventoryDecrease');
+    expect(stocktakeAction).toContain('STOCKTAKE_SHORTFALL');
+    expect(stocktakeAction).toContain('SURPLUS_PENDING_REVIEW');
+    expect(stocktakeAction).not.toContain("direction: variance > 0 ? 'INCREASE'");
+    expect(stocktakeAction).not.toContain("from '@/lib/services/inventory'");
+  });
+
+  it('no production callers import the disabled legacy inventory service', () => {
+    const inventoryAction = readFileSync(join(process.cwd(), 'app/actions/inventory.ts'), 'utf8');
+    const stocktakeAction = readFileSync(join(process.cwd(), 'app/actions/stocktake.ts'), 'utf8');
+    const phase3a = readFileSync(join(process.cwd(), 'scripts/phase3a-qa.ts'), 'utf8');
+    expect(inventoryAction).not.toContain("from '@/lib/services/inventory'");
+    expect(stocktakeAction).not.toContain("from '@/lib/services/inventory'");
+    expect(phase3a).toContain('createInventoryDecrease');
+    expect(phase3a).not.toContain('createStockAdjustment');
+  });
+});

--- a/lib/services/inventory-decrease-actions.test.ts
+++ b/lib/services/inventory-decrease-actions.test.ts
@@ -39,13 +39,22 @@ describe('inventory decrease Phase 1 actions', () => {
     expect(stocktakeAction).not.toContain("from '@/lib/services/inventory'");
   });
 
+  it('stocktake shortfalls require the Phase 1 flag', () => {
+    expect(stocktakeAction).toContain('isInventoryDecreasePhase1Enabled');
+    expect(stocktakeAction).toContain('shortfallCount > 0 && !isInventoryDecreasePhase1Enabled()');
+  });
+
   it('no production callers import the disabled legacy inventory service', () => {
-    const inventoryAction = readFileSync(join(process.cwd(), 'app/actions/inventory.ts'), 'utf8');
-    const stocktakeAction = readFileSync(join(process.cwd(), 'app/actions/stocktake.ts'), 'utf8');
     const phase3a = readFileSync(join(process.cwd(), 'scripts/phase3a-qa.ts'), 'utf8');
     expect(inventoryAction).not.toContain("from '@/lib/services/inventory'");
     expect(stocktakeAction).not.toContain("from '@/lib/services/inventory'");
     expect(phase3a).toContain('createInventoryDecrease');
     expect(phase3a).not.toContain('createStockAdjustment');
+  });
+
+  it('use server files do not export non-async constants', () => {
+    expect(stocktakeAction).not.toMatch(/export const STOCKTAKE_SURPLUS_PENDING_REVIEW/);
+    expect(stocktakeAction).toContain("const STOCKTAKE_SURPLUS_PENDING_REVIEW = 'SURPLUS_PENDING_REVIEW'");
+    expect(inventoryAction).not.toContain('export { INVENTORY_DECREASE_ERROR }');
   });
 });

--- a/lib/services/inventory-decrease.test.ts
+++ b/lib/services/inventory-decrease.test.ts
@@ -1,0 +1,382 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ACCOUNT_CODES } from '@/lib/accounting';
+import {
+  INVENTORY_DECREASE_ERROR,
+  INVENTORY_DECREASE_SCHEMA_VERSION,
+  buildInventoryDecreasePayloadHash,
+  checkedMul,
+  createInventoryDecrease,
+  InventoryDecreaseError,
+  normalizeReasonText,
+} from './inventory-decrease';
+
+const {
+  prismaMock,
+  postJournalEntryMock,
+  decrementInventoryBalanceMock,
+  isPhase1EnabledMock,
+  detectInventoryAdjustmentRiskMock,
+} = vi.hoisted(() => ({
+  prismaMock: {
+    store: { findFirst: vi.fn() },
+    productUnit: { findFirst: vi.fn() },
+    business: { findUnique: vi.fn() },
+    stockAdjustment: { findUnique: vi.fn(), create: vi.fn() },
+    inventoryBalance: { findUnique: vi.fn() },
+    stockMovement: { create: vi.fn() },
+    auditLog: { create: vi.fn() },
+    $transaction: vi.fn(),
+    $queryRaw: vi.fn(),
+  },
+  postJournalEntryMock: vi.fn(),
+  decrementInventoryBalanceMock: vi.fn(),
+  isPhase1EnabledMock: vi.fn(() => true),
+  detectInventoryAdjustmentRiskMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/prisma', () => ({ prisma: prismaMock }));
+vi.mock('@/lib/inventory-decrease-flag', () => ({
+  isInventoryDecreasePhase1Enabled: isPhase1EnabledMock,
+}));
+vi.mock('@/lib/accounting', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/accounting')>('@/lib/accounting');
+  return {
+    ...actual,
+    postJournalEntry: postJournalEntryMock,
+  };
+});
+vi.mock('@/lib/accounting-inventory-loss-5100', () => ({
+  assertAccount5100SafeForInventoryLoss: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./shared', async () => {
+  const actual = await vi.importActual<typeof import('./shared')>('./shared');
+  return {
+    ...actual,
+    decrementInventoryBalance: decrementInventoryBalanceMock,
+  };
+});
+vi.mock('./risk-monitor', () => ({
+  detectInventoryAdjustmentRisk: detectInventoryAdjustmentRiskMock,
+}));
+const BIZ = 'biz-1';
+const STORE = 'store-1';
+const PRODUCT = 'prod-1';
+const UNIT = 'unit-1';
+
+function baseInput(overrides: Partial<Parameters<typeof createInventoryDecrease>[0]> = {}) {
+  return {
+    businessId: BIZ,
+    storeId: STORE,
+    productId: PRODUCT,
+    unitId: UNIT,
+    qtyInUnit: 2,
+    reasonCode: 'WASTAGE' as const,
+    reason: 'Floor wastage',
+    idempotencyKey: 'idem-1',
+    userId: 'user-1',
+    userName: 'Manager',
+    userRole: 'MANAGER',
+    ...overrides,
+  };
+}
+
+function makeCreated(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'adj-1',
+    storeId: STORE,
+    productId: PRODUCT,
+    unitId: UNIT,
+    qtyInUnit: 2,
+    qtyBase: -2,
+    reasonCode: 'WASTAGE',
+    reason: 'Floor wastage',
+    idempotencyKey: 'idem-1',
+    payloadHash: 'hash',
+    unitCostBasePence: 100,
+    valuePence: 200,
+    schemaVersion: INVENTORY_DECREASE_SCHEMA_VERSION,
+    ...overrides,
+  };
+}
+
+describe('inventory decrease helpers', () => {
+  it('normalizes reason text', () => {
+    expect(normalizeReasonText('  Floor   wastage  ')).toBe('Floor wastage');
+  });
+
+  it('checkedMul rejects unsafe products', () => {
+    expect(checkedMul(2, 3)).toBe(6);
+    expect(() => checkedMul(Number.MAX_SAFE_INTEGER, 2)).toThrow(InventoryDecreaseError);
+  });
+
+  it('payloadHash changes when reason changes', () => {
+    const a = buildInventoryDecreasePayloadHash({
+      businessId: BIZ,
+      storeId: STORE,
+      productId: PRODUCT,
+      unitId: UNIT,
+      conversionToBase: 1,
+      qtyBase: 2,
+      reasonCode: 'WASTAGE',
+      normalizedReason: 'Floor wastage',
+      schemaVersion: 1,
+    });
+    const b = buildInventoryDecreasePayloadHash({
+      businessId: BIZ,
+      storeId: STORE,
+      productId: PRODUCT,
+      unitId: UNIT,
+      conversionToBase: 1,
+      qtyBase: 2,
+      reasonCode: 'WASTAGE',
+      normalizedReason: 'Different reason',
+      schemaVersion: 1,
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('createInventoryDecrease', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isPhase1EnabledMock.mockReturnValue(true);
+    process.env.DATABASE_URL = 'file:./dev.db';
+
+    prismaMock.store.findFirst.mockResolvedValue({ id: STORE });
+    prismaMock.productUnit.findFirst.mockResolvedValue({ conversionToBase: 1 });
+    prismaMock.stockAdjustment.findUnique.mockResolvedValue(null);
+    prismaMock.inventoryBalance.findUnique.mockResolvedValue({
+      qtyOnHandBase: 10,
+      avgCostBasePence: 100,
+    });
+    prismaMock.stockAdjustment.create.mockResolvedValue(makeCreated());
+    prismaMock.stockMovement.create.mockResolvedValue({ id: 'mov-1' });
+    prismaMock.auditLog.create.mockResolvedValue({ id: 'audit-1' });
+    prismaMock.business.findUnique.mockResolvedValue({ inventoryAdjustmentRiskThresholdBase: 50 });
+    decrementInventoryBalanceMock.mockResolvedValue(8);
+    postJournalEntryMock.mockResolvedValue({ id: 'je-1' });
+
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
+  });
+
+  it('rejects when the Phase 1 flag is off', async () => {
+    isPhase1EnabledMock.mockReturnValue(false);
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.FLAG_DISABLED,
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('posts a decrease with Dr 5100 / Cr 1200 and in-tx audit', async () => {
+    const result = await createInventoryDecrease(baseInput({ reasonCode: 'EXPIRED' }));
+
+    expect(result.replayed).toBe(false);
+    expect(result.id).toBe('adj-1');
+    expect(decrementInventoryBalanceMock).toHaveBeenCalledWith(prismaMock, STORE, PRODUCT, 2);
+    expect(postJournalEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lines: [
+          { accountCode: ACCOUNT_CODES.inventoryLoss, debitPence: 200 },
+          { accountCode: ACCOUNT_CODES.inventory, creditPence: 200 },
+        ],
+      }),
+    );
+    expect(ACCOUNT_CODES.inventoryLoss).toBe('5100');
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: 'INVENTORY_ADJUST',
+          entityId: 'adj-1',
+        }),
+      }),
+    );
+    expect(prismaMock.stockMovement.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          qtyBase: -2,
+          beforeQtyBase: 10,
+          afterQtyBase: 8,
+          unitCostBasePence: 100,
+        }),
+      }),
+    );
+  });
+
+  it('supports each Phase 1 reason code', async () => {
+    for (const reasonCode of [
+      'WASTAGE',
+      'EXPIRED',
+      'DAMAGED',
+      'THEFT',
+      'STOCKTAKE_SHORTFALL',
+      'AUTHORISED_QUANTITY_CORRECTION',
+    ] as const) {
+      vi.clearAllMocks();
+      isPhase1EnabledMock.mockReturnValue(true);
+      prismaMock.store.findFirst.mockResolvedValue({ id: STORE });
+      prismaMock.productUnit.findFirst.mockResolvedValue({ conversionToBase: 1 });
+      prismaMock.stockAdjustment.findUnique.mockResolvedValue(null);
+      prismaMock.inventoryBalance.findUnique.mockResolvedValue({
+        qtyOnHandBase: 10,
+        avgCostBasePence: 50,
+      });
+      prismaMock.stockAdjustment.create.mockResolvedValue(
+        makeCreated({ reasonCode, unitCostBasePence: 50, valuePence: 100 }),
+      );
+      prismaMock.stockMovement.create.mockResolvedValue({});
+      prismaMock.auditLog.create.mockResolvedValue({});
+      decrementInventoryBalanceMock.mockResolvedValue(8);
+      postJournalEntryMock.mockResolvedValue({});
+      prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+        fn(prismaMock),
+      );
+
+      const result = await createInventoryDecrease(
+        baseInput({ reasonCode, idempotencyKey: `idem-${reasonCode}` }),
+      );
+      expect(result.reasonCode).toBe(reasonCode);
+    }
+  });
+
+  it('rejects missing balance as INSUFFICIENT_QUANTITY', async () => {
+    prismaMock.inventoryBalance.findUnique.mockResolvedValue(null);
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.INSUFFICIENT_QUANTITY,
+    });
+  });
+
+  it('rejects inadequate quantity', async () => {
+    prismaMock.inventoryBalance.findUnique.mockResolvedValue({
+      qtyOnHandBase: 1,
+      avgCostBasePence: 100,
+    });
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.INSUFFICIENT_QUANTITY,
+    });
+  });
+
+  it('rejects zero avgCostBasePence as MISSING_VALUATION without writes', async () => {
+    prismaMock.inventoryBalance.findUnique.mockResolvedValue({
+      qtyOnHandBase: 10,
+      avgCostBasePence: 0,
+    });
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.MISSING_VALUATION,
+    });
+    expect(prismaMock.stockAdjustment.create).not.toHaveBeenCalled();
+    expect(postJournalEntryMock).not.toHaveBeenCalled();
+    expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it('does not use Product.defaultCostBasePence', async () => {
+    // productUnit lookup must not select default cost — only conversion.
+    await createInventoryDecrease(baseInput());
+    expect(prismaMock.productUnit.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: { conversionToBase: true },
+      }),
+    );
+  });
+
+  it('rejects invalid reason code and short reason', async () => {
+    await expect(
+      createInventoryDecrease(baseInput({ reasonCode: 'NOPE' as any })),
+    ).rejects.toMatchObject({ code: INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT });
+    await expect(createInventoryDecrease(baseInput({ reason: 'ab' }))).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT,
+    });
+  });
+
+  it('replays a matching idempotent request without a second write', async () => {
+    const hash = buildInventoryDecreasePayloadHash({
+      businessId: BIZ,
+      storeId: STORE,
+      productId: PRODUCT,
+      unitId: UNIT,
+      conversionToBase: 1,
+      qtyBase: 2,
+      reasonCode: 'WASTAGE',
+      normalizedReason: 'Floor wastage',
+      schemaVersion: INVENTORY_DECREASE_SCHEMA_VERSION,
+    });
+    prismaMock.stockAdjustment.findUnique.mockResolvedValue(makeCreated({ payloadHash: hash }));
+
+    const result = await createInventoryDecrease(baseInput());
+    expect(result.replayed).toBe(true);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns DUPLICATE_MISMATCH when idempotency key collides with different hash', async () => {
+    prismaMock.stockAdjustment.findUnique.mockResolvedValue(
+      makeCreated({ payloadHash: 'other-hash' }),
+    );
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.DUPLICATE_MISMATCH,
+    });
+  });
+
+  it('recovers from a unique-constraint race outside the aborted transaction', async () => {
+    const hash = buildInventoryDecreasePayloadHash({
+      businessId: BIZ,
+      storeId: STORE,
+      productId: PRODUCT,
+      unitId: UNIT,
+      conversionToBase: 1,
+      qtyBase: 2,
+      reasonCode: 'WASTAGE',
+      normalizedReason: 'Floor wastage',
+      schemaVersion: INVENTORY_DECREASE_SCHEMA_VERSION,
+    });
+
+    prismaMock.$transaction.mockRejectedValueOnce({
+      code: 'P2002',
+      meta: { target: ['storeId', 'idempotencyKey'] },
+    });
+    prismaMock.stockAdjustment.findUnique
+      .mockResolvedValueOnce(null) // preliminary
+      .mockResolvedValueOnce(makeCreated({ payloadHash: hash })); // post-race reread
+
+    const result = await createInventoryDecrease(baseInput());
+    expect(result.replayed).toBe(true);
+  });
+
+  it('rolls back conceptually when journal posting fails', async () => {
+    postJournalEntryMock.mockRejectedValueOnce(new Error('Unbalanced journal entry: 1 != 2'));
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.POSTING_FAILURE,
+    });
+  });
+
+  it('maps missing account codes to ACCOUNT_MAPPING_UNAVAILABLE', async () => {
+    postJournalEntryMock.mockRejectedValueOnce(new Error('Account not found for code 5100'));
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.ACCOUNT_MAPPING_UNAVAILABLE,
+    });
+  });
+
+  it('fails the transaction when audit insert fails', async () => {
+    prismaMock.auditLog.create.mockRejectedValueOnce(new Error('audit down'));
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.AUDIT_FAILURE,
+    });
+  });
+
+  it('rejects cross-tenant store', async () => {
+    prismaMock.store.findFirst.mockResolvedValue(null);
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.UNAUTHORISED,
+    });
+  });
+
+  it('uses PostgreSQL FOR UPDATE when DATABASE_URL is postgres', async () => {
+    process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/tillflow';
+    prismaMock.$queryRaw.mockResolvedValue([{ qtyOnHandBase: 10, avgCostBasePence: 100 }]);
+
+    await createInventoryDecrease(baseInput());
+
+    expect(prismaMock.$queryRaw).toHaveBeenCalled();
+    expect(prismaMock.inventoryBalance.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/lib/services/inventory-decrease.test.ts
+++ b/lib/services/inventory-decrease.test.ts
@@ -169,6 +169,18 @@ describe('createInventoryDecrease', () => {
     expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
+  it('rejects missing userRole before any writes', async () => {
+    await expect(
+      createInventoryDecrease(baseInput({ userRole: '   ' })),
+    ).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT,
+      message: expect.stringMatching(/role/i),
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    expect(prismaMock.stockAdjustment.create).not.toHaveBeenCalled();
+    expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
+  });
+
   it('posts a decrease with Dr 5100 / Cr 1200 and in-tx audit', async () => {
     const result = await createInventoryDecrease(baseInput({ reasonCode: 'EXPIRED' }));
 

--- a/lib/services/inventory-decrease.ts
+++ b/lib/services/inventory-decrease.ts
@@ -1,0 +1,547 @@
+import { createHash } from 'crypto';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { ACCOUNT_CODES, postJournalEntry } from '@/lib/accounting';
+import { assertAccount5100SafeForInventoryLoss } from '@/lib/accounting-inventory-loss-5100';
+import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
+import { isInventoryDecreasePhase1Enabled } from '@/lib/inventory-decrease-flag';
+import { decrementInventoryBalance } from './shared';
+import { detectInventoryAdjustmentRisk } from './risk-monitor';
+import { measureServerOperation, PERFORMANCE_THRESHOLDS_MS } from '@/lib/observability';
+
+export const INVENTORY_DECREASE_SCHEMA_VERSION = 1;
+
+export const INVENTORY_DECREASE_REASON_CODES = [
+  'WASTAGE',
+  'EXPIRED',
+  'DAMAGED',
+  'THEFT',
+  'STOCKTAKE_SHORTFALL',
+  'AUTHORISED_QUANTITY_CORRECTION',
+] as const;
+
+export type InventoryDecreaseReasonCode = (typeof INVENTORY_DECREASE_REASON_CODES)[number];
+
+export const INVENTORY_DECREASE_ERROR = {
+  FLAG_DISABLED: 'FLAG_DISABLED',
+  UNAUTHORISED: 'UNAUTHORISED',
+  INVALID_ADJUSTMENT: 'INVALID_ADJUSTMENT',
+  INSUFFICIENT_QUANTITY: 'INSUFFICIENT_QUANTITY',
+  MISSING_VALUATION: 'MISSING_VALUATION',
+  DUPLICATE_MISMATCH: 'DUPLICATE_MISMATCH',
+  ACCOUNT_MAPPING_UNAVAILABLE: 'ACCOUNT_MAPPING_UNAVAILABLE',
+  ARITHMETIC_LIMIT: 'ARITHMETIC_LIMIT',
+  POSTING_FAILURE: 'POSTING_FAILURE',
+  AUDIT_FAILURE: 'AUDIT_FAILURE',
+} as const;
+
+export type InventoryDecreaseErrorCode =
+  (typeof INVENTORY_DECREASE_ERROR)[keyof typeof INVENTORY_DECREASE_ERROR];
+
+export class InventoryDecreaseError extends Error {
+  readonly code: InventoryDecreaseErrorCode;
+
+  constructor(code: InventoryDecreaseErrorCode, message: string) {
+    super(message);
+    this.name = 'InventoryDecreaseError';
+    this.code = code;
+  }
+}
+
+export type InventoryDecreaseInput = {
+  businessId: string;
+  storeId: string;
+  productId: string;
+  unitId: string;
+  qtyInUnit: number;
+  reasonCode: InventoryDecreaseReasonCode;
+  reason: string;
+  idempotencyKey: string;
+  userId: string;
+  userName: string;
+  userRole: string;
+};
+
+export type InventoryDecreaseResult = {
+  id: string;
+  storeId: string;
+  productId: string;
+  unitId: string;
+  qtyInUnit: number;
+  qtyBase: number;
+  direction: 'DECREASE';
+  reasonCode: string;
+  reason: string | null;
+  idempotencyKey: string | null;
+  payloadHash: string | null;
+  unitCostBasePence: number | null;
+  valuePence: number | null;
+  schemaVersion: number | null;
+  replayed: boolean;
+};
+
+type LockedBalance = {
+  qtyOnHandBase: number;
+  avgCostBasePence: number;
+};
+
+function hasPrismaErrorCode(error: unknown, code: string): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
+function isPrismaUniqueConstraintOn(error: unknown, fields: string[]): boolean {
+  if (!hasPrismaErrorCode(error, 'P2002')) return false;
+  const target = (error as { meta?: { target?: unknown } }).meta?.target;
+  if (Array.isArray(target)) {
+    const targetFields = target.map((item) => String(item));
+    return fields.every((field) => targetFields.includes(field));
+  }
+  if (typeof target === 'string') {
+    return fields.every((field) => target.includes(field));
+  }
+  return false;
+}
+
+export function normalizeReasonText(reason: string): string {
+  return reason.trim().replace(/\s+/g, ' ');
+}
+
+export function isInventoryDecreaseReasonCode(
+  value: string,
+): value is InventoryDecreaseReasonCode {
+  return (INVENTORY_DECREASE_REASON_CODES as readonly string[]).includes(value);
+}
+
+export function checkedMul(a: number, b: number): number {
+  if (!Number.isInteger(a) || !Number.isInteger(b)) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.ARITHMETIC_LIMIT,
+      'Quantity and cost must be integers',
+    );
+  }
+  const product = a * b;
+  if (!Number.isSafeInteger(product)) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.ARITHMETIC_LIMIT,
+      'Arithmetic limit exceeded',
+    );
+  }
+  return product;
+}
+
+export function buildInventoryDecreasePayloadHash(parts: {
+  businessId: string;
+  storeId: string;
+  productId: string;
+  unitId: string;
+  conversionToBase: number;
+  qtyBase: number;
+  reasonCode: string;
+  normalizedReason: string;
+  schemaVersion: number;
+}): string {
+  const canonical = [
+    parts.businessId,
+    parts.storeId,
+    parts.productId,
+    parts.unitId,
+    String(parts.conversionToBase),
+    String(parts.qtyBase),
+    'DECREASE',
+    parts.reasonCode,
+    parts.normalizedReason,
+    String(parts.schemaVersion),
+  ].join('\0');
+  return createHash('sha256').update(canonical, 'utf8').digest('hex');
+}
+
+function toResult(
+  row: {
+    id: string;
+    storeId: string;
+    productId: string;
+    unitId: string;
+    qtyInUnit: number;
+    qtyBase: number;
+    reasonCode: string | null;
+    reason: string | null;
+    idempotencyKey: string | null;
+    payloadHash: string | null;
+    unitCostBasePence: number | null;
+    valuePence: number | null;
+    schemaVersion: number | null;
+  },
+  replayed: boolean,
+): InventoryDecreaseResult {
+  return {
+    id: row.id,
+    storeId: row.storeId,
+    productId: row.productId,
+    unitId: row.unitId,
+    qtyInUnit: row.qtyInUnit,
+    qtyBase: row.qtyBase,
+    direction: 'DECREASE',
+    reasonCode: row.reasonCode ?? '',
+    reason: row.reason,
+    idempotencyKey: row.idempotencyKey,
+    payloadHash: row.payloadHash,
+    unitCostBasePence: row.unitCostBasePence,
+    valuePence: row.valuePence,
+    schemaVersion: row.schemaVersion,
+    replayed,
+  };
+}
+
+const ADJUSTMENT_SELECT = {
+  id: true,
+  storeId: true,
+  productId: true,
+  unitId: true,
+  qtyInUnit: true,
+  qtyBase: true,
+  reasonCode: true,
+  reason: true,
+  idempotencyKey: true,
+  payloadHash: true,
+  unitCostBasePence: true,
+  valuePence: true,
+  schemaVersion: true,
+} as const;
+
+async function lockInventoryBalance(
+  tx: Prisma.TransactionClient,
+  storeId: string,
+  productId: string,
+): Promise<LockedBalance | null> {
+  if (isPostgresDatabaseUrl(process.env.DATABASE_URL)) {
+    const rows = await tx.$queryRaw<LockedBalance[]>`
+      SELECT "qtyOnHandBase", "avgCostBasePence"
+      FROM "InventoryBalance"
+      WHERE "storeId" = ${storeId} AND "productId" = ${productId}
+      FOR UPDATE
+    `;
+    return rows[0] ?? null;
+  }
+
+  return tx.inventoryBalance.findUnique({
+    where: { storeId_productId: { storeId, productId } },
+    select: { qtyOnHandBase: true, avgCostBasePence: true },
+  });
+}
+
+async function findByIdempotencyKey(storeId: string, idempotencyKey: string) {
+  return prisma.stockAdjustment.findUnique({
+    where: { storeId_idempotencyKey: { storeId, idempotencyKey } },
+    select: ADJUSTMENT_SELECT,
+  });
+}
+
+/**
+ * Phase 1 quantity-decrease only. Requires rollout flag.
+ * Does not fall back to Product.defaultCostBasePence — uses locked avgCostBasePence only.
+ */
+export async function createInventoryDecrease(
+  input: InventoryDecreaseInput,
+  outerTx?: Prisma.TransactionClient,
+): Promise<InventoryDecreaseResult> {
+  return measureServerOperation(
+    'action.stock-adjustment.create',
+    () => createInventoryDecreaseImpl(input, outerTx),
+    {
+      businessId: input.businessId,
+      storeId: input.storeId,
+      action: 'createInventoryDecrease',
+      cacheState: outerTx ? 'nested-transaction' : 'write-through',
+    },
+    { thresholdMs: PERFORMANCE_THRESHOLDS_MS.action, operationType: 'action' },
+  );
+}
+
+async function createInventoryDecreaseImpl(
+  input: InventoryDecreaseInput,
+  outerTx?: Prisma.TransactionClient,
+): Promise<InventoryDecreaseResult> {
+  if (!isInventoryDecreasePhase1Enabled()) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.FLAG_DISABLED,
+      'Inventory decrease Phase 1 is not enabled',
+    );
+  }
+
+  const idempotencyKey = input.idempotencyKey.trim();
+  if (!idempotencyKey) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT,
+      'Idempotency key is required',
+    );
+  }
+
+  if (!Number.isInteger(input.qtyInUnit) || input.qtyInUnit < 1) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT,
+      'Quantity must be an integer of at least 1',
+    );
+  }
+
+  if (!isInventoryDecreaseReasonCode(input.reasonCode)) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT,
+      'Invalid reason code',
+    );
+  }
+
+  const normalizedReason = normalizeReasonText(input.reason);
+  if (normalizedReason.length < 3) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT,
+      'Reason text is required',
+    );
+  }
+
+  const client = outerTx ?? prisma;
+
+  const [store, productUnit] = await Promise.all([
+    client.store.findFirst({
+      where: { id: input.storeId, businessId: input.businessId },
+      select: { id: true },
+    }),
+    client.productUnit.findFirst({
+      where: {
+        productId: input.productId,
+        unitId: input.unitId,
+        product: { businessId: input.businessId },
+      },
+      select: { conversionToBase: true },
+    }),
+  ]);
+
+  if (!store) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.UNAUTHORISED,
+      'Store not found for this business',
+    );
+  }
+  if (!productUnit) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.UNAUTHORISED,
+      'Unit not configured for product in this business',
+    );
+  }
+
+  const conversionToBase = productUnit.conversionToBase;
+  if (!Number.isInteger(conversionToBase) || conversionToBase < 1) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT,
+      'Invalid unit conversion',
+    );
+  }
+
+  const qtyBase = checkedMul(input.qtyInUnit, conversionToBase);
+  const payloadHash = buildInventoryDecreasePayloadHash({
+    businessId: input.businessId,
+    storeId: store.id,
+    productId: input.productId,
+    unitId: input.unitId,
+    conversionToBase,
+    qtyBase,
+    reasonCode: input.reasonCode,
+    normalizedReason,
+    schemaVersion: INVENTORY_DECREASE_SCHEMA_VERSION,
+  });
+
+  // 1. Preliminary idempotency lookup (outside the authoritative write tx).
+  const existing = await findByIdempotencyKey(store.id, idempotencyKey);
+  if (existing) {
+    if (existing.payloadHash === payloadHash) {
+      return toResult(existing, true);
+    }
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.DUPLICATE_MISMATCH,
+      'Duplicate request with a different payload',
+    );
+  }
+
+  const doWork = async (tx: Prisma.TransactionClient) => {
+    const balance = await lockInventoryBalance(tx, store.id, input.productId);
+    if (!balance) {
+      throw new InventoryDecreaseError(
+        INVENTORY_DECREASE_ERROR.INSUFFICIENT_QUANTITY,
+        'No inventory balance exists for this product',
+      );
+    }
+    if (balance.qtyOnHandBase < qtyBase) {
+      throw new InventoryDecreaseError(
+        INVENTORY_DECREASE_ERROR.INSUFFICIENT_QUANTITY,
+        'Insufficient quantity on hand',
+      );
+    }
+
+    const unitCostBasePence = balance.avgCostBasePence;
+    if (!Number.isInteger(unitCostBasePence) || unitCostBasePence <= 0) {
+      throw new InventoryDecreaseError(
+        INVENTORY_DECREASE_ERROR.MISSING_VALUATION,
+        'Authoritative average cost is missing or zero',
+      );
+    }
+
+    const valuePence = checkedMul(unitCostBasePence, qtyBase);
+    const beforeQty = balance.qtyOnHandBase;
+    const afterQty = beforeQty - qtyBase;
+
+    const created = await tx.stockAdjustment.create({
+      data: {
+        storeId: store.id,
+        productId: input.productId,
+        unitId: input.unitId,
+        qtyInUnit: input.qtyInUnit,
+        qtyBase: -qtyBase,
+        direction: 'DECREASE',
+        reason: normalizedReason,
+        reasonCode: input.reasonCode,
+        idempotencyKey,
+        payloadHash,
+        unitCostBasePence,
+        valuePence,
+        schemaVersion: INVENTORY_DECREASE_SCHEMA_VERSION,
+        userId: input.userId,
+      },
+      select: ADJUSTMENT_SELECT,
+    });
+
+    await decrementInventoryBalance(tx, store.id, input.productId, qtyBase);
+
+    await tx.stockMovement.create({
+      data: {
+        storeId: store.id,
+        productId: input.productId,
+        qtyBase: -qtyBase,
+        beforeQtyBase: beforeQty,
+        afterQtyBase: afterQty,
+        unitCostBasePence,
+        type: 'ADJUSTMENT',
+        referenceType: 'STOCK_ADJUSTMENT',
+        referenceId: created.id,
+        userId: input.userId,
+      },
+    });
+
+    try {
+      await assertAccount5100SafeForInventoryLoss(tx, input.businessId);
+      await postJournalEntry({
+        businessId: input.businessId,
+        description: `Inventory decrease ${created.id}`,
+        referenceType: 'STOCK_ADJUSTMENT',
+        referenceId: created.id,
+        lines: [
+          { accountCode: ACCOUNT_CODES.inventoryLoss, debitPence: valuePence },
+          { accountCode: ACCOUNT_CODES.inventory, creditPence: valuePence },
+        ],
+        prismaClient: tx as any,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Journal posting failed';
+      if (
+        message.includes('Account not found') ||
+        message.includes('Account 5100') ||
+        message.includes('Inventory Loss')
+      ) {
+        throw new InventoryDecreaseError(
+          INVENTORY_DECREASE_ERROR.ACCOUNT_MAPPING_UNAVAILABLE,
+          message,
+        );
+      }
+      throw new InventoryDecreaseError(
+        INVENTORY_DECREASE_ERROR.POSTING_FAILURE,
+        message,
+      );
+    }
+
+    try {
+      await tx.auditLog.create({
+        data: {
+          businessId: input.businessId,
+          userId: input.userId,
+          userName: input.userName || 'Unknown',
+          userRole: input.userRole,
+          action: 'INVENTORY_ADJUST',
+          entity: 'StockAdjustment',
+          entityId: created.id,
+          details: JSON.stringify({
+            phase: 'inventory-decrease-phase1',
+            direction: 'DECREASE',
+            reasonCode: input.reasonCode,
+            reason: normalizedReason,
+            qtyInUnit: input.qtyInUnit,
+            qtyBase,
+            beforeQtyBase: beforeQty,
+            afterQtyBase: afterQty,
+            unitCostBasePence,
+            valuePence,
+            idempotencyKey,
+            payloadHash,
+            schemaVersion: INVENTORY_DECREASE_SCHEMA_VERSION,
+            journal: {
+              debit: ACCOUNT_CODES.inventoryLoss,
+              credit: ACCOUNT_CODES.inventory,
+            },
+          }),
+        },
+      });
+    } catch (error) {
+      throw new InventoryDecreaseError(
+        INVENTORY_DECREASE_ERROR.AUDIT_FAILURE,
+        error instanceof Error ? error.message : 'Audit write failed',
+      );
+    }
+
+    return toResult(created, false);
+  };
+
+  let result: InventoryDecreaseResult;
+  try {
+    if (outerTx) {
+      result = await doWork(outerTx);
+    } else {
+      result = await prisma.$transaction(doWork);
+    }
+  } catch (error) {
+    // Unique race: never continue inside an aborted Postgres transaction.
+    // Re-read the winner outside, then replay or mismatch.
+    if (
+      !outerTx &&
+      isPrismaUniqueConstraintOn(error, ['storeId', 'idempotencyKey'])
+    ) {
+      const winner = await findByIdempotencyKey(store.id, idempotencyKey);
+      if (winner && winner.payloadHash === payloadHash) {
+        return toResult(winner, true);
+      }
+      throw new InventoryDecreaseError(
+        INVENTORY_DECREASE_ERROR.DUPLICATE_MISMATCH,
+        'Duplicate request with a different payload',
+      );
+    }
+    throw error;
+  }
+
+  if (!result.replayed && !outerTx) {
+    const business = await prisma.business.findUnique({
+      where: { id: input.businessId },
+      select: { inventoryAdjustmentRiskThresholdBase: true },
+    });
+    detectInventoryAdjustmentRisk({
+      businessId: input.businessId,
+      storeId: store.id,
+      cashierUserId: input.userId,
+      adjustmentId: result.id,
+      qtyBase: -qtyBase,
+      thresholdQtyBase: business?.inventoryAdjustmentRiskThresholdBase ?? 50,
+    }).catch(() => {});
+  }
+
+  return result;
+}

--- a/lib/services/inventory-decrease.ts
+++ b/lib/services/inventory-decrease.ts
@@ -303,6 +303,14 @@ async function createInventoryDecreaseImpl(
     );
   }
 
+  const userRole = typeof input.userRole === 'string' ? input.userRole.trim() : '';
+  if (!userRole) {
+    throw new InventoryDecreaseError(
+      INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT,
+      'Actor role is required for authoritative audit',
+    );
+  }
+
   const client = outerTx ?? prisma;
 
   const [store, productUnit] = await Promise.all([
@@ -467,7 +475,7 @@ async function createInventoryDecreaseImpl(
           businessId: input.businessId,
           userId: input.userId,
           userName: input.userName || 'Unknown',
-          userRole: input.userRole,
+          userRole,
           action: 'INVENTORY_ADJUST',
           entity: 'StockAdjustment',
           entityId: created.id,

--- a/lib/services/inventory.ts
+++ b/lib/services/inventory.ts
@@ -1,157 +1,25 @@
 import { Prisma } from '@prisma/client';
-import { prisma } from '@/lib/prisma';
-import { ACCOUNT_CODES, postJournalEntry } from '@/lib/accounting';
-import { resolveAvgCost, upsertInventoryBalance } from './shared';
-import { detectInventoryAdjustmentRisk } from './risk-monitor';
-import { measureServerOperation, PERFORMANCE_THRESHOLDS_MS } from '@/lib/observability';
+import { InventoryDecreaseError, INVENTORY_DECREASE_ERROR } from './inventory-decrease';
 
-export async function createStockAdjustment(input: {
-  businessId: string;
-  storeId: string;
-  productId: string;
-  unitId: string;
-  qtyInUnit: number;
-  direction: 'INCREASE' | 'DECREASE';
-  reason?: string | null;
-  userId: string;
-}, tx?: Prisma.TransactionClient) {
-  return measureServerOperation(
-    'action.stock-adjustment.create',
-    () => createStockAdjustmentImpl(input, tx),
-    {
-      businessId: input.businessId,
-      storeId: input.storeId,
-      action: 'createStockAdjustmentAction',
-      cacheState: tx ? 'nested-transaction' : 'write-through',
-    },
-    { thresholdMs: PERFORMANCE_THRESHOLDS_MS.action, operationType: 'action' },
+/**
+ * Legacy unhardened stock adjustment — permanently disabled.
+ * Callers must use `createInventoryDecrease` (Phase 1 decrease-only path).
+ */
+export async function createStockAdjustment(
+  _input: {
+    businessId: string;
+    storeId: string;
+    productId: string;
+    unitId: string;
+    qtyInUnit: number;
+    direction: 'INCREASE' | 'DECREASE';
+    reason?: string | null;
+    userId: string;
+  },
+  _tx?: Prisma.TransactionClient,
+): Promise<never> {
+  throw new InventoryDecreaseError(
+    INVENTORY_DECREASE_ERROR.INVALID_ADJUSTMENT,
+    'Legacy stock adjustments are disabled. Use Phase 1 inventory decrease.',
   );
-}
-
-async function createStockAdjustmentImpl(input: {
-  businessId: string;
-  storeId: string;
-  productId: string;
-  unitId: string;
-  qtyInUnit: number;
-  direction: 'INCREASE' | 'DECREASE';
-  reason?: string | null;
-  userId: string;
-}, tx?: Prisma.TransactionClient) {
-  if (input.qtyInUnit <= 0) throw new Error('Quantity must be at least 1');
-
-  // When an outer transaction client is provided, use it for reads; otherwise use the global client.
-  const client = tx ?? prisma;
-
-  // ── Parallel batch: all independent lookups at once ───────────
-  const [business, store, productUnit] = await Promise.all([
-    client.business.findUnique({
-      where: { id: input.businessId },
-      select: { inventoryAdjustmentRiskThresholdBase: true },
-    }),
-    client.store.findFirst({
-      where: { id: input.storeId, businessId: input.businessId },
-      select: { id: true },
-    }),
-    client.productUnit.findFirst({
-      where: {
-        productId: input.productId,
-        unitId: input.unitId,
-        product: { businessId: input.businessId },
-      },
-      include: { product: true }
-    }),
-  ]);
-  if (!store) throw new Error('Store not found');
-  if (!productUnit) throw new Error('Unit not configured for product');
-
-  const qtyBase = input.qtyInUnit * productUnit.conversionToBase;
-  const signedQtyBase = input.direction === 'DECREASE' ? -qtyBase : qtyBase;
-
-  // Core DB writes extracted so they can run inside an existing outer transaction or a new one.
-  const doWork = async (txClient: Prisma.TransactionClient) => {
-    // Re-read inventory balance INSIDE the transaction to prevent TOCTOU race.
-    // In PostgreSQL, this read + the subsequent upsert form an atomic unit within the transaction.
-    const inventoryInTx = await txClient.inventoryBalance.findUnique({
-      where: { storeId_productId: { storeId: store.id, productId: input.productId } },
-      select: { qtyOnHandBase: true, avgCostBasePence: true },
-    });
-    const onHand = inventoryInTx?.qtyOnHandBase ?? 0;
-    const invMap = new Map(
-      inventoryInTx
-        ? [[input.productId, { qtyOnHandBase: onHand, avgCostBasePence: inventoryInTx.avgCostBasePence }]]
-        : []
-    );
-    const currentAvgCost = resolveAvgCost(invMap, input.productId, productUnit.product.defaultCostBasePence);
-    const nextOnHand = onHand + signedQtyBase;
-    if (nextOnHand < 0) throw new Error('Adjustment would result in negative stock');
-
-    const created = await txClient.stockAdjustment.create({
-      data: {
-        storeId: store.id,
-        productId: input.productId,
-        unitId: input.unitId,
-        qtyInUnit: input.qtyInUnit,
-        qtyBase: signedQtyBase,
-        direction: input.direction,
-        reason: input.reason ?? null,
-        userId: input.userId
-      }
-    });
-
-    await upsertInventoryBalance(txClient, store.id, input.productId, nextOnHand, currentAvgCost);
-
-    await txClient.stockMovement.create({
-      data: {
-        storeId: store.id,
-        productId: input.productId,
-        qtyBase: signedQtyBase,
-        unitCostBasePence: currentAvgCost,
-        type: 'ADJUSTMENT',
-        referenceType: 'STOCK_ADJUSTMENT',
-        referenceId: created.id,
-        userId: input.userId
-      }
-    });
-
-    // Journal entry runs inside the same transaction — GL and inventory are always in sync
-    const adjustmentValue = currentAvgCost * qtyBase;
-    const journalLines =
-      input.direction === 'DECREASE'
-        ? [
-            { accountCode: ACCOUNT_CODES.cogs, debitPence: adjustmentValue },
-            { accountCode: ACCOUNT_CODES.inventory, creditPence: adjustmentValue }
-          ]
-        : [
-            { accountCode: ACCOUNT_CODES.inventory, debitPence: adjustmentValue },
-            { accountCode: ACCOUNT_CODES.cogs, creditPence: adjustmentValue }
-          ];
-
-    await postJournalEntry({
-      businessId: input.businessId,
-      description: `Stock adjustment ${created.id}`,
-      referenceType: 'STOCK_ADJUSTMENT',
-      referenceId: created.id,
-      lines: journalLines,
-      prismaClient: txClient as any
-    });
-
-    return { adjustment: created, currentAvgCost };
-  };
-
-  const { adjustment } = tx
-    ? await doWork(tx)
-    : await prisma.$transaction(doWork);
-
-  // Risk detection is non-critical — safe to be fire-and-forget
-  detectInventoryAdjustmentRisk({
-    businessId: input.businessId,
-    storeId: input.storeId,
-    cashierUserId: input.userId,
-    adjustmentId: adjustment.id,
-    qtyBase: signedQtyBase,
-    thresholdQtyBase: business?.inventoryAdjustmentRiskThresholdBase ?? 50,
-  }).catch(() => {});
-
-  return adjustment;
 }

--- a/lib/services/performance-observability.test.ts
+++ b/lib/services/performance-observability.test.ts
@@ -194,7 +194,7 @@ describe('Phase C3: performance observability baseline', () => {
       read('lib/services/payments.ts'),
       read('lib/services/purchases.ts'),
       read('lib/services/expenses.ts'),
-      read('lib/services/inventory.ts'),
+      read('lib/services/inventory-decrease.ts'),
       read('lib/services/shifts.ts'),
       read('lib/services/returns.ts'),
       read('lib/services/mobile-money.ts'),

--- a/lib/services/performance-phase-b.test.ts
+++ b/lib/services/performance-phase-b.test.ts
@@ -100,7 +100,8 @@ describe('Phase B: cache revalidation and dashboard performance hardening', () =
   });
 
   it('stock, shift, return, product, and mobile money writes revalidate owner dashboard', () => {
-    expect(inventoryActionsSrc.match(/revalidateOwnerDashboardCache\(\);/g)).toHaveLength(2);
+    // Phase 1: create path revalidates; reverse path is blocked and does not write/revalidate.
+    expect(inventoryActionsSrc.match(/revalidateOwnerDashboardCache\(\);/g)).toHaveLength(1);
     expect(shiftActionsSrc.match(/revalidateOwnerDashboardCache\(\);/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
     expect(returnActionsSrc.match(/revalidateOwnerDashboardCache\(\);/g)).toHaveLength(2);
     expect(productActionsSrc.match(/revalidateOwnerDashboardCache\(\);/g)?.length ?? 0).toBeGreaterThanOrEqual(5);

--- a/prisma/migrations/20260802120000_inventory_decrease_phase1/migration.sql
+++ b/prisma/migrations/20260802120000_inventory_decrease_phase1/migration.sql
@@ -1,0 +1,25 @@
+-- Lean inventory-decrease Phase 1: adjustment payload fields, idempotency,
+-- and stocktake surplus review status. Additive / nullable for existing rows.
+
+ALTER TABLE "StockAdjustment" ADD COLUMN "reasonCode" TEXT;
+ALTER TABLE "StockAdjustment" ADD COLUMN "idempotencyKey" TEXT;
+ALTER TABLE "StockAdjustment" ADD COLUMN "payloadHash" TEXT;
+ALTER TABLE "StockAdjustment" ADD COLUMN "unitCostBasePence" INTEGER;
+ALTER TABLE "StockAdjustment" ADD COLUMN "valuePence" INTEGER;
+ALTER TABLE "StockAdjustment" ADD COLUMN "schemaVersion" INTEGER;
+
+CREATE UNIQUE INDEX "StockAdjustment_storeId_idempotencyKey_key" ON "StockAdjustment"("storeId", "idempotencyKey");
+
+ALTER TABLE "StocktakeLine" ADD COLUMN "reviewStatus" TEXT;
+
+-- Remap unused legacy seed-once accounts only:
+--   5100 / "Operating Expenses"  →  "Inventory Loss & Shrinkage"
+-- Skip any 5100 row that already has journal lines or a customised name.
+-- Canonical day-to-day operating expenses remain on 6000.
+UPDATE "Account"
+SET "name" = 'Inventory Loss & Shrinkage'
+WHERE "code" = '5100'
+  AND "name" = 'Operating Expenses'
+  AND NOT EXISTS (
+    SELECT 1 FROM "JournalLine" AS jl WHERE jl."accountId" = "Account"."id"
+  );

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -946,24 +946,34 @@ model StockMovement {
 }
 
 model StockAdjustment {
-  id        String   @id @default(cuid())
-  storeId   String
-  productId String
-  unitId    String
-  qtyInUnit Int
-  qtyBase   Int
-  direction String
-  reason    String?
-  userId    String
-  qaTag     String?
-  qaRunId   String?
-  createdAt DateTime @default(now())
+  id                 String   @id @default(cuid())
+  storeId            String
+  productId          String
+  unitId             String
+  qtyInUnit          Int
+  qtyBase            Int
+  direction          String
+  reason             String?
+  /// Phase 1 decrease taxonomy (WASTAGE, EXPIRED, …). Null on pre-Phase-1 rows.
+  reasonCode         String?
+  /// Client/server idempotency key; unique per store when set.
+  idempotencyKey     String?
+  /// SHA-256 of the immutable decrease payload (schemaVersion-aware).
+  payloadHash        String?
+  unitCostBasePence  Int?
+  valuePence         Int?
+  schemaVersion      Int?
+  userId             String
+  qaTag              String?
+  qaRunId            String?
+  createdAt          DateTime @default(now())
 
   store   Store   @relation(fields: [storeId], references: [id])
   product Product @relation(fields: [productId], references: [id])
   unit    Unit    @relation(fields: [unitId], references: [id])
   user    User    @relation(fields: [userId], references: [id])
 
+  @@unique([storeId, idempotencyKey])
   @@index([storeId, createdAt])
   @@index([productId, createdAt])
 }
@@ -1320,6 +1330,8 @@ model StocktakeLine {
   countedBase  Int
   varianceBase Int
   adjusted     Boolean @default(false)
+  /// e.g. SURPLUS_PENDING_REVIEW — surplus counted but not posted to inventory/GL.
+  reviewStatus String?
 
   stocktake Stocktake @relation(fields: [stocktakeId], references: [id], onDelete: Cascade)
   product   Product   @relation(fields: [productId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -977,24 +977,34 @@ model StockMovement {
 }
 
 model StockAdjustment {
-  id        String   @id @default(cuid())
-  storeId   String
-  productId String
-  unitId    String
-  qtyInUnit Int
-  qtyBase   Int
-  direction String
-  reason    String?
-  userId    String
-  qaTag     String?
-  qaRunId   String?
-  createdAt DateTime @default(now())
+  id                 String   @id @default(cuid())
+  storeId            String
+  productId          String
+  unitId             String
+  qtyInUnit          Int
+  qtyBase            Int
+  direction          String
+  reason             String?
+  /// Phase 1 decrease taxonomy (WASTAGE, EXPIRED, …). Null on pre-Phase-1 rows.
+  reasonCode         String?
+  /// Client/server idempotency key; unique per store when set.
+  idempotencyKey     String?
+  /// SHA-256 of the immutable decrease payload (schemaVersion-aware).
+  payloadHash        String?
+  unitCostBasePence  Int?
+  valuePence         Int?
+  schemaVersion      Int?
+  userId             String
+  qaTag              String?
+  qaRunId            String?
+  createdAt          DateTime @default(now())
 
   store   Store   @relation(fields: [storeId], references: [id])
   product Product @relation(fields: [productId], references: [id])
   unit    Unit    @relation(fields: [unitId], references: [id])
   user    User    @relation(fields: [userId], references: [id])
 
+  @@unique([storeId, idempotencyKey])
   @@index([storeId, createdAt])
   @@index([productId, createdAt])
 }
@@ -1351,6 +1361,8 @@ model StocktakeLine {
   countedBase  Int
   varianceBase Int
   adjusted     Boolean @default(false)
+  /// e.g. SURPLUS_PENDING_REVIEW — surplus counted but not posted to inventory/GL.
+  reviewStatus String?
 
   stocktake Stocktake @relation(fields: [stocktakeId], references: [id], onDelete: Cascade)
   product   Product   @relation(fields: [productId], references: [id])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -483,6 +483,7 @@ async function main() {
     { code: '3200', name: 'Opening Balance Equity', type: 'EQUITY' },
     { code: '4000', name: 'Sales Revenue', type: 'INCOME' },
     { code: '5000', name: 'Cost of Goods Sold', type: 'EXPENSE' },
+    { code: '5100', name: 'Inventory Loss & Shrinkage', type: 'EXPENSE' },
     { code: '6000', name: 'Operating Expenses', type: 'EXPENSE' },
     { code: '6100', name: 'Rent', type: 'EXPENSE' },
     { code: '6200', name: 'Utilities', type: 'EXPENSE' },

--- a/scripts/phase3a-qa.ts
+++ b/scripts/phase3a-qa.ts
@@ -139,7 +139,7 @@ async function run() {
     const [owner, cashier, customer, mainStore] = await Promise.all([
       prisma.user.findFirst({
         where: { businessId: business.id, role: 'OWNER', active: true },
-        select: { id: true },
+        select: { id: true, name: true, role: true },
       }),
       prisma.user.findFirst({
         where: { businessId: business.id, role: 'CASHIER', active: true },

--- a/scripts/phase3a-qa.ts
+++ b/scripts/phase3a-qa.ts
@@ -6,7 +6,7 @@ import {
 } from '../lib/services/mobile-money';
 import { createSale } from '../lib/services/sales';
 import { createSalesReturn } from '../lib/services/returns';
-import { createStockAdjustment } from '../lib/services/inventory';
+import { createInventoryDecrease } from '../lib/services/inventory-decrease';
 import { ensureOrganizationAndBranches } from '../lib/services/branches';
 import { approveAndCompleteStockTransfer, requestStockTransfer } from '../lib/services/stock-transfers';
 import { resolveEffectiveSellingPricePence } from '../lib/services/shared';
@@ -474,15 +474,50 @@ async function run() {
       payments: [{ method: 'CASH', amountPence: saleLine.approxUnitPrice * 2 }],
     });
 
-    await createStockAdjustment({
+    process.env.TILLFLOW_INVENTORY_ADJUST_PHASE1 = '1';
+    const riskThreshold =
+      (
+        await prisma.business.findUnique({
+          where: { id: business.id },
+          select: { inventoryAdjustmentRiskThresholdBase: true },
+        })
+      )?.inventoryAdjustmentRiskThresholdBase ?? 50;
+    const riskQty = Math.max(riskThreshold + 1, 2);
+    const riskBalance = await prisma.inventoryBalance.findUnique({
+      where: {
+        storeId_productId: { storeId: mainStore.id, productId: saleLine.productId },
+      },
+      select: { qtyOnHandBase: true, avgCostBasePence: true },
+    });
+    if (!riskBalance || riskBalance.qtyOnHandBase < riskQty || riskBalance.avgCostBasePence <= 0) {
+      await prisma.inventoryBalance.upsert({
+        where: {
+          storeId_productId: { storeId: mainStore.id, productId: saleLine.productId },
+        },
+        update: {
+          qtyOnHandBase: Math.max(riskBalance?.qtyOnHandBase ?? 0, riskQty + 5),
+          avgCostBasePence: Math.max(riskBalance?.avgCostBasePence ?? 0, 100),
+        },
+        create: {
+          storeId: mainStore.id,
+          productId: saleLine.productId,
+          qtyOnHandBase: riskQty + 5,
+          avgCostBasePence: 100,
+        },
+      });
+    }
+    await createInventoryDecrease({
       businessId: business.id,
       storeId: mainStore.id,
       productId: saleLine.productId,
       unitId: saleLine.unitId,
-      qtyInUnit: 2,
-      direction: 'INCREASE',
+      qtyInUnit: riskQty,
+      reasonCode: 'WASTAGE',
       reason: 'QA risk threshold trigger',
+      idempotencyKey: `qa-risk-adjust-${Date.now()}`,
       userId: owner.id,
+      userName: owner.name ?? 'Owner',
+      userRole: owner.role,
     });
 
     // Service-layer risk detection is intentionally fire-and-forget; wait for


### PR DESCRIPTION
## Summary
- Harden inventory adjustments to decrease-only Phase 1 posting at locked WAC with Dr 5100 / Cr 1200.
- Add race-safe idempotency, transactional audit, Preview rollout flag, and safe unused-5100 rename migration.
- Disable legacy mutate and automated reversal; stocktake surplus stays SURPLUS_PENDING_REVIEW.

## Test plan
- [x] Unit/service tests for decrease, 5100 remediation, actions contracts
- [x] tsc --noEmit
- [x] eslint on touched paths
- [ ] Preview/Staging migration + controlled validation (post-merge)

Made with [Cursor](https://cursor.com)