### PR TITLE
feat(inventory): business-scoped Phase 2 increase allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,13 @@ METRICS_TOKEN="replace-with-a-long-random-metrics-token"
 # Optional additive allowlist (TillFlow QA Demo ID is built into source).
 # TILLFLOW_INTERNAL_QA_BUSINESS_IDS="cmextraqa0000000000000001"
 
+# Inventory increase Phase 2 (controlled surplus / stock found). Server-side only.
+# Both are required: global flag AND exact business allowlist. Missing allowlist fails closed.
+# Never use "*", "all", names, emails, or domains. Fake IDs shown — do not commit real Production IDs.
+# See docs/INVENTORY_INCREASE_PHASE2_ROLLOUT.md
+# TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE="1"
+# TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS="cmexamplebiz00000000000001,cmexamplebiz00000000000002"
+
 # -----------------------------------------------------------------------------
 # Redis / rate limiting
 # -----------------------------------------------------------------------------

--- a/app/(protected)/inventory/adjustments/page.tsx
+++ b/app/(protected)/inventory/adjustments/page.tsx
@@ -5,7 +5,7 @@ import { requireBusinessStore } from '@/lib/auth';
 import { formatMixedUnit, getPrimaryPackagingUnit } from '@/lib/units';
 import { formatDateTime, formatMoney } from '@/lib/format';
 import { isInventoryDecreasePhase1Enabled } from '@/lib/inventory-decrease-flag';
-import { isInventoryIncreasePhase2Enabled } from '@/lib/inventory-increase-flag';
+import { isInventoryIncreasePhase2EnabledForBusiness } from '@/lib/inventory-increase-flag';
 import StockAdjustmentClient from '../StockAdjustmentClient';
 
 export const dynamic = 'force-dynamic';
