### PR TITLE
Fix commercial snapshot business id for internal-QA write gate

### DIFF
--- a/lib/action-utils.ts
+++ b/lib/action-utils.ts
@@ -77,7 +77,12 @@ type BusinessContextOptions = {
   requireWrite?: boolean;
 };
 
-async function assertBusinessWriteAllowed(businessId: string) {
+/**
+ * Server-action write gate. Uses the commercial billing snapshot (including
+ * business id) so exact-ID internal-QA entitlements apply consistently with
+ * the authenticated layout path.
+ */
+export async function assertBusinessWriteAllowed(businessId: string) {
   const { business } = await findBusinessCommercialSnapshot(businessId);
 
   if (!business) redirect('/settings');

--- a/lib/action-utils.write-gate.test.ts
+++ b/lib/action-utils.write-gate.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { COMMERCIAL_BILLING_SELECT } from '@/lib/billing-db-compat';
+import { BUILTIN_INTERNAL_QA_BUSINESS_IDS } from '@/lib/internal-qa-access';
+import { getBillingEntitlement } from '@/lib/billing-entitlements';
+import { UserError } from '@/lib/action-utils';
+
+const QA_ID = BUILTIN_INTERNAL_QA_BUSINESS_IDS[0];
+const CUSTOMER_ID = 'cmcustomer000000000000001';
+const OTHER_DEMO_ID = 'cmmm6apt40000t9bepahhkehw';
+const SIMILAR_NAME_ID = 'cmsimilarqa00000000000001';
+
+const findBusinessCommercialSnapshot = vi.fn();
+
+vi.mock('@/lib/billing-db-compat', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/billing-db-compat')>();
+  return {
+    ...actual,
+    findBusinessCommercialSnapshot: (...args: unknown[]) =>
+      findBusinessCommercialSnapshot(...args),
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`REDIRECT:${path}`);
+  }),
+}));
+
+function overdueCommercialSnapshot(id: string) {
+  return {
+    id,
+    mode: 'GROWTH',
+    storeMode: 'SINGLE_STORE',
+    plan: 'GROWTH',
+    selectedPlan: 'GROWTH',
+    subscriptionStatus: 'PAID_ACTIVE',
+    firstPaymentAt: new Date('2026-07-01T19:54:03.773Z'),
+    lastPaymentAt: new Date('2026-07-01T19:54:03.773Z'),
+    nextBillingDate: new Date('2026-08-01T19:54:03.773Z'),
+    paymentGraceEndsAt: null,
+  };
+}
+
+describe('COMMERCIAL_BILLING_SELECT identity', () => {
+  it('includes business id so write-gate entitlements can match exact QA IDs', () => {
+    expect(COMMERCIAL_BILLING_SELECT).toMatchObject({ id: true });
+  });
+});
+
+describe('commercial snapshot → internal-QA write gate', () => {
+  const now = new Date('2026-08-03T12:00:00.000Z');
+  const previous = process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+
+  beforeEach(() => {
+    delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+    findBusinessCommercialSnapshot.mockReset();
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+    else process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS = previous;
+  });
+
+  it('QA Demo commercial snapshot yields PAYMENT_RESTRICTED + canWrite via exact ID', () => {
+    const snapshot = overdueCommercialSnapshot(QA_ID);
+    expect(snapshot.id).toBe(QA_ID);
+
+    const entitlement = getBillingEntitlement(snapshot as any, now);
+    expect(entitlement.accessState).toBe('PAYMENT_RESTRICTED');
+    expect(entitlement.internalQaAccess).toBe(true);
+    expect(entitlement.canWrite).toBe(true);
+    expect(entitlement.primaryBanner).toMatch(/Access restricted until payment is confirmed/i);
+    expect(entitlement.merchantMessage).toMatch(/Access restricted until payment is confirmed/i);
+  });
+
+  it('overdue genuine customer remains canWrite=false', () => {
+    const entitlement = getBillingEntitlement(overdueCommercialSnapshot(CUSTOMER_ID) as any, now);
+    expect(entitlement.accessState).toBe('PAYMENT_RESTRICTED');
+    expect(entitlement.internalQaAccess).toBe(false);
+    expect(entitlement.canWrite).toBe(false);
+  });
+
+  it('different isDemo-like tenant ID remains restricted', () => {
+    const entitlement = getBillingEntitlement(overdueCommercialSnapshot(OTHER_DEMO_ID) as any, now);
+    expect(entitlement.internalQaAccess).toBe(false);
+    expect(entitlement.canWrite).toBe(false);
+  });
+
+  it('similarly named business ID remains restricted', () => {
+    const entitlement = getBillingEntitlement(overdueCommercialSnapshot(SIMILAR_NAME_ID) as any, now);
+    expect(entitlement.internalQaAccess).toBe(false);
+    expect(entitlement.canWrite).toBe(false);
+  });
+
+  it('omitting id from commercial snapshot reproduces the Production write-gate defect', () => {
+    const { id: _omit, ...withoutId } = overdueCommercialSnapshot(QA_ID);
+    const entitlement = getBillingEntitlement(withoutId as any, now);
+    expect(entitlement.accessState).toBe('PAYMENT_RESTRICTED');
+    expect(entitlement.internalQaAccess).toBe(false);
+    expect(entitlement.canWrite).toBe(false);
+  });
+
+  it('assertBusinessWriteAllowed allows TillFlow QA Demo when snapshot includes id', async () => {
+    findBusinessCommercialSnapshot.mockResolvedValue({
+      business: overdueCommercialSnapshot(QA_ID),
+      billingSchemaReady: true,
+    });
+
+    const { assertBusinessWriteAllowed } = await import('@/lib/action-utils');
+    await expect(assertBusinessWriteAllowed(QA_ID)).resolves.toBeUndefined();
+    expect(findBusinessCommercialSnapshot).toHaveBeenCalledWith(QA_ID);
+  });
+
+  it('assertBusinessWriteAllowed rejects overdue customer (failed write path)', async () => {
+    findBusinessCommercialSnapshot.mockResolvedValue({
+      business: overdueCommercialSnapshot(CUSTOMER_ID),
+      billingSchemaReady: true,
+    });
+
+    const { assertBusinessWriteAllowed } = await import('@/lib/action-utils');
+    await expect(assertBusinessWriteAllowed(CUSTOMER_ID)).rejects.toBeInstanceOf(UserError);
+    await expect(assertBusinessWriteAllowed(CUSTOMER_ID)).rejects.toThrow(/read-only/i);
+  });
+
+  it('assertBusinessWriteAllowed rejects when commercial snapshot omits id (regression of defect)', async () => {
+    const { id: _omit, ...withoutId } = overdueCommercialSnapshot(QA_ID);
+    findBusinessCommercialSnapshot.mockResolvedValue({
+      business: withoutId,
+      billingSchemaReady: true,
+    });
+
+    const { assertBusinessWriteAllowed } = await import('@/lib/action-utils');
+    await expect(assertBusinessWriteAllowed(QA_ID)).rejects.toBeInstanceOf(UserError);
+  });
+});

