### PR TITLE
fix(inventory): resolve only 1200/5100 inside decrease transactions

### DIFF
--- a/lib/accounting-inventory-decrease-accounts.test.ts
+++ b/lib/accounting-inventory-decrease-accounts.test.ts
@@ -1,13 +1,28 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ACCOUNT_CODES, CHART_OF_ACCOUNTS } from '@/lib/accounting';
 import { INVENTORY_LOSS_5100_NAME } from '@/lib/accounting-inventory-loss-5100';
-import {
+
+const { isPostgresRuntimeEnvMock } = vi.hoisted(() => ({
+  isPostgresRuntimeEnvMock: vi.fn(() => false),
+}));
+
+vi.mock('@/lib/database-runtime', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/database-runtime')>(
+    '@/lib/database-runtime',
+  );
+  return {
+    ...actual,
+    isPostgresRuntimeEnv: isPostgresRuntimeEnvMock,
+  };
+});
+
+const {
   INVENTORY_DECREASE_REQUIRED_ACCOUNTS,
   assertInventoryDecreaseAccountCompatible,
   ensureInventoryDecreaseAccounts,
-} from './accounting-inventory-decrease-accounts';
+} = await import('./accounting-inventory-decrease-accounts');
 
 describe('inventory-decrease account contract', () => {
   it('requires exactly 1200 Inventory ASSET and 5100 Inventory Loss EXPENSE', () => {
@@ -92,16 +107,7 @@ describe('ensureInventoryDecreaseAccounts', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.POSTGRES_PRISMA_URL;
-    delete process.env.POSTGRES_URL;
-    delete process.env.POSTGRES_URL_NON_POOLING;
-    process.env.DATABASE_URL = 'file:./dev.db';
-  });
-
-  afterEach(() => {
-    delete process.env.POSTGRES_PRISMA_URL;
-    delete process.env.POSTGRES_URL;
-    delete process.env.POSTGRES_URL_NON_POOLING;
+    isPostgresRuntimeEnvMock.mockReturnValue(false);
   });
 
   it('empty COA: upserts exactly 1200 and 5100 (sqlite path) and creates no unrelated codes', async () => {
@@ -158,9 +164,8 @@ describe('ensureInventoryDecreaseAccounts', () => {
     expect(client.account.upsert.mock.calls[0][0].create.code).toBe('1200');
   });
 
-  it('postgres path: single INSERT for missing accounts when POSTGRES_* is set without DATABASE_URL', async () => {
-    delete process.env.DATABASE_URL;
-    process.env.POSTGRES_PRISMA_URL = 'postgresql://neondb_owner:x@ep-x/neondb';
+  it('postgres path: single INSERT for missing accounts when Postgres runtime is detected', async () => {
+    isPostgresRuntimeEnvMock.mockReturnValue(true);
     client.account.findMany
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([approved1200, approved5100]);
@@ -173,9 +178,7 @@ describe('ensureInventoryDecreaseAccounts', () => {
   });
 
   it('concurrent creators: ON CONFLICT then re-read returns stable IDs without duplicate create side effects', async () => {
-    delete process.env.DATABASE_URL;
-    process.env.POSTGRES_PRISMA_URL = 'postgresql://neondb_owner:x@ep-x/neondb';
-    // First finder sees empty; insert conflicts (0 rows); re-read sees winner rows.
+    isPostgresRuntimeEnvMock.mockReturnValue(true);
     client.account.findMany
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([approved1200, approved5100]);

--- a/lib/accounting-inventory-decrease-accounts.test.ts
+++ b/lib/accounting-inventory-decrease-accounts.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ACCOUNT_CODES, CHART_OF_ACCOUNTS } from '@/lib/accounting';
+import { INVENTORY_LOSS_5100_NAME } from '@/lib/accounting-inventory-loss-5100';
+import {
+  INVENTORY_DECREASE_REQUIRED_ACCOUNTS,
+  assertInventoryDecreaseAccountCompatible,
+  ensureInventoryDecreaseAccounts,
+} from './accounting-inventory-decrease-accounts';
+
+describe('inventory-decrease account contract', () => {
+  it('requires exactly 1200 Inventory ASSET and 5100 Inventory Loss EXPENSE', () => {
+    expect(INVENTORY_DECREASE_REQUIRED_ACCOUNTS).toEqual([
+      { code: '1200', name: 'Inventory', type: 'ASSET' },
+      { code: '5100', name: INVENTORY_LOSS_5100_NAME, type: 'EXPENSE' },
+    ]);
+    expect(INVENTORY_DECREASE_REQUIRED_ACCOUNTS).toHaveLength(2);
+    expect(CHART_OF_ACCOUNTS.length).toBeGreaterThan(2);
+  });
+
+  it('inventory-decrease service uses the narrow helper, not full COA ensure', () => {
+    const source = readFileSync(join(process.cwd(), 'lib/services/inventory-decrease.ts'), 'utf8');
+    expect(source).toContain('ensureInventoryDecreaseAccounts');
+    expect(source).toContain('accountMap');
+    expect(source).not.toContain('ensureChartOfAccounts');
+  });
+});
+
+describe('assertInventoryDecreaseAccountCompatible', () => {
+  it('accepts approved mappings', () => {
+    expect(() =>
+      assertInventoryDecreaseAccountCompatible({
+        id: '1',
+        code: '1200',
+        name: 'Inventory',
+        type: 'ASSET',
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertInventoryDecreaseAccountCompatible({
+        id: '2',
+        code: '5100',
+        name: INVENTORY_LOSS_5100_NAME,
+        type: 'EXPENSE',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects incompatible name or type', () => {
+    expect(() =>
+      assertInventoryDecreaseAccountCompatible({
+        id: '1',
+        code: '1200',
+        name: 'Stock Asset',
+        type: 'ASSET',
+      }),
+    ).toThrow(/incorrectly configured/i);
+    expect(() =>
+      assertInventoryDecreaseAccountCompatible({
+        id: '2',
+        code: '5100',
+        name: 'Operating Expenses',
+        type: 'EXPENSE',
+      }),
+    ).toThrow(/incorrectly configured/i);
+  });
+});
+
+describe('ensureInventoryDecreaseAccounts', () => {
+  const BIZ = 'biz-empty-coa';
+  const client = {
+    account: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+    $executeRaw: vi.fn(),
+  };
+
+  const approved1200 = {
+    id: 'id-1200',
+    code: ACCOUNT_CODES.inventory,
+    name: 'Inventory',
+    type: 'ASSET',
+  };
+  const approved5100 = {
+    id: 'id-5100',
+    code: ACCOUNT_CODES.inventoryLoss,
+    name: INVENTORY_LOSS_5100_NAME,
+    type: 'EXPENSE',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.POSTGRES_PRISMA_URL;
+    delete process.env.POSTGRES_URL;
+    delete process.env.POSTGRES_URL_NON_POOLING;
+    process.env.DATABASE_URL = 'file:./dev.db';
+  });
+
+  afterEach(() => {
+    delete process.env.POSTGRES_PRISMA_URL;
+    delete process.env.POSTGRES_URL;
+    delete process.env.POSTGRES_URL_NON_POOLING;
+  });
+
+  it('empty COA: upserts exactly 1200 and 5100 (sqlite path) and creates no unrelated codes', async () => {
+    client.account.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([approved1200, approved5100]);
+    client.account.upsert.mockImplementation(async ({ create }: any) => ({
+      id: `id-${create.code}`,
+      ...create,
+    }));
+
+    const started = Date.now();
+    const map = await ensureInventoryDecreaseAccounts(BIZ, client as any);
+    const elapsedMs = Date.now() - started;
+
+    expect([...map.keys()].sort()).toEqual(['1200', '5100']);
+    expect(client.account.upsert).toHaveBeenCalledTimes(2);
+    const upsertedCodes = client.account.upsert.mock.calls.map((c) => c[0].create.code).sort();
+    expect(upsertedCodes).toEqual(['1200', '5100']);
+    expect(upsertedCodes.every((c) => !['1000', '5000', '6000'].includes(c))).toBe(true);
+    // Timing evidence is in-process mock latency only — not Production RTT proof.
+    expect(elapsedMs).toBeLessThan(5000);
+  });
+
+  it('existing complete COA: reuses both and performs no upserts', async () => {
+    client.account.findMany.mockResolvedValue([approved1200, approved5100]);
+
+    const map = await ensureInventoryDecreaseAccounts(BIZ, client as any);
+    expect(map.get('1200')).toBe('id-1200');
+    expect(map.get('5100')).toBe('id-5100');
+    expect(client.account.upsert).not.toHaveBeenCalled();
+    expect(client.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it('only 1200 exists: reuses 1200 and creates 5100 once', async () => {
+    client.account.findMany
+      .mockResolvedValueOnce([approved1200])
+      .mockResolvedValueOnce([approved1200, approved5100]);
+    client.account.upsert.mockResolvedValue(approved5100);
+
+    await ensureInventoryDecreaseAccounts(BIZ, client as any);
+    expect(client.account.upsert).toHaveBeenCalledTimes(1);
+    expect(client.account.upsert.mock.calls[0][0].create.code).toBe('5100');
+  });
+
+  it('only 5100 exists: reuses 5100 and creates 1200 once', async () => {
+    client.account.findMany
+      .mockResolvedValueOnce([approved5100])
+      .mockResolvedValueOnce([approved1200, approved5100]);
+    client.account.upsert.mockResolvedValue(approved1200);
+
+    await ensureInventoryDecreaseAccounts(BIZ, client as any);
+    expect(client.account.upsert).toHaveBeenCalledTimes(1);
+    expect(client.account.upsert.mock.calls[0][0].create.code).toBe('1200');
+  });
+
+  it('postgres path: single INSERT for missing accounts when POSTGRES_* is set without DATABASE_URL', async () => {
+    delete process.env.DATABASE_URL;
+    process.env.POSTGRES_PRISMA_URL = 'postgresql://neondb_owner:x@ep-x/neondb';
+    client.account.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([approved1200, approved5100]);
+    client.$executeRaw.mockResolvedValue(2);
+
+    const map = await ensureInventoryDecreaseAccounts(BIZ, client as any);
+    expect(map.size).toBe(2);
+    expect(client.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(client.account.upsert).not.toHaveBeenCalled();
+  });
+
+  it('concurrent creators: ON CONFLICT then re-read returns stable IDs without duplicate create side effects', async () => {
+    delete process.env.DATABASE_URL;
+    process.env.POSTGRES_PRISMA_URL = 'postgresql://neondb_owner:x@ep-x/neondb';
+    // First finder sees empty; insert conflicts (0 rows); re-read sees winner rows.
+    client.account.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([approved1200, approved5100]);
+    client.$executeRaw.mockResolvedValue(0);
+
+    const map = await ensureInventoryDecreaseAccounts(BIZ, client as any);
+    expect(map.get('1200')).toBe('id-1200');
+    expect(map.get('5100')).toBe('id-5100');
+    expect(client.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(client.account.findMany).toHaveBeenCalledTimes(2);
+  });
+
+  it('incompatible existing 1200 fails before any create', async () => {
+    client.account.findMany.mockResolvedValue([
+      { id: 'bad', code: '1200', name: 'Merchandise', type: 'ASSET' },
+    ]);
+
+    await expect(ensureInventoryDecreaseAccounts(BIZ, client as any)).rejects.toThrow(
+      /incorrectly configured/i,
+    );
+    expect(client.account.upsert).not.toHaveBeenCalled();
+    expect(client.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it('timing-focused empty-COA path stays under interactive-tx budget (mock limitation noted)', async () => {
+    // Limitation: this measures in-memory mock duration, not Neon RTT. The
+    // Production failure was ~19 sequential upserts at ~5s; the narrow path
+    // performs at most 2 upserts (or 1 bulk INSERT) for required codes only.
+    const BEFORE_UPSERTS = CHART_OF_ACCOUNTS.length; // 19
+    const AFTER_UPSERTS_MAX = INVENTORY_DECREASE_REQUIRED_ACCOUNTS.length; // 2
+    expect(AFTER_UPSERTS_MAX).toBe(2);
+    expect(BEFORE_UPSERTS).toBeGreaterThanOrEqual(19);
+
+    client.account.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([approved1200, approved5100]);
+    client.account.upsert.mockImplementation(async () => approved1200);
+
+    const PRISMA_DEFAULT_TX_TIMEOUT_MS = 5000;
+    const started = performance.now();
+    await ensureInventoryDecreaseAccounts(BIZ, client as any);
+    const elapsedMs = performance.now() - started;
+
+    expect(client.account.upsert).toHaveBeenCalledTimes(AFTER_UPSERTS_MAX);
+    expect(elapsedMs).toBeLessThan(PRISMA_DEFAULT_TX_TIMEOUT_MS * 0.5);
+  });
+});

--- a/lib/accounting-inventory-decrease-accounts.ts
+++ b/lib/accounting-inventory-decrease-accounts.ts
@@ -1,0 +1,143 @@
+import { Prisma } from '@prisma/client';
+import type { PrismaClient } from '@prisma/client';
+import { ACCOUNT_CODES } from '@/lib/accounting';
+import { INVENTORY_LOSS_5100_NAME } from '@/lib/accounting-inventory-loss-5100';
+import { isPostgresRuntimeEnv } from '@/lib/database-runtime';
+
+/**
+ * Accounts required for Inventory Decrease Phase 1 journal posting.
+ * Deliberately excludes the rest of CHART_OF_ACCOUNTS so empty-COA tenants
+ * do not burn the interactive-transaction budget seeding unrelated codes.
+ */
+export const INVENTORY_DECREASE_REQUIRED_ACCOUNTS = [
+  {
+    code: ACCOUNT_CODES.inventory,
+    name: 'Inventory',
+    type: 'ASSET' as const,
+  },
+  {
+    code: ACCOUNT_CODES.inventoryLoss,
+    name: INVENTORY_LOSS_5100_NAME,
+    type: 'EXPENSE' as const,
+  },
+] as const;
+
+export type InventoryDecreaseAccountSpec =
+  (typeof INVENTORY_DECREASE_REQUIRED_ACCOUNTS)[number];
+
+type AccountRow = {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+};
+
+type TxLike = {
+  account: {
+    findMany: (args: any) => Promise<AccountRow[]>;
+    upsert?: (args: any) => Promise<AccountRow>;
+  };
+  $executeRaw?: (query: TemplateStringsArray | Prisma.Sql, ...values: any[]) => Promise<number>;
+};
+
+function specForCode(code: string): InventoryDecreaseAccountSpec {
+  const spec = INVENTORY_DECREASE_REQUIRED_ACCOUNTS.find((a) => a.code === code);
+  if (!spec) {
+    throw new Error(`Unsupported inventory-decrease account code ${code}`);
+  }
+  return spec;
+}
+
+/**
+ * Reject incompatible existing mappings rather than posting to the wrong account.
+ * Legacy unused 5100 "Operating Expenses" is handled by assertAccount5100SafeForInventoryLoss
+ * before this helper runs; once renamed it matches INVENTORY_LOSS_5100_NAME.
+ */
+export function assertInventoryDecreaseAccountCompatible(account: AccountRow): void {
+  const spec = specForCode(account.code);
+  if (account.name !== spec.name || account.type !== spec.type) {
+    throw new Error(
+      `Account ${account.code} is configured as "${account.name}" (${account.type}) ` +
+        `but inventory decrease requires "${spec.name}" (${spec.type}). ` +
+        'Refusing to post to an incorrectly configured account.',
+    );
+  }
+}
+
+async function loadRequiredAccounts(
+  client: TxLike,
+  businessId: string,
+): Promise<Map<string, AccountRow>> {
+  const rows = await client.account.findMany({
+    where: {
+      businessId,
+      code: { in: INVENTORY_DECREASE_REQUIRED_ACCOUNTS.map((a) => a.code) },
+    },
+    select: { id: true, code: true, name: true, type: true },
+  });
+  return new Map(rows.map((row) => [row.code, row]));
+}
+
+/**
+ * Resolve or create only 1200 and 5100 inside the caller's transaction client.
+ *
+ * - Empty COA → creates exactly those two accounts
+ * - Partial COA → reuses existing, creates the missing one
+ * - Complete → reuses both, creates none
+ * - Concurrent → unique (businessId, code) + ON CONFLICT / upsert; re-read after insert
+ * - Incompatible existing mapping → throws (caller must roll back)
+ *
+ * Returns code → accountId for postJournalEntry(accountMap).
+ */
+export async function ensureInventoryDecreaseAccounts(
+  businessId: string,
+  client: TxLike | PrismaClient,
+): Promise<Map<string, string>> {
+  const tx = client as TxLike;
+  let byCode = await loadRequiredAccounts(tx, businessId);
+
+  for (const existing of byCode.values()) {
+    assertInventoryDecreaseAccountCompatible(existing);
+  }
+
+  const missing = INVENTORY_DECREASE_REQUIRED_ACCOUNTS.filter((a) => !byCode.has(a.code));
+  if (missing.length === 0) {
+    return new Map([...byCode.entries()].map(([code, row]) => [code, row.id]));
+  }
+
+  // Prefer a single INSERT ... ON CONFLICT when Postgres is available (Production
+  // often has POSTGRES_* without DATABASE_URL). Fall back to per-code upsert.
+  if (isPostgresRuntimeEnv(process.env) && typeof tx.$executeRaw === 'function') {
+    const values = missing.map(
+      (a) =>
+        Prisma.sql`(gen_random_uuid()::text, ${businessId}, ${a.code}, ${a.name}, ${a.type}, NOW())`,
+    );
+    await tx.$executeRaw`
+      INSERT INTO "Account" ("id", "businessId", "code", "name", "type", "createdAt")
+      VALUES ${Prisma.join(values)}
+      ON CONFLICT ("businessId", "code") DO NOTHING
+    `;
+  } else if (typeof tx.account.upsert === 'function') {
+    for (const a of missing) {
+      await tx.account.upsert({
+        where: { businessId_code: { businessId, code: a.code } },
+        update: {},
+        create: { businessId, code: a.code, name: a.name, type: a.type },
+      });
+    }
+  } else {
+    throw new Error('Transaction client cannot create inventory-decrease accounts');
+  }
+
+  // Re-read after insert/conflict so concurrent creators resolve to the same IDs.
+  byCode = await loadRequiredAccounts(tx, businessId);
+  for (const spec of INVENTORY_DECREASE_REQUIRED_ACCOUNTS) {
+    const row = byCode.get(spec.code);
+    if (!row) {
+      throw new Error(`Account not found for code ${spec.code}`);
+    }
+    assertInventoryDecreaseAccountCompatible(row);
+  }
+
+  return new Map([...byCode.entries()].map(([code, row]) => [code, row.id]));
+}

--- a/lib/accounting.test.ts
+++ b/lib/accounting.test.ts
@@ -1,21 +1,42 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { computeOutstandingBalance, ensureChartOfAccounts, CHART_OF_ACCOUNTS } from './accounting';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computeOutstandingBalance, CHART_OF_ACCOUNTS } from './accounting';
+
+const { isPostgresRuntimeEnvMock } = vi.hoisted(() => ({
+  isPostgresRuntimeEnvMock: vi.fn(() => false),
+}));
+
+vi.mock('@/lib/database-runtime', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/database-runtime')>(
+    '@/lib/database-runtime',
+  );
+  return {
+    ...actual,
+    isPostgresRuntimeEnv: isPostgresRuntimeEnvMock,
+  };
+});
+
+// Import after mock so ensureChartOfAccounts sees the stubbed runtime detector.
+const { ensureChartOfAccounts } = await import('./accounting');
 
 describe('computeOutstandingBalance', () => {
   it('treats paid invoices as closed even when legacy payment rows are missing', () => {
-    expect(computeOutstandingBalance({
-      totalPence: 7_480_00,
-      paymentStatus: 'PAID',
-      payments: [],
-    })).toBe(0);
+    expect(
+      computeOutstandingBalance({
+        totalPence: 7_480_00,
+        paymentStatus: 'PAID',
+        payments: [],
+      }),
+    ).toBe(0);
   });
 
   it('subtracts recorded payments for unpaid and part-paid invoices', () => {
-    expect(computeOutstandingBalance({
-      totalPence: 10_000,
-      paymentStatus: 'PART_PAID',
-      payments: [{ amountPence: 2_500 }, { amountPence: 3_000 }],
-    })).toBe(4_500);
+    expect(
+      computeOutstandingBalance({
+        totalPence: 10_000,
+        paymentStatus: 'PART_PAID',
+        payments: [{ amountPence: 2_500 }, { amountPence: 3_000 }],
+      }),
+    ).toBe(4_500);
   });
 });
 
@@ -27,28 +48,18 @@ describe('ensureChartOfAccounts postgres detection', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.DATABASE_URL;
-    delete process.env.POSTGRES_PRISMA_URL;
-    delete process.env.POSTGRES_URL;
-    delete process.env.POSTGRES_URL_NON_POOLING;
+    isPostgresRuntimeEnvMock.mockReturnValue(false);
   });
 
-  afterEach(() => {
-    delete process.env.DATABASE_URL;
-    delete process.env.POSTGRES_PRISMA_URL;
-    delete process.env.POSTGRES_URL;
-    delete process.env.POSTGRES_URL_NON_POOLING;
-  });
-
-  it('uses bulk INSERT when only POSTGRES_PRISMA_URL is set (Production-shaped env)', async () => {
-    process.env.POSTGRES_PRISMA_URL = 'postgresql://neondb_owner:x@ep-x/neondb';
+  it('uses bulk INSERT when Postgres runtime env is detected (Production-shaped POSTGRES_* )', async () => {
+    isPostgresRuntimeEnvMock.mockReturnValue(true);
     await ensureChartOfAccounts('biz-1', client as any);
     expect(client.$executeRaw).toHaveBeenCalledTimes(1);
     expect(client.account.upsert).not.toHaveBeenCalled();
   });
 
-  it('falls back to sequential upserts for sqlite DATABASE_URL', async () => {
-    process.env.DATABASE_URL = 'file:./dev.db';
+  it('falls back to sequential upserts when Postgres runtime is not detected', async () => {
+    isPostgresRuntimeEnvMock.mockReturnValue(false);
     client.account.upsert.mockResolvedValue({});
     await ensureChartOfAccounts('biz-1', client as any);
     expect(client.account.upsert).toHaveBeenCalledTimes(CHART_OF_ACCOUNTS.length);

--- a/lib/accounting.test.ts
+++ b/lib/accounting.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { computeOutstandingBalance } from './accounting';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { computeOutstandingBalance, ensureChartOfAccounts, CHART_OF_ACCOUNTS } from './accounting';
 
 describe('computeOutstandingBalance', () => {
   it('treats paid invoices as closed even when legacy payment rows are missing', () => {
@@ -16,5 +16,42 @@ describe('computeOutstandingBalance', () => {
       paymentStatus: 'PART_PAID',
       payments: [{ amountPence: 2_500 }, { amountPence: 3_000 }],
     })).toBe(4_500);
+  });
+});
+
+describe('ensureChartOfAccounts postgres detection', () => {
+  const client = {
+    account: { upsert: vi.fn() },
+    $executeRaw: vi.fn().mockResolvedValue(CHART_OF_ACCOUNTS.length),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.DATABASE_URL;
+    delete process.env.POSTGRES_PRISMA_URL;
+    delete process.env.POSTGRES_URL;
+    delete process.env.POSTGRES_URL_NON_POOLING;
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+    delete process.env.POSTGRES_PRISMA_URL;
+    delete process.env.POSTGRES_URL;
+    delete process.env.POSTGRES_URL_NON_POOLING;
+  });
+
+  it('uses bulk INSERT when only POSTGRES_PRISMA_URL is set (Production-shaped env)', async () => {
+    process.env.POSTGRES_PRISMA_URL = 'postgresql://neondb_owner:x@ep-x/neondb';
+    await ensureChartOfAccounts('biz-1', client as any);
+    expect(client.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(client.account.upsert).not.toHaveBeenCalled();
+  });
+
+  it('falls back to sequential upserts for sqlite DATABASE_URL', async () => {
+    process.env.DATABASE_URL = 'file:./dev.db';
+    client.account.upsert.mockResolvedValue({});
+    await ensureChartOfAccounts('biz-1', client as any);
+    expect(client.account.upsert).toHaveBeenCalledTimes(CHART_OF_ACCOUNTS.length);
+    expect(client.$executeRaw).not.toHaveBeenCalled();
   });
 });

--- a/lib/accounting.ts
+++ b/lib/accounting.ts
@@ -1,7 +1,11 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import type { PrismaClient } from '@prisma/client';
-import { isPostgresDatabaseUrl, isSqliteDatabaseUrl } from '@/lib/database-runtime';
+import {
+  isPostgresDatabaseUrl,
+  isPostgresRuntimeEnv,
+  isSqliteDatabaseUrl,
+} from '@/lib/database-runtime';
 
 export const ACCOUNT_CODES = {
   cash: '1000',
@@ -51,7 +55,10 @@ function isSqliteRuntime() {
 }
 
 function isPostgresRuntime() {
-  return isPostgresDatabaseUrl(process.env.DATABASE_URL);
+  // Production Vercel often exposes POSTGRES_PRISMA_URL / POSTGRES_URL without
+  // DATABASE_URL. Checking only DATABASE_URL incorrectly selected the sequential
+  // upsert path and timed out inventory-decrease interactive transactions.
+  return isPostgresRuntimeEnv(process.env) || isPostgresDatabaseUrl(process.env.DATABASE_URL);
 }
 
 /**

--- a/lib/services/inventory-decrease.test.ts
+++ b/lib/services/inventory-decrease.test.ts
@@ -13,6 +13,7 @@ import {
 const {
   prismaMock,
   postJournalEntryMock,
+  ensureInventoryDecreaseAccountsMock,
   decrementInventoryBalanceMock,
   isPhase1EnabledMock,
   detectInventoryAdjustmentRiskMock,
@@ -29,6 +30,7 @@ const {
     $queryRaw: vi.fn(),
   },
   postJournalEntryMock: vi.fn(),
+  ensureInventoryDecreaseAccountsMock: vi.fn(),
   decrementInventoryBalanceMock: vi.fn(),
   isPhase1EnabledMock: vi.fn(() => true),
   detectInventoryAdjustmentRiskMock: vi.fn().mockResolvedValue(undefined),
@@ -45,6 +47,9 @@ vi.mock('@/lib/accounting', async () => {
     postJournalEntry: postJournalEntryMock,
   };
 });
+vi.mock('@/lib/accounting-inventory-decrease-accounts', () => ({
+  ensureInventoryDecreaseAccounts: ensureInventoryDecreaseAccountsMock,
+}));
 vi.mock('@/lib/accounting-inventory-loss-5100', () => ({
   assertAccount5100SafeForInventoryLoss: vi.fn().mockResolvedValue(undefined),
 }));
@@ -155,6 +160,12 @@ describe('createInventoryDecrease', () => {
     prismaMock.business.findUnique.mockResolvedValue({ inventoryAdjustmentRiskThresholdBase: 50 });
     decrementInventoryBalanceMock.mockResolvedValue(8);
     postJournalEntryMock.mockResolvedValue({ id: 'je-1' });
+    ensureInventoryDecreaseAccountsMock.mockResolvedValue(
+      new Map([
+        [ACCOUNT_CODES.inventory, 'acc-1200'],
+        [ACCOUNT_CODES.inventoryLoss, 'acc-5100'],
+      ]),
+    );
 
     prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
       fn(prismaMock),
@@ -193,8 +204,10 @@ describe('createInventoryDecrease', () => {
           { accountCode: ACCOUNT_CODES.inventoryLoss, debitPence: 200 },
           { accountCode: ACCOUNT_CODES.inventory, creditPence: 200 },
         ],
+        accountMap: expect.any(Map),
       }),
     );
+    expect(ensureInventoryDecreaseAccountsMock).toHaveBeenCalledWith(BIZ, prismaMock);
     expect(ACCOUNT_CODES.inventoryLoss).toBe('5100');
     expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -241,6 +254,12 @@ describe('createInventoryDecrease', () => {
       prismaMock.auditLog.create.mockResolvedValue({});
       decrementInventoryBalanceMock.mockResolvedValue(8);
       postJournalEntryMock.mockResolvedValue({});
+      ensureInventoryDecreaseAccountsMock.mockResolvedValue(
+        new Map([
+          [ACCOUNT_CODES.inventory, 'acc-1200'],
+          [ACCOUNT_CODES.inventoryLoss, 'acc-5100'],
+        ]),
+      );
       prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
         fn(prismaMock),
       );
@@ -267,6 +286,8 @@ describe('createInventoryDecrease', () => {
     await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
       code: INVENTORY_DECREASE_ERROR.INSUFFICIENT_QUANTITY,
     });
+    expect(ensureInventoryDecreaseAccountsMock).not.toHaveBeenCalled();
+    expect(postJournalEntryMock).not.toHaveBeenCalled();
   });
 
   it('rejects zero avgCostBasePence as MISSING_VALUATION without writes', async () => {
@@ -278,6 +299,7 @@ describe('createInventoryDecrease', () => {
       code: INVENTORY_DECREASE_ERROR.MISSING_VALUATION,
     });
     expect(prismaMock.stockAdjustment.create).not.toHaveBeenCalled();
+    expect(ensureInventoryDecreaseAccountsMock).not.toHaveBeenCalled();
     expect(postJournalEntryMock).not.toHaveBeenCalled();
     expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
   });
@@ -366,6 +388,18 @@ describe('createInventoryDecrease', () => {
     await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
       code: INVENTORY_DECREASE_ERROR.ACCOUNT_MAPPING_UNAVAILABLE,
     });
+  });
+
+  it('maps incompatible account resolution to ACCOUNT_MAPPING_UNAVAILABLE without journal', async () => {
+    ensureInventoryDecreaseAccountsMock.mockRejectedValueOnce(
+      new Error(
+        'Account 1200 is configured as "Merchandise" (ASSET) but inventory decrease requires "Inventory" (ASSET). Refusing to post to an incorrectly configured account.',
+      ),
+    );
+    await expect(createInventoryDecrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_DECREASE_ERROR.ACCOUNT_MAPPING_UNAVAILABLE,
+    });
+    expect(postJournalEntryMock).not.toHaveBeenCalled();
   });
 
   it('fails the transaction when audit insert fails', async () => {

--- a/lib/services/inventory-decrease.ts
+++ b/lib/services/inventory-decrease.ts
@@ -2,6 +2,7 @@ import { createHash } from 'crypto';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { ACCOUNT_CODES, postJournalEntry } from '@/lib/accounting';
+import { ensureInventoryDecreaseAccounts } from '@/lib/accounting-inventory-decrease-accounts';
 import { assertAccount5100SafeForInventoryLoss } from '@/lib/accounting-inventory-loss-5100';
 import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
 import { isInventoryDecreasePhase1Enabled } from '@/lib/inventory-decrease-flag';
@@ -439,7 +440,11 @@ async function createInventoryDecreaseImpl(
     });
 
     try {
+      // Narrow account resolution only (1200 + 5100). Do not seed the full COA
+      // inside this interactive transaction — empty tenants previously timed out
+      // after ~19 sequential upserts against the default 5s budget.
       await assertAccount5100SafeForInventoryLoss(tx, input.businessId);
+      const accountMap = await ensureInventoryDecreaseAccounts(input.businessId, tx);
       await postJournalEntry({
         businessId: input.businessId,
         description: `Inventory decrease ${created.id}`,
@@ -450,13 +455,16 @@ async function createInventoryDecreaseImpl(
           { accountCode: ACCOUNT_CODES.inventory, creditPence: valuePence },
         ],
         prismaClient: tx as any,
+        accountMap,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Journal posting failed';
       if (
         message.includes('Account not found') ||
         message.includes('Account 5100') ||
-        message.includes('Inventory Loss')
+        message.includes('Account 1200') ||
+        message.includes('Inventory Loss') ||
+        message.includes('incorrectly configured')
       ) {
         throw new InventoryDecreaseError(
           INVENTORY_DECREASE_ERROR.ACCOUNT_MAPPING_UNAVAILABLE,


### PR DESCRIPTION
## Summary
- Empty-COA inventory decreases timed out because `postJournalEntry` → `ensureChartOfAccounts` seeded the full chart via sequential `account.upsert` when Production had `POSTGRES_*` but no `DATABASE_URL`.
- Add a narrow transactional helper that resolves/creates only accounts 1200 and 5100, pass the account map into journal posting, and use `isPostgresRuntimeEnv` for COA bulk insert detection.
- Leave the interactive transaction timeout at the Prisma default (5s); Preview empty-COA posting completed in ~572ms.

## Test plan
- [x] Unit: empty/partial/complete COA, concurrency conflict path, incompatible mapping, timing budget
- [x] Inventory decrease service + action tests
- [x] Write-gate / internal-QA / FLAG_DISABLED tests
- [x] Full unit suite (1942)
- [x] typecheck, lint, pos-safety unit, Production build
- [x] Preview `tillflow_preview_qa` empty-COA controlled decrease reconciliation
- [ ] Merge then deploy Production with `TILLFLOW_INVENTORY_ADJUST_PHASE1` absent/off