### PR TITLE
feat(inventory): Phase 2 general-release rollout mode

### DIFF
--- a/app/(protected)/inventory/StockAdjustmentClient.tsx
+++ b/app/(protected)/inventory/StockAdjustmentClient.tsx
@@ -436,7 +436,9 @@ export default function StockAdjustmentClient({
                 />
                 <span>
                   I confirm this is a physical-count surplus or genuinely found stock — not a
-                  purchase, return, transfer, sale correction, or opening balance.
+                  purchase, return, transfer, sale correction, or opening balance. I counted the
+                  product first, reviewed quantity and value, and will submit once (do not resubmit
+                  if the response is delayed).
                 </span>
               </label>
             </div>

--- a/lib/inventory-increase-flag.test.ts
+++ b/lib/inventory-increase-flag.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   INVENTORY_INCREASE_PHASE2_BUSINESS_IDS_ENV,
+  INVENTORY_INCREASE_PHASE2_ROLLOUT_MODE_ENV,
   isInventoryIncreasePhase2BusinessAllowlisted,
   isInventoryIncreasePhase2Enabled,
   isInventoryIncreasePhase2EnabledForBusiness,
   parseInventoryIncreasePhase2BusinessIds,
+  parseInventoryIncreasePhase2RolloutMode,
 } from './inventory-increase-flag';
 
 const FLAG = 'TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE';
 const ALLOW = INVENTORY_INCREASE_PHASE2_BUSINESS_IDS_ENV;
+const MODE = INVENTORY_INCREASE_PHASE2_ROLLOUT_MODE_ENV;
 
 const BIZ_A = 'cmexamplebiz00000000000001';
 const BIZ_B = 'cmexamplebiz00000000000002';
@@ -18,15 +21,18 @@ function env(partial: Record<string, string | undefined>): NodeJS.ProcessEnv {
   return partial as unknown as NodeJS.ProcessEnv;
 }
 
-describe('inventory increase Phase 2 flag + business allowlist', () => {
+describe('inventory increase Phase 2 flag + rollout mode + allowlist', () => {
   const previousFlag = process.env[FLAG];
   const previousAllow = process.env[ALLOW];
+  const previousMode = process.env[MODE];
 
   afterEach(() => {
     if (previousFlag === undefined) delete process.env[FLAG];
     else process.env[FLAG] = previousFlag;
     if (previousAllow === undefined) delete process.env[ALLOW];
     else process.env[ALLOW] = previousAllow;
+    if (previousMode === undefined) delete process.env[MODE];
+    else process.env[MODE] = previousMode;
   });
 
   it('global flag is enabled only when env is exactly 1', () => {
@@ -35,14 +41,33 @@ describe('inventory increase Phase 2 flag + business allowlist', () => {
     expect(isInventoryIncreasePhase2Enabled(env({ [FLAG]: '1' }))).toBe(true);
   });
 
+  it('rollout mode parses only ALLOWLIST and GENERAL (case-insensitive)', () => {
+    expect(parseInventoryIncreasePhase2RolloutMode(null)).toBeNull();
+    expect(parseInventoryIncreasePhase2RolloutMode('')).toBeNull();
+    expect(parseInventoryIncreasePhase2RolloutMode('allowlist')).toBe('ALLOWLIST');
+    expect(parseInventoryIncreasePhase2RolloutMode('GENERAL')).toBe('GENERAL');
+    expect(parseInventoryIncreasePhase2RolloutMode(' general ')).toBe('GENERAL');
+    expect(parseInventoryIncreasePhase2RolloutMode('OPEN')).toBeNull();
+    expect(parseInventoryIncreasePhase2RolloutMode('*')).toBeNull();
+    expect(parseInventoryIncreasePhase2RolloutMode('1')).toBeNull();
+  });
+
   it('missing configuration fails closed (no eligible businesses)', () => {
     expect(parseInventoryIncreasePhase2BusinessIds(null).size).toBe(0);
     expect(parseInventoryIncreasePhase2BusinessIds(undefined).size).toBe(0);
     expect(parseInventoryIncreasePhase2BusinessIds('').size).toBe(0);
     expect(parseInventoryIncreasePhase2BusinessIds('   ,  ,\t').size).toBe(0);
+    // Flag on but no mode → denied
     expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1' }))).toBe(
       false,
     );
+    // Flag on + allowlist but no mode → denied (mode is mandatory)
+    expect(
+      isInventoryIncreasePhase2EnabledForBusiness(
+        BIZ_A,
+        env({ [FLAG]: '1', [ALLOW]: BIZ_A }),
+      ),
+    ).toBe(false);
   });
 
   it('trims whitespace, ignores empty entries, and deduplicates', () => {
@@ -55,19 +80,58 @@ describe('inventory increase Phase 2 flag + business allowlist', () => {
     expect(ids.has(BIZ_C)).toBe(true);
   });
 
-  it('supports multiple allowlisted business IDs with exact membership', () => {
-    const e = env({ [FLAG]: '1', [ALLOW]: `${BIZ_A},${BIZ_B}` });
+  it('ALLOWLIST mode supports multiple exact IDs', () => {
+    const e = env({
+      [FLAG]: '1',
+      [MODE]: 'ALLOWLIST',
+      [ALLOW]: `${BIZ_A},${BIZ_B}`,
+    });
     expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, e)).toBe(true);
     expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_B, e)).toBe(true);
     expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_C, e)).toBe(false);
   });
 
-  it('rejects wildcard-like values (never means all businesses)', () => {
+  it('GENERAL mode permits any non-empty business ID when flag is on', () => {
+    const e = env({ [FLAG]: '1', [MODE]: 'GENERAL', [ALLOW]: BIZ_A });
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, e)).toBe(true);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_B, e)).toBe(true);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_C, e)).toBe(true);
+  });
+
+  it('GENERAL mode ignores allowlist contents (allowlist is not required)', () => {
+    const e = env({ [FLAG]: '1', [MODE]: 'GENERAL' });
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, e)).toBe(true);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_B, e)).toBe(true);
+  });
+
+  it('GENERAL mode still denied when global flag is off', () => {
+    const e = env({ [FLAG]: '0', [MODE]: 'GENERAL' });
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, e)).toBe(false);
+    expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [MODE]: 'GENERAL' }))).toBe(
+      false,
+    );
+  });
+
+  it('invalid rollout mode fails closed even with flag on and allowlist present', () => {
+    for (const bad of ['OPEN', 'ALL', '*', 'true', '1', 'allow', 'generalize', '']) {
+      expect(
+        isInventoryIncreasePhase2EnabledForBusiness(
+          BIZ_A,
+          env({ [FLAG]: '1', [MODE]: bad, [ALLOW]: BIZ_A }),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it('rejects wildcard-like allowlist values (never means all businesses)', () => {
     for (const token of ['*', 'all', 'ALL', 'true', 'TRUE', 'yes', '1', 'any', 'global', 'everyone']) {
       const ids = parseInventoryIncreasePhase2BusinessIds(token);
       expect(ids.size).toBe(0);
       expect(
-        isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1', [ALLOW]: token })),
+        isInventoryIncreasePhase2EnabledForBusiness(
+          BIZ_A,
+          env({ [FLAG]: '1', [MODE]: 'ALLOWLIST', [ALLOW]: token }),
+        ),
       ).toBe(false);
     }
   });
@@ -89,7 +153,7 @@ describe('inventory increase Phase 2 flag + business allowlist', () => {
   });
 
   it('rejects substring collisions (exact match only)', () => {
-    const e = env({ [FLAG]: '1', [ALLOW]: BIZ_A });
+    const e = env({ [FLAG]: '1', [MODE]: 'ALLOWLIST', [ALLOW]: BIZ_A });
     expect(isInventoryIncreasePhase2BusinessAllowlisted(BIZ_A, e)).toBe(true);
     expect(isInventoryIncreasePhase2BusinessAllowlisted(BIZ_A.slice(0, 12), e)).toBe(false);
     expect(isInventoryIncreasePhase2BusinessAllowlisted(`${BIZ_A}x`, e)).toBe(false);
@@ -97,49 +161,81 @@ describe('inventory increase Phase 2 flag + business allowlist', () => {
   });
 
   describe('fail-closed truth table', () => {
-    it('flag off + business absent → denied', () => {
-      expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '0' }))).toBe(
-        false,
-      );
-    });
-
-    it('flag off + business allowlisted → denied', () => {
+    it('flag off + any mode → denied', () => {
       expect(
-        isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '0', [ALLOW]: BIZ_A })),
+        isInventoryIncreasePhase2EnabledForBusiness(
+          BIZ_A,
+          env({ [FLAG]: '0', [MODE]: 'GENERAL' }),
+        ),
       ).toBe(false);
-      expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [ALLOW]: BIZ_A }))).toBe(
-        false,
-      );
+      expect(
+        isInventoryIncreasePhase2EnabledForBusiness(
+          BIZ_A,
+          env({ [FLAG]: '0', [MODE]: 'ALLOWLIST', [ALLOW]: BIZ_A }),
+        ),
+      ).toBe(false);
     });
 
