### PR TITLE
Add internal QA billing access allowlist for TillFlow QA Demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,11 @@ ALLOW_SEED="false"
 # Bearer token required by /api/metrics.
 METRICS_TOKEN="replace-with-a-long-random-metrics-token"
 
+# Exact TillFlow-owned internal QA business IDs (comma-separated). Server-side only.
+# Lifts operational billing write restriction for allowlisted IDs without changing billing history.
+# Never use email domains or tenant names here.
+# TILLFLOW_INTERNAL_QA_BUSINESS_IDS="cmr2h7pna55f22d2288316407"
+
 # -----------------------------------------------------------------------------
 # Redis / rate limiting
 # -----------------------------------------------------------------------------

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -121,8 +121,10 @@ export default async function ProtectedLayout({ children }: { children: React.Re
   const billingNextActionHref = String((business as any).billingNextActionHref ?? '/settings/billing');
   const billingControlMessage = String((business as any).billingControlMessage ?? 'Billing access is being evaluated.');
   const billingMerchantMessage = String((business as any).billingMerchantMessage ?? getMerchantSubscriptionMessage(business as any));
+  const billingInternalQaAccess = Boolean((business as any).billingInternalQaAccess);
   const shouldRestrictPage =
     RESTRICTED_BILLING_STATES.has(billingAccessState) &&
+    !billingInternalQaAccess &&
     !isAllowedWhenBillingRestricted(pathname);
 
   return (

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -317,6 +317,7 @@ const _getBusiness = cache(async (businessId: string) => {
     billingAccessState: entitlement.accessState,
     billingCanWrite: entitlement.canWrite,
     billingReadOnly: entitlement.isReadOnly,
+    billingInternalQaAccess: entitlement.internalQaAccess,
     billingDisplayStatus: entitlement.displayStatus,
     billingDaysRemaining: entitlement.daysRemaining,
     billingIsTrial: entitlement.isTrial,

--- a/lib/billing-entitlements.internal-qa.test.ts
+++ b/lib/billing-entitlements.internal-qa.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { getBillingEntitlement } from '@/lib/billing-entitlements';
+
+const QA_ID = 'cmr2h7pna55f22d2288316407';
+const CUSTOMER_ID = 'cmcustomer000000000000001';
+
+function overduePaidInput(id: string) {
+  return {
+    id,
+    selectedPlan: 'GROWTH' as const,
+    subscriptionStatus: 'PAID_ACTIVE',
+    firstPaymentAt: new Date('2026-07-01T19:54:03.773Z'),
+    lastPaymentAt: new Date('2026-07-01T19:54:03.773Z'),
+    nextBillingDate: new Date('2026-08-01T19:54:03.773Z'),
+    paymentGraceEndsAt: null,
+  };
+}
+
+describe('internal QA billing access entitlement', () => {
+  const previous = process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+    else process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS = previous;
+  });
+
+  it('lifts write restriction only for exact allowlisted business IDs', () => {
+    process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS = QA_ID;
+    const now = new Date('2026-08-03T12:00:00.000Z');
+
+    const qa = getBillingEntitlement(overduePaidInput(QA_ID), now);
+    expect(qa.accessState).toBe('PAYMENT_RESTRICTED');
+    expect(qa.internalQaAccess).toBe(true);
+    expect(qa.canWrite).toBe(true);
+    expect(qa.isReadOnly).toBe(false);
+    expect(qa.nextPaymentDueAt?.toISOString()).toBe('2026-08-01T19:54:03.773Z');
+
+    const customer = getBillingEntitlement(overduePaidInput(CUSTOMER_ID), now);
+    expect(customer.accessState).toBe('PAYMENT_RESTRICTED');
+    expect(customer.internalQaAccess).toBe(false);
+    expect(customer.canWrite).toBe(false);
+    expect(customer.isReadOnly).toBe(true);
+  });
+
+  it('does not unlock overdue customers when allowlist is empty', () => {
+    delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+    const now = new Date('2026-08-03T12:00:00.000Z');
+    const qa = getBillingEntitlement(overduePaidInput(QA_ID), now);
+    expect(qa.internalQaAccess).toBe(false);
+    expect(qa.canWrite).toBe(false);
+  });
+
+  it('does not unlock from isDemo-like naming alone (ID must match)', () => {
+    process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS = QA_ID;
+    const now = new Date('2026-08-03T12:00:00.000Z');
+    const otherDemo = getBillingEntitlement(overduePaidInput('cmmm6apt40000t9bepahhkehw'), now);
+    expect(otherDemo.internalQaAccess).toBe(false);
+    expect(otherDemo.canWrite).toBe(false);
+  });
+});

--- a/lib/billing-entitlements.ts
+++ b/lib/billing-entitlements.ts
@@ -1,4 +1,5 @@
 import { getBusinessPlan, type BusinessMode, type BusinessPlan, type StoreMode } from './features';
+import { isInternalQaBusinessId } from './internal-qa-access';
 import {
   computeBillingAccessState,
   getSubscriptionSnapshot,
@@ -7,6 +8,7 @@ import {
 } from './subscription-lifecycle';
 
 type BillingBusinessInput = SubscriptionInput & {
+  id?: string | null;
   plan?: BusinessPlan | null;
   mode?: BusinessMode | null;
   storeMode?: StoreMode | null;
@@ -20,6 +22,8 @@ export type BillingEntitlement = {
   accessState: BillingAccessState;
   canWrite: boolean;
   isReadOnly: boolean;
+  /** True when an exact allowlisted internal-QA business ID bypasses write restriction. */
+  internalQaAccess: boolean;
   statusLabel: string;
   displayStatus: string;
   daysRemaining: number | null;
@@ -53,7 +57,10 @@ export function getBillingEntitlement(input: BillingBusinessInput, now = new Dat
   const computation = computeBillingAccessState({ ...input, selectedPlan: purchasedPlan }, now);
   const snapshot = getSubscriptionSnapshot({ ...input, selectedPlan: purchasedPlan }, now);
   const accessState = computation.accessState;
-  const isReadOnly = computation.isRestricted;
+  const internalQaAccess = isInternalQaBusinessId(input.id);
+  // Preserve truthful billing accessState / dates for reporting. Only lift the
+  // operational write gate for exact allowlisted internal-QA business IDs.
+  const isReadOnly = internalQaAccess ? false : computation.isRestricted;
 
   return {
     purchasedPlan,
@@ -62,6 +69,7 @@ export function getBillingEntitlement(input: BillingBusinessInput, now = new Dat
     accessState,
     canWrite: !isReadOnly,
     isReadOnly,
+    internalQaAccess,
     statusLabel: labelFor(accessState),
     displayStatus: computation.displayStatus,
     daysRemaining: computation.daysRemaining,

--- a/lib/internal-qa-access.test.ts
+++ b/lib/internal-qa-access.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isInternalQaBusinessId,
+  parseInternalQaBusinessIds,
+} from '@/lib/internal-qa-access';
+
+describe('internal QA business allowlist', () => {
+  const qaId = 'cmr2h7pna55f22d2288316407';
+
+  it('parses comma-separated exact IDs', () => {
+    expect([...parseInternalQaBusinessIds(`${qaId}, other-id`)]).toEqual([qaId, 'other-id']);
+  });
+
+  it('defaults to empty when unset', () => {
+    expect(parseInternalQaBusinessIds(undefined).size).toBe(0);
+    expect(parseInternalQaBusinessIds('')).toEqual(new Set());
+    expect(parseInternalQaBusinessIds('   ')).toEqual(new Set());
+  });
+
+  it('matches only exact business IDs', () => {
+    expect(isInternalQaBusinessId(qaId, qaId)).toBe(true);
+    expect(isInternalQaBusinessId('cmr2h7pn', qaId)).toBe(false);
+    expect(isInternalQaBusinessId(`${qaId}x`, qaId)).toBe(false);
+  });
+
+  it('does not grant access from name or email-like strings', () => {
+    expect(isInternalQaBusinessId('TillFlow QA Demo', qaId)).toBe(false);
+    expect(isInternalQaBusinessId('qa-owner@tillflow.app', qaId)).toBe(false);
+  });
+
+  it('rejects null/empty business ids', () => {
+    expect(isInternalQaBusinessId(null, qaId)).toBe(false);
+    expect(isInternalQaBusinessId('', qaId)).toBe(false);
+  });
+});

--- a/lib/internal-qa-access.ts
+++ b/lib/internal-qa-access.ts
@@ -1,0 +1,30 @@
+/**
+ * Explicit internal-QA business allowlist for TillFlow-owned smoke tenants.
+ *
+ * Security boundary: exact business IDs from env only.
+ * - Not inferred from tenant name
+ * - Not inferred from email domain
+ * - Not inferred from isDemo alone
+ * - Not activatable by ordinary tenant users
+ *
+ * Env: TILLFLOW_INTERNAL_QA_BUSINESS_IDS=id1,id2
+ */
+export function parseInternalQaBusinessIds(
+  raw: string | undefined | null = process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS,
+): Set<string> {
+  if (!raw || typeof raw !== 'string') return new Set();
+  return new Set(
+    raw
+      .split(/[,\s]+/)
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
+  );
+}
+
+export function isInternalQaBusinessId(
+  businessId: string | null | undefined,
+  rawEnv: string | undefined | null = process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS,
+): boolean {
+  if (!businessId || typeof businessId !== 'string') return false;
+  return parseInternalQaBusinessIds(rawEnv).has(businessId);
+}


### PR DESCRIPTION
## Summary
- Adds `TILLFLOW_INTERNAL_QA_BUSINESS_IDS` exact-ID allowlist so TillFlow-owned QA tenants can use the app when payment-restricted.
- Does not fabricate billing/payment history, does not unlock by name/email/`isDemo`, and does not enable Inventory Decrease Phase 1.

## Test plan
- [x] Unit tests for allowlist + entitlement isolation
- [x] typecheck / lint / next build
- [ ] Production: set env to TillFlow QA Demo ID only; verify Owner/Manager/Cashier access; verify overdue customers remain restricted; flag remains off