--- a/lib/billing-db-compat.ts
+++ b/lib/billing-db-compat.ts
@@ -94,7 +94,13 @@ const COMMERCIAL_LEGACY_SELECT = {
   storeMode: true,
 } as const;
 
-const COMMERCIAL_BILLING_SELECT = {
+/**
+ * Commercial billing snapshot used by write-gate and plan checks.
+ * `id` is required so getBillingEntitlement can apply the exact-ID
+ * internal-QA allowlist (and any future tenant-scoped entitlement rules).
+ */
+export const COMMERCIAL_BILLING_SELECT = {
+  id: true,
   ...COMMERCIAL_LEGACY_SELECT,
   plan: true,
   planStatus: true,

--- a/lib/billing-entitlements.internal-qa.test.ts
+++ b/lib/billing-entitlements.internal-qa.test.ts
@@ -35,6 +35,8 @@ describe('internal QA billing access entitlement', () => {
     expect(qa.canWrite).toBe(true);
     expect(qa.isReadOnly).toBe(false);
     expect(qa.nextPaymentDueAt?.toISOString()).toBe('2026-08-01T19:54:03.773Z');
+    expect(qa.primaryBanner).toBe('Access restricted until payment is confirmed.');
+    expect(qa.merchantMessage).toBe('Access restricted until payment is confirmed.');
   });
 
   it('keeps overdue genuine customers restricted', () => {

--- a/lib/internal-qa-write-gate-isolation.test.ts
+++ b/lib/internal-qa-write-gate-isolation.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { getBillingEntitlement } from '@/lib/billing-entitlements';
+import { isInternalQaBusinessId, BUILTIN_INTERNAL_QA_BUSINESS_IDS } from '@/lib/internal-qa-access';
+import {
+  createInventoryDecrease,
+  InventoryDecreaseError,
+  INVENTORY_DECREASE_ERROR,
+} from '@/lib/services/inventory-decrease';
+import { isInventoryDecreasePhase1Enabled } from '@/lib/inventory-decrease-flag';
+
+const QA_ID = BUILTIN_INTERNAL_QA_BUSINESS_IDS[0];
+
+function overduePaidInput(id: string) {
+  return {
+    id,
+    selectedPlan: 'GROWTH' as const,
+    subscriptionStatus: 'PAID_ACTIVE',
+    firstPaymentAt: new Date('2026-07-01T19:54:03.773Z'),
+    lastPaymentAt: new Date('2026-07-01T19:54:03.773Z'),
+    nextBillingDate: new Date('2026-08-01T19:54:03.773Z'),
+    paymentGraceEndsAt: null,
+  };
+}
+
+describe('internal-QA isolation and Phase 1 flag-off boundaries', () => {
+  const previousFlag = process.env.TILLFLOW_INVENTORY_ADJUST_PHASE1;
+  const previousAllow = process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+
+  afterEach(() => {
+    if (previousFlag === undefined) delete process.env.TILLFLOW_INVENTORY_ADJUST_PHASE1;
+    else process.env.TILLFLOW_INVENTORY_ADJUST_PHASE1 = previousFlag;
+    if (previousAllow === undefined) delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+    else process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS = previousAllow;
+  });
+
+  it('does not grant access from tenant name strings', () => {
+    expect(isInternalQaBusinessId('TillFlow QA Demo')).toBe(false);
+    expect(isInternalQaBusinessId('TillFlow QA Demo', QA_ID)).toBe(false);
+  });
+
+  it('does not grant access from email-like strings or @tillflow.app alone', () => {
+    expect(isInternalQaBusinessId('qa-owner@tillflow.app')).toBe(false);
+    expect(isInternalQaBusinessId('owner@tillflow.app', QA_ID)).toBe(false);
+    expect(isInternalQaBusinessId('cmtillflowapp000000000001')).toBe(false);
+  });
+
+  it('with flag off, direct decrease returns FLAG_DISABLED and creates no durable intent', async () => {
+    delete process.env.TILLFLOW_INVENTORY_ADJUST_PHASE1;
+    expect(isInventoryDecreasePhase1Enabled()).toBe(false);
+
+    await expect(
+      createInventoryDecrease({
+        businessId: QA_ID,
+        storeId: 'store-x',
+        productId: 'product-x',
+        unitId: 'unit-x',
+        qtyInUnit: 1,
+        reasonCode: 'DAMAGED',
+        reason: 'must not write',
+        idempotencyKey: 'write-gate-fix-flagoff',
+        userId: 'user-x',
+        userName: 'QA Owner',
+        userRole: 'OWNER',
+      }),
+    ).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.FLAG_DISABLED,
+    });
+
+    try {
+      await createInventoryDecrease({
+        businessId: QA_ID,
+        storeId: 'store-x',
+        productId: 'product-x',
+        unitId: 'unit-x',
+        qtyInUnit: 1,
+        reasonCode: 'DAMAGED',
+        reason: 'must not write',
+        idempotencyKey: 'write-gate-fix-flagoff-2',
+        userId: 'user-x',
+        userName: 'QA Owner',
+        userRole: 'OWNER',
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(InventoryDecreaseError);
+      expect((error as InventoryDecreaseError).code).toBe(INVENTORY_DECREASE_ERROR.FLAG_DISABLED);
+    }
+  });
+
+  it('QA entitlement remains truthful PAYMENT_RESTRICTED with banner while canWrite', () => {
+    delete process.env.TILLFLOW_INTERNAL_QA_BUSINESS_IDS;
+    const now = new Date('2026-08-03T12:00:00.000Z');
+    const qa = getBillingEntitlement(overduePaidInput(QA_ID), now);
+    expect(qa.accessState).toBe('PAYMENT_RESTRICTED');
+    expect(qa.canWrite).toBe(true);
+    expect(qa.primaryBanner).toBe('Access restricted until payment is confirmed.');
+  });
+});

--- a/lib/services/inventory-decrease-actions.test.ts
+++ b/lib/services/inventory-decrease-actions.test.ts
@@ -31,6 +31,13 @@ describe('inventory decrease Phase 1 actions', () => {
     expect(legacyService).not.toContain('postJournalEntry');
   });
 
+  it('create action restricts adjustments to Owner/Manager and excludes Cashier', () => {
+    expect(inventoryAction).toContain("withBusinessStoreContext(['MANAGER', 'OWNER'])");
+    expect(inventoryAction).not.toMatch(
+      /withBusinessStoreContext\(\s*\[[^\]]*['"]CASHIER['"]/,
+    );
+  });
+
   it('stocktake posts shortfalls via Phase 1 and marks surplus pending review', () => {
     expect(stocktakeAction).toContain('createInventoryDecrease');
     expect(stocktakeAction).toContain('STOCKTAKE_SHORTFALL');


### PR DESCRIPTION
## Summary
- Add `id: true` to `COMMERCIAL_BILLING_SELECT` so `assertBusinessWriteAllowed` / `getBillingEntitlement` can apply the exact-ID internal-QA allowlist.
- Export `assertBusinessWriteAllowed` and add regression tests covering the failed server-action write path.
- Keep Phase 1 Production flag off; no inventory posting.

## Test plan
- [x] write-gate + entitlement + isolation unit tests
- [x] inventory-decrease (+ actions) under node env
- [x] tsc / eslint
- [x] production build
- [ ] CI unit/lint/typecheck/build/pos-safety
- [ ] Production flag-off entitlement verification after deploy

Made with [Cursor](https://cursor.com)