@@ -56,7 +56,8 @@ export default async function StockAdjustmentsPage({
 
   const page = Math.max(1, parseInt(searchParams?.page ?? '1', 10) || 1);
   const phase1Enabled = isInventoryDecreasePhase1Enabled();
-  const phase2Enabled = isInventoryIncreasePhase2Enabled();
+  // Visibility only — createInventoryIncrease still enforces the scoped gate.
+  const phase2Enabled = isInventoryIncreasePhase2EnabledForBusiness(business.id);
 
   const [products, adjustmentCount, adjustments, increaseCount, decreaseCount] = await Promise.all([
     prisma.product.findMany({

--- a/app/actions/inventory.ts
+++ b/app/actions/inventory.ts
@@ -7,7 +7,7 @@ import { withBusinessStoreContext, formAction, UserError } from '@/lib/action-ut
 import { checkAndSendLowStockAlert } from '@/app/actions/stock-alerts';
 import { revalidateOwnerDashboardCache } from '@/lib/reports/cache-revalidation';
 import { isInventoryDecreasePhase1Enabled } from '@/lib/inventory-decrease-flag';
-import { isInventoryIncreasePhase2Enabled } from '@/lib/inventory-increase-flag';
+import { isInventoryIncreasePhase2EnabledForBusiness } from '@/lib/inventory-increase-flag';
 import {
   createInventoryDecrease,
   InventoryDecreaseError,
@@ -104,7 +104,9 @@ export async function createStockAdjustmentAction(formData: FormData): Promise<v
     }
 
     if (direction === 'INCREASE') {
-      if (!isInventoryIncreasePhase2Enabled()) {
+      // Server-authoritative scoped gate (global flag + exact business allowlist).
+      // UI visibility is not the enforcement boundary.
+      if (!isInventoryIncreasePhase2EnabledForBusiness(businessId)) {
         throw new UserError('Inventory increases are temporarily unavailable.');
       }
       if (!isInventoryIncreaseReasonCode(reasonCodeRaw)) {

--- a/docs/INVENTORY_INCREASE_PHASE2_ROLLOUT.md
+++ b/docs/INVENTORY_INCREASE_PHASE2_ROLLOUT.md
@@ -1,0 +1,102 @@
+# Inventory Increase Phase 2 — Business-Scoped Rollout
+
+## Purpose
+
+Phase 2 inventory increases (physical-count surplus / stock found) are gated by **two** independent server-side conditions:
+
+1. Global flag enabled
+2. Target business ID exactly allowlisted
+
+This prevents all-or-nothing Production exposure when the global flag is turned on.
+
+Merging code that supports the allowlist **does not** authorise Production enablement or allowlisting.
+
+## Configuration
+
+| Variable | Required | Meaning |
+| --- | --- | --- |
+| `TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE` | Yes (for any increase) | Must be exactly `1` to enable the Phase 2 code path |
+| `TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS` | Yes (for any increase) | Comma- and/or whitespace-separated **immutable business IDs** |
+
+Both must be satisfied:
+
+`eligible = (PHASE2_INCREASE === "1") AND (businessId ∈ parsed allowlist)`
+
+### Format
+
+- Use exact business IDs only (never names, emails, domains, or display labels).
+- Trim whitespace; empty entries are ignored.
+- Duplicate IDs are harmless.
+- Missing, empty, or fully invalid allowlist → **no** eligible businesses (fail closed).
+- Tokens such as `*`, `all`, `true`, `yes`, `1`, `global` are ignored and **never** mean every business.
+
+### Example (fake IDs only)
+
+```bash
+TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE=1
+TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS=cmexamplebiz00000000000001,cmexamplebiz00000000000002
+```
+
+Do not commit real Production business IDs in documentation, PRs, or examples.
+
+## Truth table
+
+| Global flag | Business allowlisted | Result |
+| --- | ---: | --- |
+| Off / missing | No | Denied |
+| Off / missing | Yes | Denied |
+| On | No | Denied |
+| On | Yes | Continue to role, billing, and validation checks |
+
+Denied responses stay generic (`Inventory increases are temporarily unavailable` / Phase 2 not enabled) so eligibility is not leaked.
+
+## Enforcement points (server-authoritative)
+
+| Location | Role |
+| --- | --- |
+| `lib/inventory-increase-flag.ts` | Centralised parse + eligibility helpers |
+| `lib/services/inventory-increase.ts` → `createInventoryIncrease` | Hard gate before idempotency reads and any mutation |
+| `app/actions/inventory.ts` → increase branch | Action-level gate using session `businessId` |
+| `app/(protected)/inventory/adjustments/page.tsx` | UI visibility only (not the security boundary) |
+
+UI hiding is convenience only. Crafted requests still hit the service gate.
+
+Tenant binding remains enforced: the actor’s session business must own the store/product. Passing an allowlisted foreign business ID cannot post for another tenant.
+
+## Operations
+
+### Add a canary business
+
+1. Obtain the immutable business ID from an authorised operator source (not from UI labels).
+2. Append it to `TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS` (exact ID).
+3. Ensure `TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE=1`.
+4. Apply env on the target Vercel environment (Preview or Production as authorised).
+5. **Redeploy** (or otherwise restart) so the runtime picks up env changes for serverless deployments.
+6. Verify: allowlisted Owner/Manager sees Record increase; a non-allowlisted business does not; Cashier remains denied.
+
+### Remove a business / roll back Phase 2 posting ability
+
+1. Remove the business ID from the allowlist, **or** set `TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE` to anything other than `1` / remove it.
+2. Redeploy so the change is effective.
+3. Confirm Record increase is unavailable for that business.
+
+**Important:** Disabling the flag or removing a business from the allowlist prevents **new** postings. It does **not** reverse completed inventory, journal, or audit records. Use the approved accounting correction procedure if remediation is required. Do not delete or rewrite Production postings.
+
+### Verification checklist
+
+- [ ] Global flag off → allowlisted business denied
+- [ ] Global flag on → non-allowlisted business denied
+- [ ] Global flag on → allowlisted business Owner/Manager can see increase UI
+- [ ] Cashier / unauthenticated / billing-restricted actors denied
+- [ ] Direct server increase for non-allowlisted business denied with no durable records
+- [ ] Phase 1 decrease behaviour unchanged
+
+## Early-rollout concurrency warning
+
+Cross-workflow concurrency involving purchase receipts, opening stock, transfers, returns, and legacy absolute read-modify-write adjustments remains a documented limitation. Do **not** adjust the same product concurrently through those workflows during early Phase 2 rollout.
+
+## Related code
+
+- Flag helper: `lib/inventory-increase-flag.ts`
+- Posting service: `lib/services/inventory-increase.ts`
+- Accounts: Debit `1200` Inventory / Credit `4100` Inventory Gain & Surplus (`INCOME`)

--- a/lib/inventory-increase-flag.test.ts
+++ b/lib/inventory-increase-flag.test.ts
@@ -1,25 +1,147 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { isInventoryIncreasePhase2Enabled } from './inventory-increase-flag';
+import {
+  INVENTORY_INCREASE_PHASE2_BUSINESS_IDS_ENV,
+  isInventoryIncreasePhase2BusinessAllowlisted,
+  isInventoryIncreasePhase2Enabled,
+  isInventoryIncreasePhase2EnabledForBusiness,
+  parseInventoryIncreasePhase2BusinessIds,
+} from './inventory-increase-flag';
 
-describe('isInventoryIncreasePhase2Enabled', () => {
-  const previous = process.env.TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE;
+const FLAG = 'TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE';
+const ALLOW = INVENTORY_INCREASE_PHASE2_BUSINESS_IDS_ENV;
+
+const BIZ_A = 'cmexamplebiz00000000000001';
+const BIZ_B = 'cmexamplebiz00000000000002';
+const BIZ_C = 'cmexamplebiz00000000000003';
+
+function env(partial: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return partial as unknown as NodeJS.ProcessEnv;
+}
+
+describe('inventory increase Phase 2 flag + business allowlist', () => {
+  const previousFlag = process.env[FLAG];
+  const previousAllow = process.env[ALLOW];
 
   afterEach(() => {
-    if (previous === undefined) delete process.env.TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE;
-    else process.env.TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE = previous;
+    if (previousFlag === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = previousFlag;
+    if (previousAllow === undefined) delete process.env[ALLOW];
+    else process.env[ALLOW] = previousAllow;
   });
 
-  it('is enabled only when env is exactly 1', () => {
-    expect(isInventoryIncreasePhase2Enabled({} as unknown as NodeJS.ProcessEnv)).toBe(false);
-    expect(
-      isInventoryIncreasePhase2Enabled({
-        TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE: '0',
-      } as unknown as NodeJS.ProcessEnv),
-    ).toBe(false);
-    expect(
-      isInventoryIncreasePhase2Enabled({
-        TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE: '1',
-      } as unknown as NodeJS.ProcessEnv),
-    ).toBe(true);
+  it('global flag is enabled only when env is exactly 1', () => {
+    expect(isInventoryIncreasePhase2Enabled(env({}))).toBe(false);
+    expect(isInventoryIncreasePhase2Enabled(env({ [FLAG]: '0' }))).toBe(false);
+    expect(isInventoryIncreasePhase2Enabled(env({ [FLAG]: '1' }))).toBe(true);
+  });
+
+  it('missing configuration fails closed (no eligible businesses)', () => {
+    expect(parseInventoryIncreasePhase2BusinessIds(null).size).toBe(0);
+    expect(parseInventoryIncreasePhase2BusinessIds(undefined).size).toBe(0);
+    expect(parseInventoryIncreasePhase2BusinessIds('').size).toBe(0);
+    expect(parseInventoryIncreasePhase2BusinessIds('   ,  ,\t').size).toBe(0);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1' }))).toBe(
+      false,
+    );
+  });
+
+  it('trims whitespace, ignores empty entries, and deduplicates', () => {
+    const ids = parseInventoryIncreasePhase2BusinessIds(
+      `  ${BIZ_A},,  ${BIZ_B}\n${BIZ_A}\t${BIZ_C}  `,
+    );
+    expect(ids.size).toBe(3);
+    expect(ids.has(BIZ_A)).toBe(true);
+    expect(ids.has(BIZ_B)).toBe(true);
+    expect(ids.has(BIZ_C)).toBe(true);
+  });
+
+  it('supports multiple allowlisted business IDs with exact membership', () => {
+    const e = env({ [FLAG]: '1', [ALLOW]: `${BIZ_A},${BIZ_B}` });
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, e)).toBe(true);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_B, e)).toBe(true);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_C, e)).toBe(false);
+  });
+
+  it('rejects wildcard-like values (never means all businesses)', () => {
+    for (const token of ['*', 'all', 'ALL', 'true', 'TRUE', 'yes', '1', 'any', 'global', 'everyone']) {
+      const ids = parseInventoryIncreasePhase2BusinessIds(token);
+      expect(ids.size).toBe(0);
+      expect(
+        isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1', [ALLOW]: token })),
+      ).toBe(false);
+    }
+  });
+
+  it('rejects malformed IDs and free-text labels safely', () => {
+    const raw = [
+      'TillFlow QA Demo',
+      'qa-owner@tillflow.app',
+      'example.com',
+      'biz*',
+      'a',
+      '???',
+      'Has Space Label',
+      'MixedCaseId',
+    ].join(',');
+    const ids = parseInventoryIncreasePhase2BusinessIds(raw);
+    expect(ids.size).toBe(0);
+    expect(parseInventoryIncreasePhase2BusinessIds('TillFlow QA Demo').size).toBe(0);
+  });
+
+  it('rejects substring collisions (exact match only)', () => {
+    const e = env({ [FLAG]: '1', [ALLOW]: BIZ_A });
+    expect(isInventoryIncreasePhase2BusinessAllowlisted(BIZ_A, e)).toBe(true);
+    expect(isInventoryIncreasePhase2BusinessAllowlisted(BIZ_A.slice(0, 12), e)).toBe(false);
+    expect(isInventoryIncreasePhase2BusinessAllowlisted(`${BIZ_A}x`, e)).toBe(false);
+    expect(isInventoryIncreasePhase2BusinessAllowlisted(`x${BIZ_A}`, e)).toBe(false);
+  });
+
+  describe('fail-closed truth table', () => {
+    it('flag off + business absent → denied', () => {
+      expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '0' }))).toBe(
+        false,
+      );
+    });
+
+    it('flag off + business allowlisted → denied', () => {
+      expect(
+        isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '0', [ALLOW]: BIZ_A })),
+      ).toBe(false);
+      expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [ALLOW]: BIZ_A }))).toBe(
+        false,
+      );
+    });
+
+    it('flag on + business absent → denied', () => {
+      expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1' }))).toBe(
+        false,
+      );
+    });
+
+    it('flag on + different business allowlisted → denied', () => {
+      expect(
+        isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1', [ALLOW]: BIZ_B })),
+      ).toBe(false);
+    });
+
+    it('flag on + exact business allowlisted → allowed', () => {
+      expect(
+        isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1', [ALLOW]: BIZ_A })),
+      ).toBe(true);
+    });
+  });
+
+  it('null/empty business ids are never eligible', () => {
+    const e = env({ [FLAG]: '1', [ALLOW]: BIZ_A });
+    expect(isInventoryIncreasePhase2EnabledForBusiness(null, e)).toBe(false);
+    expect(isInventoryIncreasePhase2EnabledForBusiness('', e)).toBe(false);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(undefined, e)).toBe(false);
+  });
+
+  it('keeps wildcard tokens from enabling access even when mixed with a valid ID', () => {
+    const e = env({ [FLAG]: '1', [ALLOW]: `*,all,true,${BIZ_A},yes` });
+    expect(parseInventoryIncreasePhase2BusinessIds(e[ALLOW]).size).toBe(1);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, e)).toBe(true);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_B, e)).toBe(false);
   });
 });