-    it('flag on + business absent → denied', () => {
+    it('flag on + mode missing → denied', () => {
       expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1' }))).toBe(
         false,
       );
     });
 
-    it('flag on + different business allowlisted → denied', () => {
+    it('flag on + ALLOWLIST + empty allowlist → denied', () => {
       expect(
-        isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1', [ALLOW]: BIZ_B })),
+        isInventoryIncreasePhase2EnabledForBusiness(
+          BIZ_A,
+          env({ [FLAG]: '1', [MODE]: 'ALLOWLIST' }),
+        ),
       ).toBe(false);
     });
 
-    it('flag on + exact business allowlisted → allowed', () => {
+    it('flag on + ALLOWLIST + different business → denied', () => {
       expect(
-        isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, env({ [FLAG]: '1', [ALLOW]: BIZ_A })),
+        isInventoryIncreasePhase2EnabledForBusiness(
+          BIZ_A,
+          env({ [FLAG]: '1', [MODE]: 'ALLOWLIST', [ALLOW]: BIZ_B }),
+        ),
+      ).toBe(false);
+    });
+
+    it('flag on + ALLOWLIST + exact business → allowed', () => {
+      expect(
+        isInventoryIncreasePhase2EnabledForBusiness(
+          BIZ_A,
+          env({ [FLAG]: '1', [MODE]: 'ALLOWLIST', [ALLOW]: BIZ_A }),
+        ),
+      ).toBe(true);
+    });
+
+    it('flag on + GENERAL → allowed for any business id', () => {
+      expect(
+        isInventoryIncreasePhase2EnabledForBusiness(
+          BIZ_A,
+          env({ [FLAG]: '1', [MODE]: 'GENERAL' }),
+        ),
       ).toBe(true);
     });
   });
 
   it('null/empty business ids are never eligible', () => {
-    const e = env({ [FLAG]: '1', [ALLOW]: BIZ_A });
-    expect(isInventoryIncreasePhase2EnabledForBusiness(null, e)).toBe(false);
-    expect(isInventoryIncreasePhase2EnabledForBusiness('', e)).toBe(false);
-    expect(isInventoryIncreasePhase2EnabledForBusiness(undefined, e)).toBe(false);
+    const allowlist = env({ [FLAG]: '1', [MODE]: 'ALLOWLIST', [ALLOW]: BIZ_A });
+    const general = env({ [FLAG]: '1', [MODE]: 'GENERAL' });
+    for (const e of [allowlist, general]) {
+      expect(isInventoryIncreasePhase2EnabledForBusiness(null, e)).toBe(false);
+      expect(isInventoryIncreasePhase2EnabledForBusiness('', e)).toBe(false);
+      expect(isInventoryIncreasePhase2EnabledForBusiness(undefined, e)).toBe(false);
+      expect(isInventoryIncreasePhase2EnabledForBusiness('   ', e)).toBe(false);
+    }
   });
 
-  it('keeps wildcard tokens from enabling access even when mixed with a valid ID', () => {
-    const e = env({ [FLAG]: '1', [ALLOW]: `*,all,true,${BIZ_A},yes` });
+  it('keeps wildcard tokens from enabling ALLOWLIST access even when mixed with a valid ID', () => {
+    const e = env({
+      [FLAG]: '1',
+      [MODE]: 'ALLOWLIST',
+      [ALLOW]: `*,all,true,${BIZ_A},yes`,
+    });
     expect(parseInventoryIncreasePhase2BusinessIds(e[ALLOW]).size).toBe(1);
     expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_A, e)).toBe(true);
     expect(isInventoryIncreasePhase2EnabledForBusiness(BIZ_B, e)).toBe(false);

--- a/lib/inventory-increase-flag.ts
+++ b/lib/inventory-increase-flag.ts
@@ -3,19 +3,30 @@
  * Independent of Phase 1 decrease. When disabled, increase UI/actions must
  * hide or reject — never fall back to the legacy unhardened mutation.
  *
- * Production blast radius is controlled by TWO independent conditions:
+ * Access requires ALL of:
  *   1. Global flag TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE === "1"
- *   2. Exact business ID membership in TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS
+ *   2. Explicit rollout mode (see below)
+ *   3. Authenticated business membership + Owner/Manager (enforced outside this module)
  *
- * Both must be true. Missing/invalid/empty allowlist fails closed (no businesses).
- * Wildcard-like values never mean "all businesses".
+ * Rollout modes (TILLFLOW_INVENTORY_ADJUST_PHASE2_ROLLOUT_MODE):
+ *   - ALLOWLIST — only exact IDs in TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS
+ *   - GENERAL  — any business with a non-empty authenticated business ID
  *
- * Env allowlist is read via dynamic key access so Next.js does not inline a
- * build-time empty value over a runtime-configured allowlist.
+ * Missing, empty, or unknown rollout mode fails closed (deny everywhere),
+ * even when the global flag is on. Empty/absent allowlist never means "all".
+ * Wildcard-like allowlist tokens are rejected.
+ *
+ * Env values are read via dynamic key access so Next.js does not inline
+ * build-time empty values over runtime configuration.
  */
 
 export const INVENTORY_INCREASE_PHASE2_BUSINESS_IDS_ENV =
   'TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS' as const;
+
+export const INVENTORY_INCREASE_PHASE2_ROLLOUT_MODE_ENV =
+  'TILLFLOW_INVENTORY_ADJUST_PHASE2_ROLLOUT_MODE' as const;
+
+export type InventoryIncreasePhase2RolloutMode = 'ALLOWLIST' | 'GENERAL';
 
 /** Tokens that must never grant global or wildcard Phase 2 access. */
 const PHASE2_ALLOWLIST_REJECTED_TOKENS = new Set([
@@ -59,10 +70,19 @@ function readPhase2BusinessIdsEnv(
   return env[INVENTORY_INCREASE_PHASE2_BUSINESS_IDS_ENV];
 }
 
+function readPhase2RolloutModeEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  rawOverride?: string | null,
+): string | undefined | null {
+  if (rawOverride !== undefined) return rawOverride;
+  return env[INVENTORY_INCREASE_PHASE2_ROLLOUT_MODE_ENV];
+}
+
 /**
  * Parse the Phase 2 business allowlist.
  * Fail-closed: missing, empty, or fully invalid configuration → empty Set.
  * Never logs the allowlist. Exact membership only (no substring matching).
+ * Used only when rollout mode is ALLOWLIST.
  */
 export function parseInventoryIncreasePhase2BusinessIds(
   raw?: string | null,
@@ -81,6 +101,22 @@ export function parseInventoryIncreasePhase2BusinessIds(
   return ids;
 }
 
+/**
+ * Resolve explicit rollout mode.
+ * Only ALLOWLIST and GENERAL are accepted. Anything else (including missing) → null (fail closed).
+ */
+export function parseInventoryIncreasePhase2RolloutMode(
+  raw?: string | null,
+  env: NodeJS.ProcessEnv = process.env,
+): InventoryIncreasePhase2RolloutMode | null {
+  const value = readPhase2RolloutModeEnv(env, raw);
+  if (!value || typeof value !== 'string') return null;
+  const normalized = value.trim().toUpperCase();
+  if (normalized === 'ALLOWLIST') return 'ALLOWLIST';
+  if (normalized === 'GENERAL') return 'GENERAL';
+  return null;
+}
+
 export function isInventoryIncreasePhase2Enabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -89,8 +125,8 @@ export function isInventoryIncreasePhase2Enabled(
 
 /**
  * Exact allowlist membership for a business ID.
- * Does not consult the global flag — use isInventoryIncreasePhase2EnabledForBusiness
- * for the full gate.
+ * Does not consult the global flag or rollout mode — use
+ * isInventoryIncreasePhase2EnabledForBusiness for the full gate.
  */
 export function isInventoryIncreasePhase2BusinessAllowlisted(
   businessId: string | null | undefined,
@@ -103,15 +139,29 @@ export function isInventoryIncreasePhase2BusinessAllowlisted(
 
 /**
  * Authoritative Phase 2 eligibility for a business.
- * Requires global flag ON and exact allowlist membership.
+ * Requires global flag ON and an explicit valid rollout mode.
+ * - ALLOWLIST: exact allowlist membership required
+ * - GENERAL: any non-empty business ID is rollout-eligible (role/membership still enforced elsewhere)
  * Safe for UI visibility; must also be enforced on every posting path.
  */
 export function isInventoryIncreasePhase2EnabledForBusiness(
   businessId: string | null | undefined,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return (
-    isInventoryIncreasePhase2Enabled(env) &&
-    isInventoryIncreasePhase2BusinessAllowlisted(businessId, env)
-  );
+  if (!businessId || typeof businessId !== 'string' || !businessId.trim()) {
+    return false;
+  }
+  if (!isInventoryIncreasePhase2Enabled(env)) {
+    return false;
+  }
+
+  const mode = parseInventoryIncreasePhase2RolloutMode(undefined, env);
+  if (mode === 'GENERAL') {
+    return true;
+  }
+  if (mode === 'ALLOWLIST') {
+    return isInventoryIncreasePhase2BusinessAllowlisted(businessId, env);
+  }
+  // Missing / invalid / unknown mode → fail closed.
+  return false;
 }

--- a/lib/services/inventory-increase-scoped-gate.test.ts
+++ b/lib/services/inventory-increase-scoped-gate.test.ts
@@ -1,6 +1,6 @@
 /**
  * Service-level scoped-gate denials using the real flag helper (no mock).
- * Proves non-allowlisted / cross-config requests create no durable records.
+ * Proves non-allowlisted / invalid-mode / cross-config requests create no durable records.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ACCOUNT_CODES } from '@/lib/accounting';
@@ -51,6 +51,7 @@ vi.mock('./shared', async () => {
 
 const FLAG = 'TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE';
 const ALLOW = 'TILLFLOW_INVENTORY_ADJUST_PHASE2_BUSINESS_IDS';
+const MODE = 'TILLFLOW_INVENTORY_ADJUST_PHASE2_ROLLOUT_MODE';
 const BIZ = 'cmscopedgatebiz00000000001';
 const OTHER = 'cmscopedgatebiz00000000002';
 
@@ -81,9 +82,10 @@ function expectNoDurableSideEffects() {
   expect(incrementInventoryBalanceQtyOnlyMock).not.toHaveBeenCalled();
 }
 
-describe('createInventoryIncrease scoped allowlist (real flag helper)', () => {
+describe('createInventoryIncrease scoped gate (real flag helper)', () => {
   const previousFlag = process.env[FLAG];
   const previousAllow = process.env[ALLOW];
+  const previousMode = process.env[MODE];
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -111,10 +113,13 @@ describe('createInventoryIncrease scoped allowlist (real flag helper)', () => {
     else process.env[FLAG] = previousFlag;
     if (previousAllow === undefined) delete process.env[ALLOW];
     else process.env[ALLOW] = previousAllow;
+    if (previousMode === undefined) delete process.env[MODE];
+    else process.env[MODE] = previousMode;
   });
 
   it('flag off + allowlisted business → denied, no durable records', async () => {
     delete process.env[FLAG];
+    process.env[MODE] = 'ALLOWLIST';
     process.env[ALLOW] = BIZ;
     await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
       code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
@@ -122,8 +127,19 @@ describe('createInventoryIncrease scoped allowlist (real flag helper)', () => {
     expectNoDurableSideEffects();
   });
 
-  it('flag on + business absent → denied, no durable records', async () => {
+  it('flag on + mode missing → denied, no durable records', async () => {
     process.env[FLAG] = '1';
+    delete process.env[MODE];
+    process.env[ALLOW] = BIZ;
+    await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
+    });
+    expectNoDurableSideEffects();
+  });
+
+  it('flag on + ALLOWLIST + business absent → denied, no durable records', async () => {
+    process.env[FLAG] = '1';
+    process.env[MODE] = 'ALLOWLIST';
     delete process.env[ALLOW];
     await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
       code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
@@ -131,8 +147,9 @@ describe('createInventoryIncrease scoped allowlist (real flag helper)', () => {
     expectNoDurableSideEffects();
   });
 
-  it('flag on + different business allowlisted → denied, no durable records', async () => {
+  it('flag on + ALLOWLIST + different business allowlisted → denied, no durable records', async () => {
     process.env[FLAG] = '1';
+    process.env[MODE] = 'ALLOWLIST';
     process.env[ALLOW] = OTHER;
     await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
       code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
@@ -142,6 +159,7 @@ describe('createInventoryIncrease scoped allowlist (real flag helper)', () => {
 
   it('direct request for non-allowlisted business is denied even with crafted input', async () => {
     process.env[FLAG] = '1';
+    process.env[MODE] = 'ALLOWLIST';
     process.env[ALLOW] = OTHER;
     await expect(
       createInventoryIncrease(baseInput({ businessId: BIZ, storeId: 'store-of-other' })),
@@ -151,8 +169,9 @@ describe('createInventoryIncrease scoped allowlist (real flag helper)', () => {
     expectNoDurableSideEffects();
   });
 
-  it('flag on + exact business allowlisted proceeds past the gate (then tenant checks apply)', async () => {
+  it('flag on + ALLOWLIST + exact business proceeds past the gate (then tenant checks apply)', async () => {
     process.env[FLAG] = '1';
+    process.env[MODE] = 'ALLOWLIST';
     process.env[ALLOW] = BIZ;
     // Fail at tenant/store binding to prove we passed the gate but still enforce tenancy.
     prismaMock.store.findFirst.mockResolvedValue(null);
@@ -165,5 +184,31 @@ describe('createInventoryIncrease scoped allowlist (real flag helper)', () => {
       }),
     );
     expect(prismaMock.stockAdjustment.create).not.toHaveBeenCalled();
+  });
+
+  it('flag on + GENERAL proceeds past the gate without allowlist membership', async () => {
+    process.env[FLAG] = '1';
+    process.env[MODE] = 'GENERAL';
+    delete process.env[ALLOW];
+    prismaMock.store.findFirst.mockResolvedValue(null);
+    await expect(createInventoryIncrease(baseInput({ businessId: OTHER }))).rejects.toMatchObject({
+      code: INVENTORY_INCREASE_ERROR.UNAUTHORISED,
+    });
+    expect(prismaMock.store.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'store-1', businessId: OTHER },
+      }),
+    );
+    expect(prismaMock.stockAdjustment.create).not.toHaveBeenCalled();
+  });
+
+  it('flag on + invalid mode fails closed even with allowlist', async () => {
+    process.env[FLAG] = '1';
+    process.env[MODE] = 'OPEN';
+    process.env[ALLOW] = BIZ;
+    await expect(createInventoryIncrease(baseInput())).rejects.toMatchObject({
+      code: INVENTORY_INCREASE_ERROR.FLAG_DISABLED,
+    });
+    expectNoDurableSideEffects();
   });
 });


### PR DESCRIPTION
## Summary
- Add explicit `TILLFLOW_INVENTORY_ADJUST_PHASE2_ROLLOUT_MODE` (`ALLOWLIST` | `GENERAL`) for controlled general Production release of inventory increases.
- Keep global Phase 2 kill switch; missing/invalid mode fails closed; exact-ID allowlist preserved for canaries/rollback.
- Strengthen increase confirmation copy (count first, review value, submit once).

## Test plan
- [x] Unit: `lib/inventory-increase-flag.test.ts` (20/20)
- [x] `tsc --noEmit`
- [x] eslint on touched files
- [ ] CI unit suite on PR
- [ ] Production: set `ROLLOUT_MODE=GENERAL`, deploy, verify Owner/Manager visibility without posting

## Emergency kill switch
Turn off `TILLFLOW_INVENTORY_ADJUST_PHASE2_INCREASE` to deny all further increases.
