### PR TITLE
Embed TillFlow QA Demo in internal-QA allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,8 @@ METRICS_TOKEN="replace-with-a-long-random-metrics-token"
 # Exact TillFlow-owned internal QA business IDs (comma-separated). Server-side only.
 # Lifts operational billing write restriction for allowlisted IDs without changing billing history.
 # Never use email domains or tenant names here.
-# TILLFLOW_INTERNAL_QA_BUSINESS_IDS="cmr2h7pna55f22d2288316407"
+# Optional additive allowlist (TillFlow QA Demo ID is built into source).
+# TILLFLOW_INTERNAL_QA_BUSINESS_IDS="cmextraqa0000000000000001"
 
 # -----------------------------------------------------------------------------
 # Redis / rate limiting

--- a/lib/billing-entitlements.internal-qa.test.ts
+++ b/lib/billing-entitlements.internal-qa.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, afterEach } from 'vitest';
 import { getBillingEntitlement } from '@/lib/billing-entitlements';
+import { BUILTIN_INTERNAL_QA_BUSINESS_IDS } from '@/lib/internal-qa-access';
 
-const QA_ID = 'cmr2h7pna55f22d2288316407';
+const QA_ID = BUILTIN_INTERNAL_QA_BUSINESS_IDS[0];
 const CUSTOMER_ID = 'cmcustomer000000000000001';
 
 function overduePaidInput(id: string) {
@@ -24,8 +25,8 @@ describe('internal QA billing access entitlement', () => {
     else process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS = previous;
   });
 
-  it('lifts write restriction only for exact allowlisted business IDs', () => {
-    process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS = QA_ID;
+  it('lifts write restriction for built-in TillFlow QA Demo without env', () => {
+    delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
     const now = new Date('2026-08-03T12:00:00.000Z');
 
     const qa = getBillingEntitlement(overduePaidInput(QA_ID), now);
@@ -34,6 +35,11 @@ describe('internal QA billing access entitlement', () => {
     expect(qa.canWrite).toBe(true);
     expect(qa.isReadOnly).toBe(false);
     expect(qa.nextPaymentDueAt?.toISOString()).toBe('2026-08-01T19:54:03.773Z');
+  });
+
+  it('keeps overdue genuine customers restricted', () => {
+    delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+    const now = new Date('2026-08-03T12:00:00.000Z');
 
     const customer = getBillingEntitlement(overduePaidInput(CUSTOMER_ID), now);
     expect(customer.accessState).toBe('PAYMENT_RESTRICTED');
@@ -42,19 +48,19 @@ describe('internal QA billing access entitlement', () => {
     expect(customer.isReadOnly).toBe(true);
   });
 
-  it('does not unlock overdue customers when allowlist is empty', () => {
-    delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
-    const now = new Date('2026-08-03T12:00:00.000Z');
-    const qa = getBillingEntitlement(overduePaidInput(QA_ID), now);
-    expect(qa.internalQaAccess).toBe(false);
-    expect(qa.canWrite).toBe(false);
-  });
-
   it('does not unlock from isDemo-like naming alone (ID must match)', () => {
-    process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS = QA_ID;
+    delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
     const now = new Date('2026-08-03T12:00:00.000Z');
     const otherDemo = getBillingEntitlement(overduePaidInput('cmmm6apt40000t9bepahhkehw'), now);
     expect(otherDemo.internalQaAccess).toBe(false);
     expect(otherDemo.canWrite).toBe(false);
+  });
+
+  it('env allowlist can add additional exact business IDs', () => {
+    const extra = 'cmextraqa0000000000000001';
+    process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS = extra;
+    const now = new Date('2026-08-03T12:00:00.000Z');
+    expect(getBillingEntitlement(overduePaidInput(extra), now).internalQaAccess).toBe(true);
+    expect(getBillingEntitlement(overduePaidInput(CUSTOMER_ID), now).internalQaAccess).toBe(false);
   });
 });

--- a/lib/internal-qa-access.test.ts
+++ b/lib/internal-qa-access.test.ts
@@ -1,31 +1,35 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BUILTIN_INTERNAL_QA_BUSINESS_IDS,
   isInternalQaBusinessId,
   parseInternalQaBusinessIds,
 } from '@/lib/internal-qa-access';
 
 describe('internal QA business allowlist', () => {
-  const qaId = 'cmr2h7pna55f22d2288316407';
+  const qaId = BUILTIN_INTERNAL_QA_BUSINESS_IDS[0];
 
-  it('parses comma-separated exact IDs', () => {
-    expect([...parseInternalQaBusinessIds(`${qaId}, other-id`)]).toEqual([qaId, 'other-id']);
+  it('always includes the built-in TillFlow QA Demo ID', () => {
+    expect(parseInternalQaBusinessIds(null).has(qaId)).toBe(true);
+    expect(parseInternalQaBusinessIds('').has(qaId)).toBe(true);
+    expect(isInternalQaBusinessId(qaId, '')).toBe(true);
+    expect(isInternalQaBusinessId(qaId, null)).toBe(true);
   });
 
-  it('defaults to empty when unset', () => {
-    expect(parseInternalQaBusinessIds(undefined).size).toBe(0);
-    expect(parseInternalQaBusinessIds('')).toEqual(new Set());
-    expect(parseInternalQaBusinessIds('   ')).toEqual(new Set());
+  it('merges optional env IDs with built-ins', () => {
+    const ids = parseInternalQaBusinessIds(`${qaId}, other-id`);
+    expect(ids.has(qaId)).toBe(true);
+    expect(ids.has('other-id')).toBe(true);
   });
 
   it('matches only exact business IDs', () => {
-    expect(isInternalQaBusinessId(qaId, qaId)).toBe(true);
-    expect(isInternalQaBusinessId('cmr2h7pn', qaId)).toBe(false);
-    expect(isInternalQaBusinessId(`${qaId}x`, qaId)).toBe(false);
+    expect(isInternalQaBusinessId(qaId, '')).toBe(true);
+    expect(isInternalQaBusinessId('cmr2h7pn', '')).toBe(false);
+    expect(isInternalQaBusinessId(`${qaId}x`, '')).toBe(false);
   });
 
   it('does not grant access from name or email-like strings', () => {
-    expect(isInternalQaBusinessId('TillFlow QA Demo', qaId)).toBe(false);
-    expect(isInternalQaBusinessId('qa-owner@tillflow.app', qaId)).toBe(false);
+    expect(isInternalQaBusinessId('TillFlow QA Demo', '')).toBe(false);
+    expect(isInternalQaBusinessId('qa-owner@tillflow.app', '')).toBe(false);
   });
 
   it('rejects null/empty business ids', () => {

--- a/lib/internal-qa-access.ts
+++ b/lib/internal-qa-access.ts
@@ -1,16 +1,24 @@
 /**
  * Explicit internal-QA business allowlist for TillFlow-owned smoke tenants.
  *
- * Security boundary: exact business IDs from env only.
+ * Security boundary: exact business IDs only.
  * - Not inferred from tenant name
  * - Not inferred from email domain
  * - Not inferred from isDemo alone
  * - Not activatable by ordinary tenant users
  *
- * Env: TILLFLOW_INTERNAL_QA_BUSINESS_IDS=id1,id2
+ * Built-in IDs are source-auditable (authorised TillFlow QA tenants).
+ * Optional env TILLFLOW_INTERNAL_QA_BUSINESS_IDS can add further exact IDs.
  *
- * Read via dynamic env access so Next.js does not inline a build-time empty value.
+ * Env is read via dynamic key access so Next.js does not inline a build-time
+ * empty value over the optional allowlist extension.
  */
+
+/** TillFlow QA Demo — INTERNAL_QA_TENANT (authorised Production smoke tenant). */
+export const BUILTIN_INTERNAL_QA_BUSINESS_IDS = [
+  'cmr2h7pna55f22d2288316407',
+] as const;
+
 function readInternalQaBusinessIdsEnv(
   raw?: string | null,
 ): string | undefined | null {
@@ -22,14 +30,14 @@ function readInternalQaBusinessIdsEnv(
 export function parseInternalQaBusinessIds(
   raw?: string | undefined | null,
 ): Set<string> {
+  const ids = new Set<string>(BUILTIN_INTERNAL_QA_BUSINESS_IDS);
   const value = readInternalQaBusinessIdsEnv(raw);
-  if (!value || typeof value !== 'string') return new Set();
-  return new Set(
-    value
-      .split(/[,\s]+/)
-      .map((id) => id.trim())
-      .filter((id) => id.length > 0),
-  );
+  if (!value || typeof value !== 'string') return ids;
+  for (const id of value.split(/[,\s]+/)) {
+    const trimmed = id.trim();
+    if (trimmed.length > 0) ids.add(trimmed);
+  }
+  return ids;
 }
 
 export function isInternalQaBusinessId(


### PR DESCRIPTION
## Summary
- Bake the authorised TillFlow QA Demo business ID into the internal-QA allowlist so Production smoke access does not depend on Next.js build-time env inlining.
- Keep billing `accessState` truthful (PAYMENT_RESTRICTED) while lifting only the operational write/access gate for that exact ID.
- Retain optional env as an additive extension only; no email-domain or `isDemo` bypass.

## Test plan
- [x] `vitest` internal-QA allowlist + entitlement tests
- [x] `tsc --noEmit`
- [x] `eslint` on touched files
- [x] `npm run build`
- [ ] Production: QA Owner/Manager reach adjustments without billing block
- [ ] Production: overdue customers remain restricted
- [ ] Production: Phase 1 flag still off / FLAG_DISABLED

Made with [Cursor](https://cursor.com)