--- a/lib/inventory-increase-flag.ts
+++ b/lib/inventory-increase-flag.ts
@@ -2,9 +2,116 @@
  * Rollout gate for controlled inventory-increase Phase 2.
  * Independent of Phase 1 decrease. When disabled, increase UI/actions must
  * hide or reject — never fall back to the legacy unhardened mutation.
+ *
+ * Production blast radius is controlled by TWO independent conditions:
+ *   1. Global flag TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE === "1"
+ *   2. Exact business ID membership in TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS
+ *
+ * Both must be true. Missing/invalid/empty allowlist fails closed (no businesses).
+ * Wildcard-like values never mean "all businesses".
+ *
+ * Env allowlist is read via dynamic key access so Next.js does not inline a
+ * build-time empty value over a runtime-configured allowlist.
  */
+
+export const INVENTORY_INCREASE_PHASE2_BUSINESS_IDS_ENV =
+  'TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS' as const;
+
+/** Tokens that must never grant global or wildcard Phase 2 access. */
+const PHASE2_ALLOWLIST_REJECTED_TOKENS = new Set([
+  '*',
+  'all',
+  'any',
+  'true',
+  'false',
+  'yes',
+  'no',
+  '1',
+  '0',
+  'everyone',
+  'everybody',
+  'global',
+]);
+
+/**
+ * Accept only exact immutable business-ID shaped tokens.
+ * Rejects emails, display names, domains, globs, mixed-case labels, and free text.
+ */
+function isAcceptablePhase2BusinessIdToken(token: string): boolean {
+  if (!token) return false;
+  const lower = token.toLowerCase();
+  if (PHASE2_ALLOWLIST_REJECTED_TOKENS.has(lower)) return false;
+  if (/[*?]/.test(token)) return false;
+  if (token.includes('@') || token.includes('.')) return false;
+  // Reject mixed-case / Title Case labels (cuid and fixture IDs are lowercase).
+  if (/[A-Z]/.test(token)) return false;
+  // Exact ID shape: lowercase letters, digits, underscore, hyphen; min length 2.
+  if (!/^[a-z0-9][a-z0-9_-]{1,127}$/.test(token)) return false;
+  return true;
+}
+
+function readPhase2BusinessIdsEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  rawOverride?: string | null,
+): string | undefined | null {
+  if (rawOverride !== undefined) return rawOverride;
+  // Dynamic key access — avoids Next.js build-time inlining of process.env.NAME.
+  return env[INVENTORY_INCREASE_PHASE2_BUSINESS_IDS_ENV];
+}
+
+/**
+ * Parse the Phase 2 business allowlist.
+ * Fail-closed: missing, empty, or fully invalid configuration → empty Set.
+ * Never logs the allowlist. Exact membership only (no substring matching).
+ */
+export function parseInventoryIncreasePhase2BusinessIds(
+  raw?: string | null,
+  env: NodeJS.ProcessEnv = process.env,
+): Set<string> {
+  const ids = new Set<string>();
+  const value = readPhase2BusinessIdsEnv(env, raw);
+  if (!value || typeof value !== 'string') return ids;
+
+  for (const part of value.split(/[,\s]+/)) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    if (!isAcceptablePhase2BusinessIdToken(trimmed)) continue;
+    ids.add(trimmed);
+  }
+  return ids;
+}
+
 export function isInventoryIncreasePhase2Enabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   return env.TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE === '1';
