### PR TITLE
Fix internal QA allowlist env runtime read

### DIFF
--- a/lib/internal-qa-access.ts
+++ b/lib/internal-qa-access.ts
@@ -8,13 +8,24 @@
  * - Not activatable by ordinary tenant users
  *
  * Env: TILLFLOW_INTERNAL_QA_BUSINESS_IDS=id1,id2
+ *
+ * Read via dynamic env access so Next.js does not inline a build-time empty value.
  */
+function readInternalQaBusinessIdsEnv(
+  raw?: string | null,
+): string | undefined | null {
+  if (raw !== undefined) return raw;
+  // Dynamic key access — avoids Next.js build-time inlining of process.env.NAME.
+  return process.env['TILLFLOW_INTERNAL_QA_BUSINESS_IDS'];
+}
+
 export function parseInternalQaBusinessIds(
-  raw: string | undefined | null = process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS,
+  raw?: string | undefined | null,
 ): Set<string> {
-  if (!raw || typeof raw !== 'string') return new Set();
+  const value = readInternalQaBusinessIdsEnv(raw);
+  if (!value || typeof value !== 'string') return new Set();
   return new Set(
-    raw
+    value
       .split(/[,\s]+/)
       .map((id) => id.trim())
       .filter((id) => id.length > 0),
@@ -23,7 +34,7 @@ export function parseInternalQaBusinessIds(
 
 export function isInternalQaBusinessId(
   businessId: string | null | undefined,
-  rawEnv: string | undefined | null = process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS,
+  rawEnv?: string | undefined | null,
 ): boolean {
   if (!businessId || typeof businessId !== 'string') return false;
   return parseInternalQaBusinessIds(rawEnv).has(businessId);


### PR DESCRIPTION
## Summary
- Read `TILLFLOW_INTERNAL_QA_BUSINESS_IDS` via dynamic env access so Next.js cannot inline an empty build-time value.

## Test plan
- [x] unit tests
- [ ] Production smoke: TillFlow QA Demo access; customer isolation; Phase 1 flag off