### PR TITLE
fix(mobile): Phase 1 P1 mobile discovery and operational lists

### DIFF
--- a/app/(protected)/customers/[id]/page.tsx
+++ b/app/(protected)/customers/[id]/page.tsx
@@ -2,6 +2,7 @@ import PageHeader from '@/components/PageHeader';
 import DownloadLink from '@/components/DownloadLink';
 import SubmitButton from '@/components/SubmitButton';
 import ResponsiveDataTable from '@/components/ResponsiveDataTable';
+import { DataCard, DataCardActions, DataCardField, DataCardHeader } from '@/components/DataCard';
 import TagChips from '@/components/TagChips';
 import { prisma } from '@/lib/prisma';
 import { requireBusiness } from '@/lib/auth';
@@ -90,6 +91,7 @@ export default async function CustomerDetailPage({
         select: {
           id: true,
           createdAt: true,
+          dueDate: true,
           paymentStatus: true,
           totalPence: true,
           payments: {
@@ -456,6 +458,7 @@ export default async function CustomerDetailPage({
           </div>
         </div>
         <ResponsiveDataTable
+          mode="cards"
           desktop={
             <div className="responsive-table-shell">
               <table className="table mt-4 w-full min-w-[48rem] border-separate border-spacing-y-2">
@@ -501,6 +504,78 @@ export default async function CustomerDetailPage({
                 </tbody>
               </table>
             </div>
+          }
+          mobile={
+            invoices.length === 0 ? (
+              <div className="mt-4 rounded-2xl border border-dashed border-black/15 bg-white px-5 py-6 text-center text-sm text-black/50">
+                <div className="font-semibold text-ink">No invoices yet.</div>
+                <div className="mt-1">When this customer buys on credit, their unpaid invoices will appear here.</div>
+              </div>
+            ) : (
+              <div className="mt-4 space-y-3">
+                {invoices.map((invoice) => {
+                  const paidAmount = Math.max(invoice.totalPence - invoice.balance, 0);
+                  const isOverdue =
+                    invoice.balance > 0 &&
+                    invoice.dueDate != null &&
+                    new Date(invoice.dueDate).getTime() < Date.now();
+
+                  return (
+                    <DataCard key={invoice.id}>
+                      <DataCardHeader
+                        title={<span className="font-mono">{invoice.id.slice(0, 8)}</span>}
+                        subtitle={formatDateTime(invoice.createdAt)}
+                        aside={
+                          <span className="font-semibold tabular-nums">
+                            {formatMoney(invoice.balance, business.currency)}
+                          </span>
+                        }
+                      />
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        <span className="pill bg-black/5 text-black/60">
+                          {STATUS_LABEL[invoice.paymentStatus] ?? invoice.paymentStatus}
+                        </span>
+                        {isOverdue ? (
+                          <span className="pill bg-rose-100 text-rose-700">Overdue</span>
+                        ) : null}
+                      </div>
+                      <div className="mt-3 grid grid-cols-2 gap-2">
+                        <DataCardField
+                          label="Original"
+                          value={formatMoney(invoice.totalPence, business.currency)}
+                          valueClassName="tabular-nums font-semibold"
+                        />
+                        <DataCardField
+                          label="Paid"
+                          value={formatMoney(paidAmount, business.currency)}
+                          valueClassName="tabular-nums"
+                        />
+                        {invoice.dueDate ? (
+                          <DataCardField
+                            label="Due"
+                            value={formatDate(invoice.dueDate)}
+                            className="col-span-2"
+                          />
+                        ) : null}
+                      </div>
+                      <DataCardActions>
+                        <Link className="btn-ghost text-xs" href={`/receipts/${invoice.id}`}>
+                          Print receipt
+                        </Link>
+                        {invoice.balance > 0 ? (
+                          <Link
+                            className="btn-primary text-xs"
+                            href={`/payments/customer-receipts?customerId=${customer.id}`}
+                          >
+                            Record payment
+                          </Link>
+                        ) : null}
+                      </DataCardActions>
+                    </DataCard>
+                  );
+                })}
+              </div>
+            )
           }
         />
       </div>

--- a/app/(protected)/payments/expense-payments/page.tsx
+++ b/app/(protected)/payments/expense-payments/page.tsx
@@ -2,10 +2,49 @@ import PageHeader from '@/components/PageHeader';
 import FormError from '@/components/FormError';
 import SubmitButton from '@/components/SubmitButton';
 import ResponsiveDataTable from '@/components/ResponsiveDataTable';
+import { DataCard, DataCardActions, DataCardField, DataCardHeader } from '@/components/DataCard';
 import { prisma } from '@/lib/prisma';
 import { requireBusiness } from '@/lib/auth';
 import { formatMoney, formatDateTime } from '@/lib/format';
 import { recordExpensePaymentAction } from '@/app/actions/expense-payments';
+
+function ExpensePaymentForm({ expenseId }: { expenseId: string }) {
+  return (
+    <form action={recordExpensePaymentAction} className="grid gap-2 sm:grid-cols-2">
+      <input type="hidden" name="expenseId" value={expenseId} />
+      <div>
+        <div className="text-xs text-black/50">Payment method</div>
+        <select className="input" name="method" defaultValue="CASH">
+          <option value="CASH">Cash</option>
+          <option value="CARD">Card</option>
+          <option value="TRANSFER">Transfer</option>
+          <option value="MOBILE_MONEY">Mobile Money</option>
+        </select>
+      </div>
+      <div>
+        <div className="text-xs text-black/50">Amount</div>
+        <input
+          className="input"
+          name="amount"
+          type="number"
+          min={0}
+          step="0.01"
+          inputMode="decimal"
+          placeholder="0.00"
+        />
+      </div>
+      <div className="sm:col-span-2">
+        <div className="text-xs text-black/50">Reference (optional)</div>
+        <input className="input" name="reference" placeholder="Receipt / transaction ref" />
+      </div>
+      <div className="sm:col-span-2">
+        <SubmitButton className="btn-primary w-full text-xs" loadingText="Recording…">
+          Record payment
+        </SubmitButton>
+      </div>
+    </form>
+  );
+}
 
 export default async function ExpensePaymentsPage({ searchParams }: { searchParams?: { error?: string } }) {
   const { business } = await requireBusiness(['MANAGER', 'OWNER']);
@@ -17,10 +56,11 @@ export default async function ExpensePaymentsPage({ searchParams }: { searchPara
       id: true,
       createdAt: true,
       amountPence: true,
+      paymentStatus: true,
       account: { select: { name: true } },
-      payments: { select: { amountPence: true } }
+      payments: { select: { amountPence: true } },
     },
-    orderBy: { createdAt: 'desc' }
+    orderBy: { createdAt: 'desc' },
   });
 
   return (
@@ -28,6 +68,7 @@ export default async function ExpensePaymentsPage({ searchParams }: { searchPara
       <PageHeader title="Expense Payments" subtitle="Settle unpaid operating expenses." />
       <FormError error={searchParams?.error} />
       <ResponsiveDataTable
+        mode="cards"
         desktop={
           <div className="card p-6">
             <div className="responsive-table-shell">
@@ -52,37 +93,7 @@ export default async function ExpensePaymentsPage({ searchParams }: { searchPara
                           {formatMoney(outstanding, business.currency)}
                         </td>
                         <td className="px-3 py-3">
-                          <form action={recordExpensePaymentAction} className="grid gap-2 md:grid-cols-2">
-                            <input type="hidden" name="expenseId" value={expense.id} />
-                            <div>
-                              <div className="text-xs text-black/50">Payment method</div>
-                              <select className="input" name="method" defaultValue="CASH">
-                                <option value="CASH">Cash</option>
-                                <option value="CARD">Card</option>
-                                <option value="TRANSFER">Transfer</option>
-                                <option value="MOBILE_MONEY">Mobile Money</option>
-                              </select>
-                            </div>
-                            <div>
-                              <div className="text-xs text-black/50">Amount</div>
-                              <input
-                                className="input"
-                                name="amount"
-                                type="number"
-                                min={0}
-                                step="0.01"
-                                inputMode="decimal"
-                                placeholder="0.00"
-                              />
-                            </div>
-                            <div className="md:col-span-2">
-                              <div className="text-xs text-black/50">Reference (optional)</div>
-                              <input className="input" name="reference" placeholder="Receipt / transaction ref" />
-                            </div>
-                            <div className="md:col-span-2">
-                              <SubmitButton className="btn-primary w-full text-xs" loadingText="Recording…">Record payment</SubmitButton>
-                            </div>
-                          </form>
+                          <ExpensePaymentForm expenseId={expense.id} />
                         </td>
                       </tr>
                     );
@@ -98,6 +109,51 @@ export default async function ExpensePaymentsPage({ searchParams }: { searchPara
               </table>
             </div>
           </div>
+        }
+        mobile={
+          expenses.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-black/15 bg-white px-5 py-6 text-center text-sm text-black/50">
+              No unpaid expenses.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {expenses.map((expense) => {
+                const paid = expense.payments.reduce((sum, payment) => sum + payment.amountPence, 0);
+                const outstanding = Math.max(expense.amountPence - paid, 0);
+                const statusLabel =
+                  expense.paymentStatus === 'PART_PAID'
+                    ? 'Part paid'
+                    : expense.paymentStatus === 'UNPAID'
+                      ? 'Unpaid'
+                      : expense.paymentStatus;
+
+                return (
+                  <DataCard key={expense.id}>
+                    <DataCardHeader
+                      title={expense.account.name}
+                      subtitle={formatDateTime(expense.createdAt)}
+                      aside={
+                        <span className="font-semibold tabular-nums text-amber-700">
+                          {formatMoney(outstanding, business.currency)}
+                        </span>
+                      }
+                    />
+                    <div className="mt-3 grid grid-cols-2 gap-2">
+                      <DataCardField label="Status" value={statusLabel} valueClassName="font-semibold text-amber-700" />
+                      <DataCardField
+                        label="Original amount"
+                        value={formatMoney(expense.amountPence, business.currency)}
+                        valueClassName="tabular-nums"
+                      />
+                    </div>
+                    <DataCardActions className="flex-col">
+                      <ExpensePaymentForm expenseId={expense.id} />
+                    </DataCardActions>
+                  </DataCard>
+                );
+              })}
+            </div>
+          )
         }
       />
     </div>

--- a/app/(protected)/payments/reconciliation/card-transfer/ReconciliationClient.tsx
+++ b/app/(protected)/payments/reconciliation/card-transfer/ReconciliationClient.tsx
@@ -116,45 +116,85 @@ export function TransactionDrillDown({
   }
 
   return (
-    <table className="table w-full min-w-[44rem] border-separate border-spacing-y-1">
-      <thead>
-        <tr>
-          <th>Time</th>
-          <th>Invoice</th>
-          <th>Customer</th>
-          <th>Amount</th>
-          <th>Reference</th>
-        </tr>
-      </thead>
-      <tbody>
+    <>
+      <div className="hidden lg:block">
+        <div className="responsive-table-shell">
+          <table className="table w-full min-w-[44rem] border-separate border-spacing-y-1">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Invoice</th>
+                <th>Customer</th>
+                <th>Amount</th>
+                <th>Reference</th>
+              </tr>
+            </thead>
+            <tbody>
+              {transactions.map((tx) => (
+                <tr key={tx.id} className="rounded-xl bg-white align-top">
+                  <td className="px-3 py-2 text-xs">
+                    {new Date(tx.receivedAt).toLocaleTimeString('en-GH', {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </td>
+                  <td className="px-3 py-2 text-xs">
+                    <Link
+                      className="text-emerald-700 hover:underline"
+                      href={`/receipts/${tx.salesInvoiceId}`}
+                    >
+                      {tx.salesInvoiceId.slice(0, 8)}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2 text-xs">
+                    {tx.customerName ?? <span className="text-black/40">Walk-in</span>}
+                  </td>
+                  <td className="px-3 py-2 text-sm font-semibold">
+                    {formatMoney(tx.amountPence, currency)}
+                  </td>
+                  <td className="px-3 py-2 text-xs font-mono">
+                    {tx.reference ?? <span className="text-black/40">—</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div className="space-y-2 lg:hidden">
         {transactions.map((tx) => (
-          <tr key={tx.id} className="rounded-xl bg-white align-top">
-            <td className="px-3 py-2 text-xs">
-              {new Date(tx.receivedAt).toLocaleTimeString('en-GH', {
-                hour: '2-digit',
-                minute: '2-digit',
-              })}
-            </td>
-            <td className="px-3 py-2 text-xs">
-              <Link
-                className="text-emerald-700 hover:underline"
-                href={`/receipts/${tx.salesInvoiceId}`}
-              >
-                {tx.salesInvoiceId.slice(0, 8)}
-              </Link>
-            </td>
-            <td className="px-3 py-2 text-xs">
-              {tx.customerName ?? <span className="text-black/40">Walk-in</span>}
-            </td>
-            <td className="px-3 py-2 text-sm font-semibold">
-              {formatMoney(tx.amountPence, currency)}
-            </td>
-            <td className="px-3 py-2 text-xs font-mono">
-              {tx.reference ?? <span className="text-black/40">—</span>}
-            </td>
-          </tr>
+          <div
+            key={tx.id}
+            className="rounded-xl border border-black/5 bg-white px-3 py-3"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-xs text-black/50">
+                  {new Date(tx.receivedAt).toLocaleTimeString('en-GH', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </div>
+                <div className="mt-1 text-sm font-semibold text-ink">
+                  {tx.customerName ?? 'Walk-in'}
+                </div>
+                <div className="mt-0.5 text-xs text-black/50">
+                  Invoice{' '}
+                  <Link className="text-emerald-700 hover:underline" href={`/receipts/${tx.salesInvoiceId}`}>
+                    {tx.salesInvoiceId.slice(0, 8)}
+                  </Link>
+                </div>
+              </div>
+              <div className="text-sm font-semibold tabular-nums">
+                {formatMoney(tx.amountPence, currency)}
+              </div>
+            </div>
+            <div className="mt-2 font-mono text-xs text-black/50">
+              Ref: {tx.reference ?? '—'}
+            </div>
+          </div>
         ))}
-      </tbody>
-    </table>
+      </div>
+    </>
   );
 }

--- a/app/(protected)/payments/reconciliation/card-transfer/page.tsx
+++ b/app/(protected)/payments/reconciliation/card-transfer/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 import PageHeader from '@/components/PageHeader';
+import ResponsiveDataTable from '@/components/ResponsiveDataTable';
+import { DataCard, DataCardActions, DataCardField, DataCardHeader } from '@/components/DataCard';
 import { formatMoney } from '@/lib/format';
 import { prisma } from '@/lib/prisma';
 import { requireBusiness } from '@/lib/auth';
@@ -202,96 +204,184 @@ export default async function CardTransferReconciliationPage({
         </div>
       </details>
 
-      {/* Main reconciliation table */}
-      <div className="card overflow-x-auto p-4">
-        <table className="table w-full min-w-[68rem] border-separate border-spacing-y-2">
-          <thead>
-            <tr>
-              <th>Date</th>
-              <th>Method</th>
-              <th>System Total</th>
-              <th>Actual Total</th>
-              <th>Variance</th>
-              <th>Status</th>
-              <th>Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => {
-              const methodTone =
-                row.method === 'CARD'
-                  ? 'bg-blue-100 text-blue-700'
-                  : 'bg-purple-100 text-purple-700';
-              const statusTone =
-                row.status === 'RECONCILED'
-                  ? 'bg-emerald-100 text-emerald-700'
-                  : row.status === 'DISCREPANCY'
-                    ? 'bg-rose-100 text-rose-700'
-                    : 'bg-amber-100 text-amber-800';
-              const varianceColor =
-                row.variancePence === null
-                  ? 'text-black/40'
-                  : row.variancePence === 0
-                    ? 'text-emerald-700'
-                    : row.variancePence > 0
-                      ? 'text-accent'
-                      : 'text-rose';
-              const detailKey = `${row.date}|${row.method}`;
-              const isDetailOpen = searchParams?.detail === detailKey;
-
-              return (
-                <tr key={detailKey} className="rounded-xl bg-white align-top">
-                  <td className="px-3 py-3 text-sm">
-                    <Link
-                      className="text-emerald-700 hover:underline"
-                      href={`/payments/reconciliation/card-transfer?from=${searchParams?.from ?? from.toISOString().slice(0, 10)}&to=${searchParams?.to ?? to.toISOString().slice(0, 10)}&storeId=${displayStoreId}&detail=${detailKey}`}
-                    >
-                      {row.date}
-                    </Link>
-                  </td>
-                  <td className="px-3 py-3">
-                    <span className={`pill ${methodTone}`}>
-                      {row.method === 'CARD' ? 'Card' : 'Transfer'}
-                    </span>
-                  </td>
-                  <td className="px-3 py-3 text-sm font-semibold">
-                    {formatMoney(row.systemTotalPence, business.currency)}
-                  </td>
-                  <td className="px-3 py-3 text-sm">
-                    {row.actualTotalPence !== null
-                      ? formatMoney(row.actualTotalPence, business.currency)
-                      : <span className="text-black/40">—</span>}
-                  </td>
-                  <td className={`px-3 py-3 text-sm font-semibold ${varianceColor}`}>
-                    {row.variancePence !== null
-                      ? formatMoney(row.variancePence, business.currency)
-                      : '—'}
-                  </td>
-                  <td className="px-3 py-3">
-                    <span className={`pill ${statusTone}`}>{row.status}</span>
-                  </td>
-                  <td className="px-3 py-3">
-                    <ReconcileForm
-                      date={row.date}
-                      method={row.method}
-                      storeId={resolvedStoreId}
-                      systemTotalPence={row.systemTotalPence}
-                      currency={business.currency}
-                    />
-                  </td>
+      {/* Main reconciliation list */}
+      <ResponsiveDataTable
+        mode="cards"
+        desktop={
+          <div className="card overflow-x-auto p-4">
+            <table className="table w-full min-w-[68rem] border-separate border-spacing-y-2">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Method</th>
+                  <th>System Total</th>
+                  <th>Actual Total</th>
+                  <th>Variance</th>
+                  <th>Status</th>
+                  <th>Action</th>
                 </tr>
-              );
-            })}
-            {rows.length === 0 ? (
-              <tr>
-                <td colSpan={7} className="px-3 py-8 text-center text-sm text-black/50">
-                  No card or transfer payments found for this period.
-                </td>
-              </tr>
-            ) : null}
-          </tbody>
-        </table>
-      </div>
+              </thead>
+              <tbody>
+                {rows.map((row) => {
+                  const methodTone =
+                    row.method === 'CARD'
+                      ? 'bg-blue-100 text-blue-700'
+                      : 'bg-purple-100 text-purple-700';
+                  const statusTone =
+                    row.status === 'RECONCILED'
+                      ? 'bg-emerald-100 text-emerald-700'
+                      : row.status === 'DISCREPANCY'
+                        ? 'bg-rose-100 text-rose-700'
+                        : 'bg-amber-100 text-amber-800';
+                  const varianceColor =
+                    row.variancePence === null
+                      ? 'text-black/40'
+                      : row.variancePence === 0
+                        ? 'text-emerald-700'
+                        : row.variancePence > 0
+                          ? 'text-accent'
+                          : 'text-rose';
+                  const detailKey = `${row.date}|${row.method}`;
+
+                  return (
+                    <tr key={detailKey} className="rounded-xl bg-white align-top">
+                      <td className="px-3 py-3 text-sm">
+                        <Link
+                          className="text-emerald-700 hover:underline"
+                          href={`/payments/reconciliation/card-transfer?from=${searchParams?.from ?? from.toISOString().slice(0, 10)}&to=${searchParams?.to ?? to.toISOString().slice(0, 10)}&storeId=${displayStoreId}&detail=${detailKey}`}
+                        >
+                          {row.date}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-3">
+                        <span className={`pill ${methodTone}`}>
+                          {row.method === 'CARD' ? 'Card' : 'Transfer'}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3 text-sm font-semibold">
+                        {formatMoney(row.systemTotalPence, business.currency)}
+                      </td>
+                      <td className="px-3 py-3 text-sm">
+                        {row.actualTotalPence !== null
+                          ? formatMoney(row.actualTotalPence, business.currency)
+                          : <span className="text-black/40">—</span>}
+                      </td>
+                      <td className={`px-3 py-3 text-sm font-semibold ${varianceColor}`}>
+                        {row.variancePence !== null
+                          ? formatMoney(row.variancePence, business.currency)
+                          : '—'}
+                      </td>
+                      <td className="px-3 py-3">
+                        <span className={`pill ${statusTone}`}>{row.status}</span>
+                      </td>
+                      <td className="px-3 py-3">
+                        <ReconcileForm
+                          date={row.date}
+                          method={row.method}
+                          storeId={resolvedStoreId}
+                          systemTotalPence={row.systemTotalPence}
+                          currency={business.currency}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+                {rows.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-3 py-8 text-center text-sm text-black/50">
+                      No card or transfer payments found for this period.
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        }
+        mobile={
+          rows.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-black/15 bg-white px-5 py-6 text-center text-sm text-black/50">
+              No card or transfer payments found for this period.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {rows.map((row) => {
+                const methodTone =
+                  row.method === 'CARD'
+                    ? 'bg-blue-100 text-blue-700'
+                    : 'bg-purple-100 text-purple-700';
+                const statusTone =
+                  row.status === 'RECONCILED'
+                    ? 'bg-emerald-100 text-emerald-700'
+                    : row.status === 'DISCREPANCY'
+                      ? 'bg-rose-100 text-rose-700'
+                      : 'bg-amber-100 text-amber-800';
+                const varianceColor =
+                  row.variancePence === null
+                    ? 'text-black/40'
+                    : row.variancePence === 0
+                      ? 'text-emerald-700'
+                      : row.variancePence > 0
+                        ? 'text-accent'
+                        : 'text-rose';
+                const detailKey = `${row.date}|${row.method}`;
+                const detailHref = `/payments/reconciliation/card-transfer?from=${searchParams?.from ?? from.toISOString().slice(0, 10)}&to=${searchParams?.to ?? to.toISOString().slice(0, 10)}&storeId=${displayStoreId}&detail=${detailKey}`;
+
+                return (
+                  <DataCard key={detailKey}>
+                    <DataCardHeader
+                      title={row.date}
+                      subtitle={row.method === 'CARD' ? 'Card' : 'Transfer'}
+                      aside={
+                        <span className="font-semibold tabular-nums">
+                          {formatMoney(row.systemTotalPence, business.currency)}
+                        </span>
+                      }
+                    />
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <span className={`pill ${methodTone}`}>
+                        {row.method === 'CARD' ? 'Card' : 'Transfer'}
+                      </span>
+                      <span className={`pill ${statusTone}`}>{row.status}</span>
+                    </div>
+                    <div className="mt-3 grid grid-cols-2 gap-2">
+                      <DataCardField
+                        label="Actual"
+                        value={
+                          row.actualTotalPence !== null
+                            ? formatMoney(row.actualTotalPence, business.currency)
+                            : '—'
+                        }
+                        valueClassName="tabular-nums"
+                      />
+                      <DataCardField
+                        label="Variance"
+                        value={
+                          row.variancePence !== null
+                            ? formatMoney(row.variancePence, business.currency)
+                            : '—'
+                        }
+                        valueClassName={`tabular-nums font-semibold ${varianceColor}`}
+                      />
+                    </div>
+                    <DataCardActions className="flex-col items-stretch">
+                      <Link className="btn-ghost text-xs text-center" href={detailHref}>
+                        View transactions
+                      </Link>
+                      <ReconcileForm
+                        date={row.date}
+                        method={row.method}
+                        storeId={resolvedStoreId}
+                        systemTotalPence={row.systemTotalPence}
+                        currency={business.currency}
+                      />
+                    </DataCardActions>
+                  </DataCard>
+                );
+              })}
+            </div>
+          )
+        }
+      />
 
       {/* Drill-down panel */}
       {drillDownTransactions && drillDownTransactions.success ? (

--- a/app/(protected)/payments/reconciliation/page.tsx
+++ b/app/(protected)/payments/reconciliation/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import PageHeader from '@/components/PageHeader';
 import SubmitButton from '@/components/SubmitButton';
 import ResponsiveDataTable from '@/components/ResponsiveDataTable';
+import { DataCard, DataCardActions, DataCardField, DataCardHeader } from '@/components/DataCard';
 import { formatDateTime, formatMoney } from '@/lib/format';
 import { prisma } from '@/lib/prisma';
 import { requireBusiness } from '@/lib/auth';
@@ -197,6 +198,7 @@ export default async function MomoReconciliationPage({
       </div>
 
       <ResponsiveDataTable
+        mode="cards"
         desktop={
           <div className="card p-4">
             <div className="responsive-table-shell">
@@ -313,6 +315,91 @@ export default async function MomoReconciliationPage({
               </table>
             </div>
           </div>
+        }
+        mobile={
+          collections.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-black/15 bg-white px-5 py-6 text-center text-sm text-black/50">
+              No mobile money collections yet.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {collections.map((collection) => {
+                const statusTone =
+                  collection.status === 'CONFIRMED'
+                    ? 'bg-emerald-100 text-emerald-700'
+                    : collection.status === 'PENDING'
+                      ? 'bg-amber-100 text-amber-800'
+                      : 'bg-rose-100 text-rose-700';
+                const reference =
+                  collection.providerTransactionId ??
+                  collection.providerReference ??
+                  collection.id.slice(0, 8);
+                const canReinitiate = collection.status === 'FAILED' || collection.status === 'TIMEOUT';
+
+                return (
+                  <DataCard key={collection.id}>
+                    <DataCardHeader
+                      title={collection.payerMsisdn}
+                      subtitle={`${formatDateTime(collection.initiatedAt)} · ${collection.network} | ${collection.provider}`}
+                      aside={
+                        <span className="font-semibold tabular-nums">
+                          {formatMoney(collection.amountPence, collection.currency || business.currency)}
+                        </span>
+                      }
+                    />
+                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                      <span className={`pill ${statusTone}`}>{collection.status}</span>
+                      <span className="text-xs text-black/50">{collection.providerStatus ?? '—'}</span>
+                    </div>
+                    <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-black/60">
+                      <DataCardField label="Provider ref" value={<span className="font-mono">{reference}</span>} />
+                      <DataCardField
+                        label="TillFlow sale"
+                        value={
+                          collection.salesInvoiceId ? (
+                            <Link className="text-emerald-700 hover:underline" href={`/receipts/${collection.salesInvoiceId}`}>
+                              {collection.salesInvoiceId.slice(0, 8)}
+                            </Link>
+                          ) : (
+                            'Not linked'
+                          )
+                        }
+                      />
+                    </div>
+                    {collection.lastCheckedAt ? (
+                      <div className="mt-2 text-[11px] text-black/45">
+                        Last checked: {formatDateTime(collection.lastCheckedAt)}
+                      </div>
+                    ) : null}
+                    {collection.failureReason ? (
+                      <details className="mt-2">
+                        <summary className="cursor-pointer text-xs text-rose hover:underline">
+                          Payment failed — Show reason
+                        </summary>
+                        <div className="mt-1 font-mono text-[11px] text-rose/80">{collection.failureReason}</div>
+                      </details>
+                    ) : null}
+                    <DataCardActions>
+                      <form action={recheckMomoCollectionAction} className="flex-1">
+                        <input type="hidden" name="collectionId" value={collection.id} />
+                        <SubmitButton className="btn-ghost w-full text-xs" loadingText="Checking...">
+                          Re-check
+                        </SubmitButton>
+                      </form>
+                      {canReinitiate ? (
+                        <form action={reinitiateMomoCollectionAction} className="flex-1">
+                          <input type="hidden" name="collectionId" value={collection.id} />
+                          <SubmitButton className="btn-secondary w-full text-xs" loadingText="Retrying...">
+                            Re-initiate
+                          </SubmitButton>
+                        </form>
+                      ) : null}
+                    </DataCardActions>
+                  </DataCard>
+                );
+              })}
+            </div>
+          )
         }
       />
     </div>

--- a/components/ResponsiveDataTable.tsx
+++ b/components/ResponsiveDataTable.tsx
@@ -1,19 +1,60 @@
 import type { ReactNode } from 'react';
 
-export default function ResponsiveDataTable({
-  desktop,
-  mobile,
-  mode = 'table',
-  mobileClassName = 'space-y-3 lg:hidden',
-  desktopClassName,
-}: {
+export type ResponsiveDataTableMode = 'cards' | 'dense-ledger' | 'desktop-only';
+
+type BaseProps = {
   desktop: ReactNode;
-  mobile?: ReactNode;
-  mode?: 'table' | 'cards';
   mobileClassName?: string;
   desktopClassName?: string;
-}) {
-  if (mode === 'cards' && mobile) {
+};
+
+type CardsModeProps = BaseProps & {
+  /** Operational list — requires an adapted mobile card/list representation. */
+  mode: 'cards';
+  mobile: ReactNode;
+};
+
+type DenseLedgerModeProps = BaseProps & {
+  /**
+   * Approved dense ledger/report — controlled horizontal scrolling is allowed.
+   * Prefer a mobile renderer when row identity and actions would otherwise be trapped.
+   */
+  mode: 'dense-ledger';
+  mobile?: ReactNode;
+};
+
+type DesktopOnlyModeProps = BaseProps & {
+  /**
+   * Explicit desktop-only presentation. Must be intentional and approved —
+   * do not use for Money/Stock operational lists.
+   */
+  mode: 'desktop-only';
+  mobile?: never;
+};
+
+export type ResponsiveDataTableProps = CardsModeProps | DenseLedgerModeProps | DesktopOnlyModeProps;
+
+/**
+ * Shared responsive list contract.
+ *
+ * - `cards`: mobile card/list + desktop table (required for operational Money/Stock lists)
+ * - `dense-ledger`: controlled overflow ledger; optional mobile renderer
+ * - `desktop-only`: intentional desktop-only (must not silently trap operational workflows)
+ */
+export default function ResponsiveDataTable(props: ResponsiveDataTableProps) {
+  const {
+    desktop,
+    mobile,
+    mode,
+    mobileClassName = 'space-y-3 lg:hidden',
+    desktopClassName,
+  } = props;
+
+  if (mode === 'cards') {
+    if (mobile == null && process.env.NODE_ENV !== 'production') {
+      throw new Error('ResponsiveDataTable mode="cards" requires a mobile renderer.');
+    }
+
     const resolvedDesktopClassName = desktopClassName ?? 'hidden lg:block';
 
     return (
@@ -24,11 +65,26 @@ export default function ResponsiveDataTable({
     );
   }
 
+  if (mode === 'dense-ledger') {
+    if (mobile != null) {
+      const resolvedDesktopClassName = desktopClassName ?? 'hidden lg:block';
+      return (
+        <>
+          <div className={mobileClassName}>{mobile}</div>
+          <div className={resolvedDesktopClassName}>{desktop}</div>
+        </>
+      );
+    }
+
+    return (
+      <div className={desktopClassName ?? 'responsive-table-shell overflow-x-auto'}>{desktop}</div>
+    );
+  }
+
+  // desktop-only
   if (!desktopClassName) {
     return <>{desktop}</>;
   }
 
-  return (
-    <div className={desktopClassName}>{desktop}</div>
-  );
+  return <div className={desktopClassName}>{desktop}</div>;
 }

--- a/lib/layout/mobile-overflow.test.ts
+++ b/lib/layout/mobile-overflow.test.ts
@@ -24,6 +24,23 @@ describe('mobile overflow guards', () => {
     expect(globals).toContain('minmax(0, 1fr)');
   });
 
+  it('keeps P1 operational Money/Stock lists on the cards responsive contract', () => {
+    const responsiveTable = read('components/ResponsiveDataTable.tsx');
+    expect(responsiveTable).toContain("mode: 'cards'");
+    expect(responsiveTable).toContain("mode: 'dense-ledger'");
+    expect(responsiveTable).toContain("mode: 'desktop-only'");
+
+    for (const path of [
+      'app/(protected)/payments/reconciliation/page.tsx',
+      'app/(protected)/payments/expense-payments/page.tsx',
+      'app/(protected)/customers/[id]/page.tsx',
+    ]) {
+      const src = read(path);
+      expect(src).toContain('mode="cards"');
+      expect(src).toContain('mobile=');
+    }
+  });
+
   it('keeps shared search and page header wrappers shrink-safe on mobile', () => {
     expect(searchFilter).toContain('min-w-0 w-full');
     expect(searchFilter).toContain('min-w-0 w-full flex-1');

--- a/lib/navigation/menu-simplification.test.ts
+++ b/lib/navigation/menu-simplification.test.ts
@@ -184,7 +184,18 @@ describe('T4 role-based business launcher menu', () => {
     const hrefs = sections.flatMap((section) => section.items.map((item) => item.href));
 
     expect(hrefs).toEqual(
-      expect.arrayContaining(['/products', '/customers', '/suppliers', '/reports', '/settings', '/account']),
+      expect.arrayContaining([
+        '/products',
+        '/customers',
+        '/suppliers',
+        '/reports',
+        '/settings',
+        '/account',
+        '/expenses',
+        '/payments/supplier-aging',
+        '/inventory/adjustments',
+        '/inventory/stocktake',
+      ]),
     );
     expect(hrefs).not.toContain('/users');
     expect(hrefs).not.toContain('/help');

--- a/lib/navigation/mobile-menu-config.ts
+++ b/lib/navigation/mobile-menu-config.ts
@@ -102,6 +102,14 @@ export const OWNER_BROWSE_AREAS: MobileBrowseArea[] = [
     description: 'Receive stock and manage supplier activity.',
     items: [
       { href: '/inventory', label: 'Inventory', iconKey: 'inventory', roles: ['OWNER'] },
+      { href: '/inventory/adjustments', label: 'Stock Adjustments', iconKey: 'stockAdjustments', roles: ['OWNER'] },
+      {
+        href: '/inventory/stocktake',
+        label: 'Stocktake',
+        iconKey: 'inventory',
+        roles: ['OWNER'],
+        minimumPlan: 'GROWTH',
+      },
       { href: '/purchases', label: 'Purchases', iconKey: 'purchases', roles: ['OWNER'] },
       { href: '/suppliers', label: 'Suppliers', iconKey: 'suppliers', roles: ['OWNER'] },
       { href: '/transfers', label: 'Transfers', iconKey: 'transfers', roles: ['OWNER'] },
@@ -113,9 +121,18 @@ export const OWNER_BROWSE_AREAS: MobileBrowseArea[] = [
     description: 'Track cash, payments, and expenses.',
     items: [
       { href: '/expenses', label: 'Expenses', iconKey: 'expenses', roles: ['OWNER'] },
+      { href: '/payments/expense-payments', label: 'Expense payments', iconKey: 'expenses', roles: ['OWNER'] },
       { href: '/reports/cash-drawer', label: 'Cash drawer', iconKey: 'cashDrawer', roles: ['OWNER'] },
       { href: '/payments/customer-receipts', label: 'Customer payments', iconKey: 'payments', roles: ['OWNER'] },
       { href: '/payments/supplier-payments', label: 'Supplier payments', iconKey: 'payments', roles: ['OWNER'] },
+      { href: '/payments/supplier-aging', label: 'Supplier Ageing', iconKey: 'supplierAging', roles: ['OWNER'] },
+      { href: '/payments/reconciliation', label: 'MoMo reconciliation', iconKey: 'reconciliation', roles: ['OWNER'] },
+      {
+        href: '/payments/reconciliation/card-transfer',
+        label: 'Card/Transfer reconciliation',
+        iconKey: 'reconciliation',
+        roles: ['OWNER'],
+      },
     ],
   },
   {
@@ -164,10 +181,46 @@ export const MANAGER_MENU_SECTIONS: MobileBrowseArea[] = [
     items: [
       { href: '/pos', label: 'POS', iconKey: 'pos', roles: ['MANAGER'] },
       { href: '/sales', label: 'Sales', iconKey: 'sales', roles: ['MANAGER'] },
-      { href: '/inventory', label: 'Inventory', iconKey: 'inventory', roles: ['MANAGER'] },
-      { href: '/purchases', label: 'Purchases', iconKey: 'purchases', roles: ['MANAGER'] },
       { href: '/products', label: 'Products', iconKey: 'products', roles: ['MANAGER'] },
       { href: '/shifts', label: 'Shifts', iconKey: 'shifts', roles: ['MANAGER'] },
+    ],
+  },
+  {
+    id: 'stock',
+    label: 'Stock',
+    description: 'Count, adjust, and move inventory.',
+    items: [
+      { href: '/inventory', label: 'Inventory', iconKey: 'inventory', roles: ['MANAGER'] },
+      { href: '/inventory/adjustments', label: 'Stock Adjustments', iconKey: 'stockAdjustments', roles: ['MANAGER'] },
+      {
+        href: '/inventory/stocktake',
+        label: 'Stocktake',
+        iconKey: 'inventory',
+        roles: ['MANAGER'],
+        minimumPlan: 'GROWTH',
+      },
+      { href: '/purchases', label: 'Purchases', iconKey: 'purchases', roles: ['MANAGER'] },
+      { href: '/transfers', label: 'Transfers', iconKey: 'transfers', roles: ['MANAGER'] },
+    ],
+  },
+  {
+    id: 'money',
+    label: 'Money',
+    description: 'Cash, payments, expenses, and reconciliation.',
+    items: [
+      { href: '/expenses', label: 'Expenses', iconKey: 'expenses', roles: ['MANAGER'] },
+      { href: '/payments/expense-payments', label: 'Expense payments', iconKey: 'expenses', roles: ['MANAGER'] },
+      { href: '/reports/cash-drawer', label: 'Cash drawer', iconKey: 'cashDrawer', roles: ['MANAGER'] },
+      { href: '/payments/customer-receipts', label: 'Customer payments', iconKey: 'payments', roles: ['MANAGER'] },
+      { href: '/payments/supplier-payments', label: 'Supplier payments', iconKey: 'payments', roles: ['MANAGER'] },
+      { href: '/payments/supplier-aging', label: 'Supplier Ageing', iconKey: 'supplierAging', roles: ['MANAGER'] },
+      { href: '/payments/reconciliation', label: 'MoMo reconciliation', iconKey: 'reconciliation', roles: ['MANAGER'] },
+      {
+        href: '/payments/reconciliation/card-transfer',
+        label: 'Card/Transfer reconciliation',
+        iconKey: 'reconciliation',
+        roles: ['MANAGER'],
+      },
     ],
   },
   {
@@ -188,6 +241,25 @@ export const MANAGER_MENU_SECTIONS: MobileBrowseArea[] = [
     ],
   },
 ];
+
+/**
+ * Critical Money and Stock operational routes that must remain discoverable on mobile
+ * for authorised Owner/Manager roles (direct section link or explicit Hub destination).
+ * Used by navigation parity tests — keep in sync with OWNER_BROWSE_AREAS / MANAGER_MENU_SECTIONS.
+ */
+export const CRITICAL_MOBILE_OPERATIONAL_HREFS = [
+  '/payments/supplier-aging',
+  '/payments/reconciliation',
+  '/payments/reconciliation/card-transfer',
+  '/inventory/adjustments',
+  '/inventory/stocktake',
+  '/expenses',
+  '/payments/expense-payments',
+  '/payments/customer-receipts',
+  '/payments/supplier-payments',
+  '/reports/cash-drawer',
+  '/transfers',
+] as const;
 
 /** Cashier More sheet links — mirrors desktop Sell/Admin for cashiers when POS hides bottom tabs. */
 export const CASHIER_MENU_ITEMS: MobileNavLink[] = [

--- a/lib/navigation/mobile-parity-p1.test.ts
+++ b/lib/navigation/mobile-parity-p1.test.ts
@@ -1,0 +1,235 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  CRITICAL_MOBILE_OPERATIONAL_HREFS,
+  getCashierMenu,
+  getManagerMenu,
+  getOwnerLauncherMenu,
+  MANAGER_MENU_SECTIONS,
+  OWNER_BROWSE_AREAS,
+} from '@/lib/navigation/mobile-menu-config';
+import { NAV_GROUPS } from '@/lib/navigation-config';
+import { getFeatures } from '@/lib/features';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+
+const ownerContext = {
+  role: 'OWNER' as const,
+  features: getFeatures('PRO', 'MULTI_STORE', { onlineStorefront: true }),
+  momoEnabled: true,
+};
+
+const managerContext = {
+  role: 'MANAGER' as const,
+  features: getFeatures('PRO', 'MULTI_STORE'),
+  momoEnabled: true,
+};
+
+const cashierContext = {
+  role: 'CASHIER' as const,
+  features: getFeatures('STARTER', 'SINGLE_STORE'),
+  momoEnabled: true,
+};
+
+const starterOwnerContext = {
+  role: 'OWNER' as const,
+  features: getFeatures('STARTER', 'SINGLE_STORE'),
+  momoEnabled: false,
+};
+
+function desktopRolesForHref(href: string) {
+  for (const group of NAV_GROUPS) {
+    const item = group.items.find((entry) => entry.href === href);
+    if (item) return item.roles;
+  }
+  // Expense payments is authorised for Manager/Owner but not listed in desktop NAV_GROUPS.
+  if (href === '/payments/expense-payments') return ['MANAGER', 'OWNER'] as const;
+  return null;
+}
+
+describe('P1 mobile navigation parity', () => {
+  it('exposes critical Owner Money and Stock routes directly in mobile browse areas', () => {
+    const ownerMenu = getOwnerLauncherMenu(ownerContext);
+    const money = ownerMenu.browseAreas.find((area) => area.id === 'money');
+    const stock = ownerMenu.browseAreas.find((area) => area.id === 'stock-suppliers');
+    const moneyHrefs = money?.items.map((item) => item.href) ?? [];
+    const stockHrefs = stock?.items.map((item) => item.href) ?? [];
+    const allHrefs = ownerMenu.browseAreas.flatMap((area) => area.items.map((item) => item.href));
+
+    expect(moneyHrefs).toEqual(
+      expect.arrayContaining([
+        '/expenses',
+        '/payments/expense-payments',
+        '/reports/cash-drawer',
+        '/payments/customer-receipts',
+        '/payments/supplier-payments',
+        '/payments/supplier-aging',
+        '/payments/reconciliation',
+        '/payments/reconciliation/card-transfer',
+      ]),
+    );
+    expect(stockHrefs).toEqual(
+      expect.arrayContaining([
+        '/inventory/adjustments',
+        '/inventory/stocktake',
+        '/transfers',
+      ]),
+    );
+
+    for (const href of CRITICAL_MOBILE_OPERATIONAL_HREFS) {
+      expect(allHrefs).toContain(href);
+    }
+  });
+
+  it('exposes critical Manager Money and Stock routes directly in mobile sections', () => {
+    const sections = getManagerMenu(managerContext);
+    const money = sections.find((area) => area.id === 'money');
+    const stock = sections.find((area) => area.id === 'stock');
+    const allHrefs = sections.flatMap((section) => section.items.map((item) => item.href));
+
+    expect(MANAGER_MENU_SECTIONS.map((section) => section.id)).toEqual(
+      expect.arrayContaining(['operations', 'stock', 'money', 'people', 'reports-settings']),
+    );
+    expect(money?.items.map((item) => item.href)).toEqual(
+      expect.arrayContaining([
+        '/expenses',
+        '/payments/expense-payments',
+        '/reports/cash-drawer',
+        '/payments/customer-receipts',
+        '/payments/supplier-payments',
+        '/payments/supplier-aging',
+        '/payments/reconciliation',
+        '/payments/reconciliation/card-transfer',
+      ]),
+    );
+    expect(stock?.items.map((item) => item.href)).toEqual(
+      expect.arrayContaining(['/inventory/adjustments', '/inventory/stocktake', '/transfers']),
+    );
+
+    for (const href of CRITICAL_MOBILE_OPERATIONAL_HREFS) {
+      expect(allHrefs).toContain(href);
+    }
+  });
+
+  it('keeps Cashier mobile navigation free of Money and Stock operational routes', () => {
+    const cashierHrefs = getCashierMenu(cashierContext).map((item) => item.href);
+
+    for (const href of CRITICAL_MOBILE_OPERATIONAL_HREFS) {
+      expect(cashierHrefs).not.toContain(href);
+    }
+    expect(cashierHrefs).not.toContain('/inventory');
+    expect(cashierHrefs).not.toContain('/expenses');
+    expect(cashierHrefs).not.toContain('/users');
+  });
+
+  it('does not expose mobile Money/Stock links beyond desktop-authorised roles', () => {
+    const mobileItems = [
+      ...OWNER_BROWSE_AREAS.flatMap((area) => area.items),
+      ...MANAGER_MENU_SECTIONS.flatMap((area) => area.items),
+    ].filter((item) => (CRITICAL_MOBILE_OPERATIONAL_HREFS as readonly string[]).includes(item.href));
+
+    for (const item of mobileItems) {
+      const desktopRoles = desktopRolesForHref(item.href);
+      expect(desktopRoles, `missing desktop policy for ${item.href}`).not.toBeNull();
+      for (const role of item.roles) {
+        expect(desktopRoles).toContain(role);
+      }
+      expect(item.roles).not.toContain('CASHIER');
+    }
+  });
+
+  it('preserves plan and MoMo gates on stocktake and reconciliation', () => {
+    const stocktake = OWNER_BROWSE_AREAS.flatMap((area) => area.items).find(
+      (item) => item.href === '/inventory/stocktake',
+    );
+    expect(stocktake?.minimumPlan).toBe('GROWTH');
+
+    const starterOwner = getOwnerLauncherMenu(starterOwnerContext);
+    const starterHrefs = starterOwner.browseAreas.flatMap((area) => area.items.map((item) => item.href));
+    expect(starterHrefs).not.toContain('/payments/reconciliation');
+    expect(starterHrefs).not.toContain('/transfers');
+  });
+
+  it('keeps Supplier Ageing in Money while Reports Hub remains available', () => {
+    const ownerMoney = OWNER_BROWSE_AREAS.find((area) => area.id === 'money');
+    const ownerReports = OWNER_BROWSE_AREAS.find((area) => area.id === 'reports');
+    expect(ownerMoney?.items.some((item) => item.href === '/payments/supplier-aging')).toBe(true);
+    expect(ownerReports?.items.some((item) => item.href === '/reports')).toBe(true);
+  });
+});
+
+describe('P1 ResponsiveDataTable and operational mobile lists', () => {
+  it('requires an explicit responsive mode contract', () => {
+    const src = read('components/ResponsiveDataTable.tsx');
+    expect(src).toContain("mode: 'cards'");
+    expect(src).toContain("mode: 'dense-ledger'");
+    expect(src).toContain("mode: 'desktop-only'");
+    expect(src).toContain('requires a mobile renderer');
+    expect(src).not.toContain("mode = 'table'");
+  });
+
+  it('adapts MoMo reconciliation for mobile cards', () => {
+    const src = read('app/(protected)/payments/reconciliation/page.tsx');
+    expect(src).toContain('mode="cards"');
+    expect(src).toContain('mobile={');
+    expect(src).toContain('DataCard');
+    expect(src).toContain('Re-check');
+    expect(src).toContain('Re-initiate');
+    expect(src).toContain('requireBusiness([\'MANAGER\', \'OWNER\'])');
+  });
+
+  it('adapts card/transfer reconciliation for mobile cards', () => {
+    const src = read('app/(protected)/payments/reconciliation/card-transfer/page.tsx');
+    expect(src).toContain('mode="cards"');
+    expect(src).toContain('mobile={');
+    expect(src).toContain('DataCard');
+    expect(src).toContain('ReconcileForm');
+    expect(src).toContain('View transactions');
+  });
+
+  it('adapts expense payments for mobile cards', () => {
+    const src = read('app/(protected)/payments/expense-payments/page.tsx');
+    expect(src).toContain('mode="cards"');
+    expect(src).toContain('mobile={');
+    expect(src).toContain('DataCard');
+    expect(src).toContain('Record payment');
+    expect(src).toContain('recordExpensePaymentAction');
+  });
+
+  it('adapts customer invoice history for mobile cards', () => {
+    const src = read('app/(protected)/customers/[id]/page.tsx');
+    expect(src).toContain('mode="cards"');
+    expect(src).toContain('DataCard');
+    expect(src).toContain('Print receipt');
+    expect(src).toContain('Record payment');
+    expect(src).toContain('dueDate: true');
+  });
+
+  it('keeps supplier ageing mobile cards and Money discovery intact', () => {
+    const src = read('app/(protected)/payments/supplier-aging/page.tsx');
+    expect(src).toContain('lg:hidden');
+    expect(src).toContain('DataCard');
+    expect(src).toContain('Record payment');
+    expect(src).toContain('getSupplierAgingReport');
+    expect(src).toContain('AGING_BUCKETS');
+  });
+
+  it('rejects desktop-only traps on P1 operational list call sites', () => {
+    const pages = [
+      'app/(protected)/payments/reconciliation/page.tsx',
+      'app/(protected)/payments/reconciliation/card-transfer/page.tsx',
+      'app/(protected)/payments/expense-payments/page.tsx',
+      'app/(protected)/customers/[id]/page.tsx',
+      'app/(protected)/payments/customer-receipts/page.tsx',
+      'app/(protected)/payments/supplier-payments/page.tsx',
+      'app/(protected)/transfers/page.tsx',
+    ];
+
+    for (const path of pages) {
+      const src = read(path);
+      expect(src, path).toContain('mode="cards"');
+      expect(src, path).toContain('mobile=');
+    }
+  });
+});

--- a/lib/services/supplier-aging.test.ts
+++ b/lib/services/supplier-aging.test.ts
@@ -216,4 +216,76 @@ describe('getSupplierAgingReport', () => {
     expect(afterEdit.rows[0].buckets.CURRENT).toBe(0);
     expect(afterEdit.rows[0].buckets.D31_60).toBe(9_000);
   });
+
+  it('reconciles a populated multi-supplier fixture across totals, buckets and partial payments', async () => {
+    // asOf 2024-06-15
+    // Alpha: current not-due + 1–30 overdue + partial payment
+    // Beta: 31–60 + 90+ with large digit amounts (truncation-sensitive)
+    prismaMock.purchaseInvoice.findMany.mockResolvedValue([
+      makeInvoice({
+        id: 'alpha-current',
+        supplierId: 'sup-alpha',
+        supplierName: 'Alpha Trading Co',
+        dueDate: '2024-06-20',
+        totalPence: 1_250_000,
+      }),
+      makeInvoice({
+        id: 'alpha-d1',
+        supplierId: 'sup-alpha',
+        supplierName: 'Alpha Trading Co',
+        dueDate: '2024-06-01',
+        totalPence: 500_000,
+        paid: 100_000,
+        paymentStatus: 'PART_PAID',
+      }),
+      makeInvoice({
+        id: 'beta-d31',
+        supplierId: 'sup-beta',
+        supplierName: 'Beta Wholesalers Ltd',
+        dueDate: '2024-05-01',
+        totalPence: 2_345_678,
+      }),
+      makeInvoice({
+        id: 'beta-d90',
+        supplierId: 'sup-beta',
+        supplierName: 'Beta Wholesalers Ltd',
+        dueDate: '2024-02-01',
+        totalPence: 9_876_543,
+      }),
+    ]);
+
+    const report = await getSupplierAgingReport(BIZ, now);
+
+    expect(report.rows).toHaveLength(2);
+    expect(report.totals.supplierCount).toBe(2);
+    expect(report.totals.invoiceCount).toBe(4);
+
+    // Alpha outstanding: 1_250_000 + (500_000 - 100_000) = 1_650_000
+    const alpha = report.rows.find((row) => row.supplierId === 'sup-alpha');
+    expect(alpha).toBeTruthy();
+    expect(alpha!.totalPence).toBe(1_650_000);
+    expect(alpha!.buckets.CURRENT).toBe(1_250_000);
+    expect(alpha!.buckets.D1_30).toBe(400_000);
+
+    // Beta outstanding: 2_345_678 + 9_876_543 = 12_222_221
+    const beta = report.rows.find((row) => row.supplierId === 'sup-beta');
+    expect(beta).toBeTruthy();
+    expect(beta!.totalPence).toBe(12_222_221);
+    expect(beta!.buckets.D31_60).toBe(2_345_678);
+    expect(beta!.buckets.D90_PLUS).toBe(9_876_543);
+
+    expect(report.totals.totalPence).toBe(1_650_000 + 12_222_221);
+    expect(report.totals.buckets.CURRENT).toBe(1_250_000);
+    expect(report.totals.buckets.D1_30).toBe(400_000);
+    expect(report.totals.buckets.D31_60).toBe(2_345_678);
+    expect(report.totals.buckets.D90_PLUS).toBe(9_876_543);
+
+    // Row totals must reconcile to headline totals (desktop/mobile/tiles/export share this report)
+    const rowSum = report.rows.reduce((sum, row) => sum + row.totalPence, 0);
+    expect(rowSum).toBe(report.totals.totalPence);
+    for (const bucket of AGING_BUCKETS) {
+      const bucketSum = report.rows.reduce((sum, row) => sum + row.buckets[bucket], 0);
+      expect(bucketSum).toBe(report.totals.buckets[bucket]);
+    }
+  });
 });

--- a/tests/e2e/mobile-overflow-authenticated.spec.ts
+++ b/tests/e2e/mobile-overflow-authenticated.spec.ts
@@ -12,6 +12,11 @@ const ownerRoutes = [
   ['/reports/cash-drawer', 'Cash drawer'],
   ['/payments/supplier-payments', 'Supplier payments'],
   ['/payments/customer-receipts', 'Customer payments'],
+  ['/payments/supplier-aging', 'Supplier ageing'],
+  ['/payments/expense-payments', 'Expense payments'],
+  ['/payments/reconciliation', 'MoMo reconciliation'],
+  ['/payments/reconciliation/card-transfer', 'Card transfer reconciliation'],
+  ['/inventory/adjustments', 'Stock adjustments'],
   ['/shifts', 'Shifts'],
   ['/account', 'Account'],
 ] as const;


### PR DESCRIPTION
## Summary
- Restore Owner and Manager mobile discovery for critical Money and Stock workflows (supplier ageing, reconciliations, expense payments, stock adjustments/stocktake, cash drawer, transfers, receipts/payments).
- Adapt MoMo reconciliation, card/transfer reconciliation, expense payments, and customer invoice history with mobile cards using the same loaders/actions.
- Harden `ResponsiveDataTable` to require an explicit `cards` / `dense-ledger` / `desktop-only` contract, and add navigation parity plus supplier-ageing fixture reconciliation tests.

## Test plan
- [x] Unit: mobile parity, menu simplification, overflow guards, supplier-ageing populated fixture
- [x] Lint + typecheck
- [ ] CI green
- [ ] Read-only Production smoke after deploy (no mutations)
- [ ] Viewport checks at 320/390 for P1 routes

Made with [Cursor](https://cursor.com)