+}
+
+/**
+ * Exact allowlist membership for a business ID.
+ * Does not consult the global flag — use isInventoryIncreasePhase2EnabledForBusiness
+ * for the full gate.
+ */
+export function isInventoryIncreasePhase2BusinessAllowlisted(
+  businessId: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+  rawAllowlist?: string | null,
+): boolean {
+  if (!businessId || typeof businessId !== 'string') return false;
+  return parseInventoryIncreasePhase2BusinessIds(rawAllowlist, env).has(businessId);
+}
+
+/**
+ * Authoritative Phase 2 eligibility for a business.
+ * Requires global flag ON and exact allowlist membership.
+ * Safe for UI visibility; must also be enforced on every posting path.
+ */
+export function isInventoryIncreasePhase2EnabledForBusiness(
+  businessId: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    isInventoryIncreasePhase2Enabled(env) &&
+    isInventoryIncreasePhase2BusinessAllowlisted(businessId, env)
+  );
 }

--- a/lib/services/inventory-increase-actions.test.ts
+++ b/lib/services/inventory-increase-actions.test.ts
@@ -21,9 +21,24 @@ describe('inventory increase Phase 2 actions and UI contracts', () => {
   it('create action supports Phase 2 increase and Phase 1 decrease', () => {
     expect(inventoryAction).toContain('createInventoryIncrease');
     expect(inventoryAction).toContain('createInventoryDecrease');
-    expect(inventoryAction).toContain('isInventoryIncreasePhase2Enabled');
+    expect(inventoryAction).toContain('isInventoryIncreasePhase2EnabledForBusiness');
     expect(inventoryAction).toContain('isInventoryDecreasePhase1Enabled');
     expect(inventoryAction).not.toContain("from '@/lib/services/inventory'");
+  });
+
+  it('Phase 2 action and page use business-scoped eligibility (not global-only)', () => {
+    expect(inventoryAction).toContain(
+      'isInventoryIncreasePhase2EnabledForBusiness(businessId)',
+    );
+    expect(pageSrc).toContain(
+      'isInventoryIncreasePhase2EnabledForBusiness(business.id)',
+    );
+    expect(inventoryAction).not.toMatch(
+      /if\s*\(\s*!isInventoryIncreasePhase2Enabled\(\s*\)\s*\)/,
+    );
+    expect(pageSrc).not.toMatch(
+      /phase2Enabled\s*=\s*isInventoryIncreasePhase2Enabled\(\s*\)/,
+    );
   });
 
   it('restricts adjustments to Owner/Manager and excludes Cashier', () => {

--- a/lib/services/inventory-increase-concurrency.test.ts
+++ b/lib/services/inventory-increase-concurrency.test.ts
@@ -43,6 +43,8 @@ describeConcurrency('inventory increase overlapping transactions (Postgres)', ()
       },
     });
     businessId = business.id;
+    // Scoped gate: global flag alone must not admit every tenant.
+    process.env.TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS = businessId;
     const store = await prisma.store.create({
       data: { businessId, name: `Store ${suffix}` },
     });

--- a/lib/services/inventory-increase-scoped-gate.test.ts
+++ b/lib/services/inventory-increase-scoped-gate.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Service-level scoped-gate denials using the real flag helper (no mock).
+ * Proves non-allowlisted / cross-config requests create no durable records.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ACCOUNT_CODES } from '@/lib/accounting';
+import {
+  INVENTORY_INCREASE_ERROR,
+  createInventoryIncrease,
+} from './inventory-increase';
+
+const {
+  prismaMock,
+  postJournalEntryMock,
+  ensureInventoryIncreaseAccountsMock,
+  incrementInventoryBalanceQtyOnlyMock,
+} = vi.hoisted(() => ({
+  prismaMock: {
+    store: { findFirst: vi.fn() },
+    productUnit: { findFirst: vi.fn() },
+    stockAdjustment: { findUnique: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
+    inventoryBalance: { findUnique: vi.fn() },
+    stockMovement: { create: vi.fn(), findFirst: vi.fn() },
+    auditLog: { create: vi.fn() },
+    $transaction: vi.fn(),
+    $queryRaw: vi.fn(),
+  },
+  postJournalEntryMock: vi.fn(),
+  ensureInventoryIncreaseAccountsMock: vi.fn(),
+  incrementInventoryBalanceQtyOnlyMock: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({ prisma: prismaMock }));
+vi.mock('@/lib/accounting', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/accounting')>('@/lib/accounting');
+  return {
+    ...actual,
+    postJournalEntry: postJournalEntryMock,
+  };
+});
+vi.mock('@/lib/accounting-inventory-increase-accounts', () => ({
+  ensureInventoryIncreaseAccounts: ensureInventoryIncreaseAccountsMock,
+}));
+vi.mock('./shared', async () => {
+  const actual = await vi.importActual<typeof import('./shared')>('./shared');
+  return {
+    ...actual,
+    incrementInventoryBalanceQtyOnly: incrementInventoryBalanceQtyOnlyMock,
+  };
+});
+
+const FLAG = 'TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE';
+const ALLOW = 'TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS';
+const BIZ = 'cmscopedgatebiz00000000001';
+const OTHER = 'cmscopedgatebiz00000000002';
+
+function baseInput(overrides: Record<string, unknown> = {}) {
+  return {
+    businessId: BIZ,
+    storeId: 'store-1',
+    productId: 'prod-1',
+    unitId: 'unit-1',
+    qtyInUnit: 1,
+    reasonCode: 'STOCK_FOUND' as const,
+    reason: 'Found on shelf',
+    idempotencyKey: 'idem-scoped-1',
+    userId: 'user-1',
+    userName: 'Owner',
+    userRole: 'OWNER',
+    ...overrides,
+  };
+}
+
+function expectNoDurableSideEffects() {
+  expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  expect(prismaMock.stockAdjustment.findUnique).not.toHaveBeenCalled();
+  expect(prismaMock.stockAdjustment.create).not.toHaveBeenCalled();
+  expect(prismaMock.stockMovement.create).not.toHaveBeenCalled();
+  expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
+  expect(postJournalEntryMock).not.toHaveBeenCalled();
+  expect(incrementInventoryBalanceQtyOnlyMock).not.toHaveBeenCalled();
+}
+
+describe('createInventoryIncrease scoped allowlist (real flag helper)', () => {
+  const previousFlag = process.env[FLAG];
+  const previousAllow = process.env[ALLOW];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DATABASE_URL = 'file:./dev.db';
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
+    prismaMock.store.findFirst.mockResolvedValue({ id: 'store-1' });
+    prismaMock.productUnit.findFirst.mockResolvedValue({ conversionToBase: 1 });
+    prismaMock.stockAdjustment.findUnique.mockResolvedValue(null);
+    prismaMock.inventoryBalance.findUnique.mockResolvedValue({
+      qtyOnHandBase: 5,
+      avgCostBasePence: 100,
+    });
+    ensureInventoryIncreaseAccountsMock.mockResolvedValue(
+      new Map([
+        [ACCOUNT_CODES.inventory, 'acc-1200'],
+        [ACCOUNT_CODES.inventoryGain, 'acc-4100'],
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    if (previousFlag === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = previousFlag;
+    if (previousAllow === undefined) delete process.env[ALLOW];
+    else process.env[ALLOW] = previousAllow;
+  });
+
+  it('flag off + allowlisted business → denied, no durable records', async () => {
+    delete process.env[FLAG];
+    process.env[ALLOW] = BIZ;
+    await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
+    });
+    expectNoDurableSideEffects();
+  });
+
+  it('flag on + business absent → denied, no durable records', async () => {
+    process.env[FLAG] = '1';
+    delete process.env[ALLOW];
+    await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
+    });
+    expectNoDurableSideEffects();
+  });
+
+  it('flag on + different business allowlisted → denied, no durable records', async () => {
+    process.env[FLAG] = '1';
+    process.env[ALLOW] = OTHER;
+    await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
+    });
+    expectNoDurableSideEffects();
+  });
+
+  it('direct request for non-allowlisted business is denied even with crafted input', async () => {
+    process.env[FLAG] = '1';
+    process.env[ALLOW] = OTHER;
+    await expect(
+      createInventoryIncrease(baseInput({ businessId: BIZ, storeId: 'store-of-other' })),
+    ).rejects.toMatchObject({
+      code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
+    });
+    expectNoDurableSideEffects();
+  });
+
+  it('flag on + exact business allowlisted proceeds past the gate (then tenant checks apply)', async () => {
+    process.env[FLAG] = '1';
+    process.env[ALLOW] = BIZ;
+    // Fail at tenant/store binding to prove we passed the gate but still enforce tenancy.
+    prismaMock.store.findFirst.mockResolvedValue(null);
+    await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_INCREASE_ERROR.UNAUTHORISED,
+    });
+    expect(prismaMock.store.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'store-1', businessId: BIZ },
+      }),
+    );
+    expect(prismaMock.stockAdjustment.create).not.toHaveBeenCalled();
+  });
+});

--- a/lib/services/inventory-increase.test.ts
+++ b/lib/services/inventory-increase.test.ts
@@ -17,7 +17,7 @@ const {
   postJournalEntryMock,
   ensureInventoryIncreaseAccountsMock,
   incrementInventoryBalanceQtyOnlyMock,
-  isPhase2EnabledMock,
+  isPhase2EnabledForBusinessMock,
 } = vi.hoisted(() => ({
   prismaMock: {
     store: { findFirst: vi.fn() },
@@ -32,12 +32,12 @@ const {
   postJournalEntryMock: vi.fn(),
   ensureInventoryIncreaseAccountsMock: vi.fn(),
   incrementInventoryBalanceQtyOnlyMock: vi.fn(),
-  isPhase2EnabledMock: vi.fn(() => true),
+  isPhase2EnabledForBusinessMock: vi.fn(() => true),
 }));
 
 vi.mock('@/lib/prisma', () => ({ prisma: prismaMock }));
 vi.mock('@/lib/inventory-increase-flag', () => ({
-  isInventoryIncreasePhase2Enabled: isPhase2EnabledMock,
+  isInventoryIncreasePhase2EnabledForBusiness: isPhase2EnabledForBusinessMock,
 }));
 vi.mock('@/lib/accounting', async () => {
   const actual = await vi.importActual<typeof import('@/lib/accounting')>('@/lib/accounting');
@@ -153,7 +153,7 @@ describe('inventory increase helpers', () => {
 describe('createInventoryIncrease', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    isPhase2EnabledMock.mockReturnValue(true);
+    isPhase2EnabledForBusinessMock.mockReturnValue(true);
     process.env.DATABASE_URL = 'file:./dev.db';
 
     prismaMock.store.findFirst.mockResolvedValue({ id: STORE });
@@ -182,12 +182,23 @@ describe('createInventoryIncrease', () => {
     );
   });
 
-  it('rejects when the Phase 2 flag is off', async () => {
-    isPhase2EnabledMock.mockReturnValue(false);
+  it('rejects when the Phase 2 scoped gate is off (flag and/or allowlist)', async () => {
+    isPhase2EnabledForBusinessMock.mockReturnValue(false);
     await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
       code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
     });
     expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    expect(prismaMock.stockAdjustment.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.stockAdjustment.create).not.toHaveBeenCalled();
+    expect(prismaMock.stockMovement.create).not.toHaveBeenCalled();
+    expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
+    expect(postJournalEntryMock).not.toHaveBeenCalled();
+    expect(incrementInventoryBalanceQtyOnlyMock).not.toHaveBeenCalled();
+  });
+
+  it('passes the target businessId into the scoped eligibility helper', async () => {
+    await createInventoryIncrease(baseInput());
+    expect(isPhase2EnabledForBusinessMock).toHaveBeenCalledWith(BIZ);
   });
 
   it('Owner records PHYSICAL_COUNT_SURPLUS with Dr 1200 / Cr 4100', async () => {
@@ -232,6 +243,21 @@ describe('createInventoryIncrease', () => {
         }),
       }),
     );
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          businessId: BIZ,
+          action: 'INVENTORY_ADJUST',
+          details: expect.stringContaining('"scopedEligible":true'),
+        }),
+      }),
+    );
+    const auditDetails = JSON.parse(
+      prismaMock.auditLog.create.mock.calls[0][0].data.details as string,
+    );
+    expect(auditDetails.rolloutGate).toBe('phase2-business-allowlist');
+    expect(auditDetails.phase).toBe('inventory-increase-phase2');
+    expect(auditDetails).not.toHaveProperty('allowlist');
   });
 
   it('Manager records STOCK_FOUND', async () => {

--- a/lib/services/inventory-increase.ts
+++ b/lib/services/inventory-increase.ts
@@ -4,7 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { ACCOUNT_CODES, postJournalEntry } from '@/lib/accounting';
 import { ensureInventoryIncreaseAccounts } from '@/lib/accounting-inventory-increase-accounts';
 import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
-import { isInventoryIncreasePhase2Enabled } from '@/lib/inventory-increase-flag';
+import { isInventoryIncreasePhase2EnabledForBusiness } from '@/lib/inventory-increase-flag';
 import { incrementInventoryBalanceQtyOnly } from './shared';
 import { measureServerOperation, PERFORMANCE_THRESHOLDS_MS } from '@/lib/observability';
 
@@ -246,7 +246,8 @@ async function findByIdempotencyKey(storeId: string, idempotencyKey: string) {
 }
 
 /**
- * Phase 2 controlled quantity-increase. Requires rollout flag.
+ * Phase 2 controlled quantity-increase.
+ * Requires global Phase 2 flag AND exact business allowlist membership.
  * Inherits locked avgCostBasePence only — does not recompute WAC or accept user cost.
  */
 export async function createInventoryIncrease(
@@ -270,7 +271,8 @@ async function createInventoryIncreaseImpl(
   input: InventoryIncreaseInput,
   outerTx?: Prisma.TransactionClient,
 ): Promise<InventoryIncreaseResult> {
-  if (!isInventoryIncreasePhase2Enabled()) {
+  // Fail-closed scoped gate before any durable work (including idempotency reads).
+  if (!isInventoryIncreasePhase2EnabledForBusiness(input.businessId)) {
     throw new InventoryIncreaseError(
       INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
       'Inventory increase Phase 2 is not enabled',
@@ -560,6 +562,8 @@ async function createInventoryIncreaseImpl(
           entityId: created.id,
           details: JSON.stringify({
             phase: 'inventory-increase-phase2',
+            rolloutGate: 'phase2-business-allowlist',
+            scopedEligible: true,
             direction: 'INCREASE',
             reasonCode: input.reasonCode,
             reason: normalizedReason,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
         setupFiles: ['./vitest.setup.ts'],
         include: ['**/*.test.{ts,tsx}'],
         exclude: ['**/node_modules/**', '.next', 'tishgroup-control/**'],
-        pool: 'threads',
+        // forks: avoid Prisma N-API "failed to delete napi ref" teardown under threads (CI exit 134)
+        pool: 'forks',
         fileParallelism: false,
         maxWorkers: 1,
         isolate: true,


### PR DESCRIPTION
## Summary

- **Problem / blast radius:** Phase 2 inventory increase was gated only by the global env flag `TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE`. Enabling it in Production would expose controlled increases to every eligible Owner and Manager.
- **Change:** Require **both** the global flag **and** exact membership in `TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS` (immutable business IDs). Missing/invalid/empty allowlist fails closed. Wildcards like `*`, `all`, `true` never mean all businesses.
- **Enforcement:** Central helper `isInventoryIncreasePhase2EnabledForBusiness` used by `createInventoryIncrease` (before any durable work), the increase server action, and adjustments page visibility (UI is not the security boundary).
- **Preserved:** Phase 1 decrease, reasons `PHYSICAL_COUNT_SURPLUS` / `STOCK_FOUND`, locked avg cost, Dr 1200 / Cr 4100 INCOME, atomicity, idempotency, billing/role gates.
- **Audit:** Successful posts record `rolloutGate: phase2-business-allowlist` and `scopedEligible: true` (no full allowlist persisted).

### Fail-closed truth table

| Global flag | Business allowlisted | Result |
| --- | ---: | --- |
| Off/missing | No | Denied |
| Off/missing | Yes | Denied |
| On | No | Denied |
| On | Yes | Continue to role/billing/validation |

### Tests executed

- `vitest`: inventory increase flag/allowlist, scoped-gate, increase service, actions contracts, decrease regression, concurrency suite (skipped without Postgres) — **99 passed, 3 skipped**
- `tsc --noEmit` — **pass**
- `eslint` on touched files — **pass**

### Preview validation

Not performed in this task (non-negotiable: do not deploy; Preview only if authorised).

### Configuration / rollback

See `docs/INVENTORY_INCREASE_PHASE2_ROLLOUT.md`. Disabling the flag or removing a business ID prevents **new** postings; it does **not** reverse completed accounting entries. Env changes require redeploy on Vercel.

### Production status

**Production Phase 2 remains disabled.** This PR does **not** authorise Production allowlisting or enablement. Current Production deploy `dpl_EzwmbwU8NA5qjCUUqrBjPYMAqPzf` / `5c51e0c` unchanged by this work; Production env still has Phase 1 only.

### Deferred limitation

Cross-workflow concurrency with purchase, opening stock, transfer, return, and legacy absolute adjustments remains deferred. Do not adjust the same product through those workflows concurrently during early rollout.

### Explicit non-authorisation

**Merging this PR does not authorise Production allowlisting or Phase 2 enablement.**
