### PR TITLE
Harden supplier-payment financial controls (auth + durable idempotency)

### DIFF
--- a/app/(protected)/payments/supplier-payments/page.tsx
+++ b/app/(protected)/payments/supplier-payments/page.tsx
@@ -1,15 +1,14 @@
 import PageHeader from '@/components/PageHeader';
 import FormError from '@/components/FormError';
-import SubmitButton from '@/components/SubmitButton';
 import ResponsiveDataTable from '@/components/ResponsiveDataTable';
 import Link from 'next/link';
 import { prisma } from '@/lib/prisma';
 import { requireBusiness } from '@/lib/auth';
 import { formatMoney, formatDate } from '@/lib/format';
-import { recordSupplierPaymentAction } from '@/app/actions/payments';
 import { computeOutstandingBalance } from '@/lib/accounting';
 import SetPurchaseDueDateButton from '@/components/SetPurchaseDueDateButton';
 import DueDateBadge from '@/components/DueDateBadge';
+import SupplierPaymentForm from '@/components/SupplierPaymentForm';
 import { measureServerOperation, PERFORMANCE_THRESHOLDS_MS } from '@/lib/observability';
 
 const PAYMENT_LABEL: Record<string, string> = {
@@ -98,57 +97,11 @@ export default async function SupplierPaymentsPage({ searchParams }: { searchPar
   const lastPaymentAt = recentPayments.length > 0 ? recentPayments[0].paidAt : null;
 
   const renderPaymentForm = (invoiceId: string) => (
-    <form action={recordSupplierPaymentAction} className="grid gap-2 md:grid-cols-2">
-      <input type="hidden" name="invoiceId" value={invoiceId} />
-      {linkedSupplier ? (
-        <input type="hidden" name="returnTo" value={`/suppliers/${linkedSupplier.id}`} />
-      ) : null}
-      <div>
-        <div className="text-xs font-medium text-black/50">Payment method</div>
-        <select className="input" name="paymentMethod" defaultValue="CASH">
-          <option value="CASH">Cash</option>
-          <option value="CARD">Card</option>
-          <option value="TRANSFER">Bank Transfer</option>
-          <option value="MOBILE_MONEY">Mobile Money (MoMo)</option>
-        </select>
-      </div>
-      <div>
-        <div className="text-xs font-medium text-black/50">Amount paid</div>
-        <input
-          className="input"
-          name="amount"
-          type="number"
-          min={0}
-          step="0.01"
-          inputMode="decimal"
-          placeholder="0.00"
-        />
-      </div>
-      <div>
-        <div className="text-xs font-medium text-black/50">Payment date</div>
-        <input
-          className="input"
-          name="paidAt"
-          type="date"
-          defaultValue={today}
-        />
-      </div>
-      <div>
-        <div className="text-xs font-medium text-black/50">Notes (optional)</div>
-        <input
-          className="input"
-          name="notes"
-          type="text"
-          placeholder="e.g. cheque #1234"
-        />
-      </div>
-      <div className="text-xs text-black/45 md:col-span-2">
-        Enter the amount paid. Do not exceed the amount owed.
-      </div>
-      <div className="flex items-end md:col-span-2">
-        <SubmitButton className="btn-primary w-full text-xs" loadingText="Recording…">Record payment</SubmitButton>
-      </div>
-    </form>
+    <SupplierPaymentForm
+      invoiceId={invoiceId}
+      today={today}
+      returnTo={linkedSupplier ? `/suppliers/${linkedSupplier.id}` : undefined}
+    />
   );
 
   return (

--- a/app/(protected)/purchases/[id]/page.tsx
+++ b/app/(protected)/purchases/[id]/page.tsx
@@ -1,15 +1,14 @@
 import Link from 'next/link';
 import PageHeader from '@/components/PageHeader';
-import SubmitButton from '@/components/SubmitButton';
 import FormError from '@/components/FormError';
 import { prisma } from '@/lib/prisma';
 import { requireBusiness } from '@/lib/auth';
 import { formatMoney, formatDateTime, formatDate } from '@/lib/format';
-import { recordSupplierPaymentAction } from '@/app/actions/payments';
 import { changePurchaseProductSupplierLinkAction } from '@/app/actions/purchases';
 import SetPurchaseDueDateButton from '@/components/SetPurchaseDueDateButton';
 import DueDateBadge from '@/components/DueDateBadge';
 import PurchaseDraftClearer from '@/components/purchases/PurchaseDraftClearer';
+import SupplierPaymentForm from '@/components/SupplierPaymentForm';
 
 export default async function PurchaseInvoicePage({
   params,
@@ -317,42 +316,15 @@ export default async function PurchaseInvoicePage({
         {!isClosed && outstanding > 0 && (
           <div className="mt-6">
             <h3 className="text-sm font-semibold">Record a payment</h3>
-            <form action={recordSupplierPaymentAction} className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              <input type="hidden" name="invoiceId" value={invoice.id} />
-              <input type="hidden" name="returnTo" value={`/purchases/${invoice.id}`} />
-              <div>
-                <label className="label">Method</label>
-                <select className="input" name="paymentMethod" defaultValue="CASH">
-                  <option value="CASH">Cash</option>
-                  <option value="CARD">Card</option>
-                  <option value="TRANSFER">Transfer</option>
-                  <option value="MOBILE_MONEY">Mobile Money</option>
-                </select>
-              </div>
-              <div>
-                <label className="label">Amount</label>
-                <input
-                  className="input"
-                  name="amount"
-                  type="number"
-                  min={0}
-                  step="0.01"
-                  inputMode="decimal"
-                  placeholder={(outstanding / 100).toFixed(2)}
-                />
-              </div>
-              <div>
-                <label className="label">Payment date</label>
-                <input className="input" name="paidAt" type="date" defaultValue={today} />
-              </div>
-              <div>
-                <label className="label">Notes (optional)</label>
-                <input className="input" name="notes" type="text" placeholder="e.g. cheque #1234" />
-              </div>
-              <div className="flex items-end sm:col-span-2 lg:col-span-4">
-                <SubmitButton className="btn-primary" loadingText="Recording…">Record payment</SubmitButton>
-              </div>
-            </form>
+            <div className="mt-3">
+              <SupplierPaymentForm
+                invoiceId={invoice.id}
+                returnTo={`/purchases/${invoice.id}`}
+                today={today}
+                amountPlaceholder={(outstanding / 100).toFixed(2)}
+                formClassName="grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+              />
+            </div>
           </div>
         )}
       </div>

--- a/app/(protected)/purchases/[id]/page.tsx
+++ b/app/(protected)/purchases/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import PageHeader from '@/components/PageHeader';
+import SubmitButton from '@/components/SubmitButton';
 import FormError from '@/components/FormError';
 import { prisma } from '@/lib/prisma';
 import { requireBusiness } from '@/lib/auth';

--- a/app/actions/payments.test.ts
+++ b/app/actions/payments.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  withBusinessContextMock,
+  recordSupplierPaymentMock,
+  redirectMock,
+  revalidateTagMock,
+  revalidateOwnerDashboardCacheMock,
+} = vi.hoisted(() => ({
+  withBusinessContextMock: vi.fn(),
+  recordSupplierPaymentMock: vi.fn(),
+  redirectMock: vi.fn((url: string) => {
+    const err = new Error(`NEXT_REDIRECT:${url}`);
+    (err as any).digest = `NEXT_REDIRECT;replace;${url};303`;
+    throw err;
+  }),
+  revalidateTagMock: vi.fn(),
+  revalidateOwnerDashboardCacheMock: vi.fn(),
+}));
+
+vi.mock('@/lib/action-utils', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/action-utils')>('@/lib/action-utils');
+  return {
+    ...actual,
+    withBusinessContext: withBusinessContextMock,
+  };
+});
+
+vi.mock('@/lib/services/payments', () => ({
+  recordCustomerPayment: vi.fn(),
+  recordSupplierPayment: recordSupplierPaymentMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidateTag: revalidateTagMock,
+}));
+
+vi.mock('@/lib/reports/cache-revalidation', () => ({
+  revalidateOwnerDashboardCache: revalidateOwnerDashboardCacheMock,
+}));
+
+import { recordSupplierPaymentAction } from './payments';
+
+function form(data: Record<string, string>) {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(data)) fd.set(k, v);
+  return fd;
+}
+
+describe('recordSupplierPaymentAction authorisation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recordSupplierPaymentMock.mockResolvedValue({
+      invoice: { id: 'inv-1', payments: [] },
+      replayed: false,
+    });
+  });
+
+  it('allows Owner and passes session-derived role + idempotency key', async () => {
+    withBusinessContextMock.mockResolvedValue({
+      businessId: 'biz-1',
+      user: { id: 'u-owner', role: 'OWNER', name: 'Owner', email: 'o@x.com', businessId: 'biz-1' },
+    });
+
+    await expect(
+      recordSupplierPaymentAction(
+        form({
+          invoiceId: 'inv-1',
+          paymentMethod: 'TRANSFER',
+          amount: '10.00',
+          idempotencyKey: 'key-owner-1',
+        }),
+      ),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(withBusinessContextMock).toHaveBeenCalledWith(['MANAGER', 'OWNER']);
+    expect(recordSupplierPaymentMock).toHaveBeenCalledWith(
+      'biz-1',
+      'inv-1',
+      [{ method: 'TRANSFER', amountPence: 1000 }],
+      expect.objectContaining({
+        recordedByUserId: 'u-owner',
+        actorRole: 'OWNER',
+        idempotencyKey: 'key-owner-1',
+      }),
+    );
+  });
+
+  it('allows Manager', async () => {
+    withBusinessContextMock.mockResolvedValue({
+      businessId: 'biz-1',
+      user: { id: 'u-mgr', role: 'MANAGER', name: 'Mgr', email: 'm@x.com', businessId: 'biz-1' },
+    });
+
+    await expect(
+      recordSupplierPaymentAction(
+        form({
+          invoiceId: 'inv-1',
+          paymentMethod: 'CASH',
+          amount: '5.00',
+          idempotencyKey: 'key-mgr-1',
+        }),
+      ),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(recordSupplierPaymentMock).toHaveBeenCalled();
+  });
+
+  it('does not call the service when withBusinessContext denies Cashier', async () => {
+    withBusinessContextMock.mockImplementation(async () => {
+      redirectMock('/pos');
+    });
+
+    await expect(
+      recordSupplierPaymentAction(
+        form({
+          invoiceId: 'inv-1',
+          paymentMethod: 'CASH',
+          amount: '5.00',
+          idempotencyKey: 'key-cashier',
+        }),
+      ),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(withBusinessContextMock).toHaveBeenCalledWith(['MANAGER', 'OWNER']);
+    expect(recordSupplierPaymentMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call the service when unauthenticated context fails', async () => {
+    withBusinessContextMock.mockImplementation(async () => {
+      redirectMock('/login');
+    });
+
+    await expect(
+      recordSupplierPaymentAction(
+        form({
+          invoiceId: 'inv-1',
+          amount: '5.00',
+          idempotencyKey: 'key-anon',
+        }),
+      ),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+
+    expect(recordSupplierPaymentMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/actions/payments.ts
+++ b/app/actions/payments.ts
@@ -4,8 +4,8 @@ import { recordCustomerPayment, recordSupplierPayment } from '@/lib/services/pay
 import { redirect } from 'next/navigation';
 import { revalidateTag } from 'next/cache';
 import { toPence } from '@/lib/form-helpers';
-import { formString, formPence } from '@/lib/form-helpers';
-import { withBusinessContext, formAction, type ActionResult } from '@/lib/action-utils';
+import { formString } from '@/lib/form-helpers';
+import { withBusinessContext, formAction } from '@/lib/action-utils';
 import type { PaymentMethod, PaymentInput } from '@/lib/services/shared';
 import { revalidateOwnerDashboardCache } from '@/lib/reports/cache-revalidation';
 
@@ -41,15 +41,23 @@ export async function recordCustomerPaymentAction(formData: FormData): Promise<v
 
 export async function recordSupplierPaymentAction(formData: FormData): Promise<void> {
   return formAction(async () => {
-    const { businessId, user } = await withBusinessContext();
+    const { businessId, user } = await withBusinessContext(['MANAGER', 'OWNER']);
 
     const invoiceId = formString(formData, 'invoiceId');
     const payments = parsePayments(formData);
     const paidAtStr = formString(formData, 'paidAt');
     const paidAt = paidAtStr ? new Date(paidAtStr) : undefined;
     const notes = formString(formData, 'notes') || undefined;
+    const idempotencyKey = formString(formData, 'idempotencyKey');
 
-    await recordSupplierPayment(businessId, invoiceId, payments, paidAt, user.id, notes);
+    await recordSupplierPayment(businessId, invoiceId, payments, {
+      paidAt,
+      recordedByUserId: user.id,
+      actorRole: user.role,
+      actorName: user.name,
+      notes,
+      idempotencyKey,
+    });
     revalidateTag('reports');
     revalidateOwnerDashboardCache();
     const returnTo = formString(formData, 'returnTo') || '/payments/supplier-payments';

--- a/components/InlinePaymentForm.tsx
+++ b/components/InlinePaymentForm.tsx
@@ -12,9 +12,16 @@ type Props = {
   returnTo: string;
 };
 
+function newIdempotencyKey() {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `pay-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 export default function InlinePaymentForm({ invoiceId, outstandingPence, currency, type, returnTo }: Props) {
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [idempotencyKey, setIdempotencyKey] = useState(newIdempotencyKey);
   const formRef = useRef<HTMLFormElement>(null);
 
   const action = type === 'customer' ? recordCustomerPaymentAction : recordSupplierPaymentAction;
@@ -24,7 +31,11 @@ export default function InlinePaymentForm({ invoiceId, outstandingPence, currenc
     return (
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          setIdempotencyKey(newIdempotencyKey());
+          setSubmitting(false);
+          setOpen(true);
+        }}
         className="btn-ghost text-xs text-primary font-semibold"
       >
         {type === 'customer' ? 'Collect' : 'Pay'}
@@ -41,10 +52,13 @@ export default function InlinePaymentForm({ invoiceId, outstandingPence, currenc
     >
       <input type="hidden" name="invoiceId" value={invoiceId} />
       <input type="hidden" name="returnTo" value={returnTo} />
+      {type === 'supplier' ? (
+        <input type="hidden" name="idempotencyKey" value={idempotencyKey} />
+      ) : null}
       <select name="paymentMethod" className="input py-1 text-xs w-20" defaultValue="CASH">
         <option value="CASH">Cash</option>
         <option value="CARD">Card</option>
-        <option value="MOMO">MoMo</option>
+        <option value="MOBILE_MONEY">MoMo</option>
         <option value="TRANSFER">Transfer</option>
       </select>
       <input
@@ -55,6 +69,7 @@ export default function InlinePaymentForm({ invoiceId, outstandingPence, currenc
         defaultValue={outstanding}
         className="input py-1 text-xs w-20"
         placeholder="Amt"
+        aria-label={`Amount (${currency})`}
       />
       <button
         type="submit"
@@ -65,7 +80,10 @@ export default function InlinePaymentForm({ invoiceId, outstandingPence, currenc
       </button>
       <button
         type="button"
-        onClick={() => setOpen(false)}
+        onClick={() => {
+          setOpen(false);
+          setSubmitting(false);
+        }}
         className="btn-ghost py-1 px-2 text-xs text-muted"
       >
         Cancel

--- a/components/SupplierPaymentForm.tsx
+++ b/components/SupplierPaymentForm.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import SubmitButton from '@/components/SubmitButton';
+import { recordSupplierPaymentAction } from '@/app/actions/payments';
+
+type Props = {
+  invoiceId: string;
+  returnTo?: string;
+  today: string;
+  amountPlaceholder?: string;
+  /** Optional form layout class; defaults to supplier-payments grid. */
+  formClassName?: string;
+};
+
+/**
+ * Supplier payment form with a durable client idempotency key per intentional submission.
+ * Server + DB uniqueness remain authoritative; pending disable is defence in depth.
+ */
+export default function SupplierPaymentForm({
+  invoiceId,
+  returnTo,
+  today,
+  amountPlaceholder = '0.00',
+  formClassName = 'grid gap-2 md:grid-cols-2',
+}: Props) {
+  const [idempotencyKey] = useState(() =>
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `sp-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+
+  return (
+    <form action={recordSupplierPaymentAction} className={formClassName}>
+      <input type="hidden" name="invoiceId" value={invoiceId} />
+      <input type="hidden" name="idempotencyKey" value={idempotencyKey} />
+      {returnTo ? <input type="hidden" name="returnTo" value={returnTo} /> : null}
+      <div>
+        <div className="text-xs font-medium text-black/50">Payment method</div>
+        <select className="input" name="paymentMethod" defaultValue="CASH">
+          <option value="CASH">Cash</option>
+          <option value="CARD">Card</option>
+          <option value="TRANSFER">Bank Transfer</option>
+          <option value="MOBILE_MONEY">Mobile Money (MoMo)</option>
+        </select>
+      </div>
+      <div>
+        <div className="text-xs font-medium text-black/50">Amount paid</div>
+        <input
+          className="input"
+          name="amount"
+          type="number"
+          min={0}
+          step="0.01"
+          inputMode="decimal"
+          placeholder={amountPlaceholder}
+        />
+      </div>
+      <div>
+        <div className="text-xs font-medium text-black/50">Payment date</div>
+        <input
+          className="input"
+          name="paidAt"
+          type="date"
+          defaultValue={today}
+        />
+      </div>
+      <div>
+        <div className="text-xs font-medium text-black/50">Notes (optional)</div>
+        <input
+          className="input"
+          name="notes"
+          type="text"
+          placeholder="e.g. cheque #1234"
+        />
+      </div>
+      <div className="text-xs text-black/45 md:col-span-2 sm:col-span-2 lg:col-span-4">
+        Enter the amount paid. Do not exceed the amount owed.
+      </div>
+      <div className="flex items-end md:col-span-2 sm:col-span-2 lg:col-span-4">
+        <SubmitButton className="btn-primary w-full text-xs sm:w-auto sm:text-sm" loadingText="Recording…">
+          Record payment
+        </SubmitButton>
+      </div>
+    </form>
+  );
+}

--- a/lib/services/cash-drawer.ts
+++ b/lib/services/cash-drawer.ts
@@ -112,6 +112,89 @@ export function findOrphanCashPurchasePayments(
   });
 }
 
+export type HistoricalCashSupplierPaymentAssessmentRow = {
+  id: string;
+  amountPence: number;
+  paidAt: Date;
+  recordedByUserId: string | null;
+  linkedDrawerCount: number;
+  shiftStatus: 'OPEN' | 'CLOSED' | 'NONE' | 'MIXED' | null;
+};
+
+export type HistoricalCashSupplierPaymentCategory =
+  | 'properly_linked'
+  | 'missing_drawer_link'
+  | 'duplicate_drawer_links'
+  | 'funding_source_ambiguous'
+  | 'shift_association_unavailable';
+
+export type HistoricalCashSupplierPaymentAggregate = {
+  category: HistoricalCashSupplierPaymentCategory;
+  recordCount: number;
+  aggregateValuePence: number;
+  closedShiftExposureCount: number;
+  deterministic: boolean;
+};
+
+/**
+ * Pure, read-only classification of historical CASH supplier payments vs drawer links.
+ * Does not infer funding source. Missing idempotency keys are ignored (not orphans).
+ */
+export function assessHistoricalCashSupplierPayments(
+  rows: HistoricalCashSupplierPaymentAssessmentRow[],
+): HistoricalCashSupplierPaymentAggregate[] {
+  const buckets: Record<
+    HistoricalCashSupplierPaymentCategory,
+    { amountPence: number; closed: number; deterministic: boolean }
+  > = {
+    properly_linked: { amountPence: 0, closed: 0, deterministic: true },
+    missing_drawer_link: { amountPence: 0, closed: 0, deterministic: true },
+    duplicate_drawer_links: { amountPence: 0, closed: 0, deterministic: true },
+    funding_source_ambiguous: { amountPence: 0, closed: 0, deterministic: false },
+    shift_association_unavailable: { amountPence: 0, closed: 0, deterministic: false },
+  };
+
+  const counts: Record<HistoricalCashSupplierPaymentCategory, number> = {
+    properly_linked: 0,
+    missing_drawer_link: 0,
+    duplicate_drawer_links: 0,
+    funding_source_ambiguous: 0,
+    shift_association_unavailable: 0,
+  };
+
+  for (const row of rows) {
+    let category: HistoricalCashSupplierPaymentCategory;
+    if (row.linkedDrawerCount > 1) {
+      category = 'duplicate_drawer_links';
+    } else if (row.linkedDrawerCount === 1) {
+      if (row.shiftStatus === 'NONE' || row.shiftStatus === null) {
+        category = 'shift_association_unavailable';
+      } else {
+        category = 'properly_linked';
+      }
+    } else if (!row.recordedByUserId) {
+      // Cash payment with no actor — cannot determine whether till funding was intended.
+      category = 'funding_source_ambiguous';
+    } else {
+      category = 'missing_drawer_link';
+    }
+
+    counts[category] += 1;
+    buckets[category].amountPence += row.amountPence;
+    if (row.shiftStatus === 'CLOSED' || row.shiftStatus === 'MIXED') {
+      buckets[category].closed += 1;
+    }
+  }
+
+  return (Object.keys(counts) as HistoricalCashSupplierPaymentCategory[]).map((category) => ({
+    category,
+    recordCount: counts[category],
+    aggregateValuePence: buckets[category].amountPence,
+    closedShiftExposureCount: buckets[category].closed,
+    deterministic: buckets[category].deterministic,
+  }));
+}
+
 function toJson(value: unknown): string | null {
   if (value === undefined) return null;
   try {

--- a/lib/services/payments-concurrency.test.ts
+++ b/lib/services/payments-concurrency.test.ts
@@ -3,11 +3,14 @@
  *
  * Requires a real Postgres DATABASE_URL (or SUPPLIER_PAYMENT_CONCURRENCY_DATABASE_URL).
  * Without it these tests are skipped — sequential mocks are not labelled as concurrency.
+ *
+ * Run isolated so modules bind to Postgres:
+ *   set DATABASE_URL and SUPPLIER_PAYMENT_CONCURRENCY_DATABASE_URL, then
+ *   npx vitest run lib/services/payments-concurrency.test.ts
  */
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { PrismaClient } from '@prisma/client';
 import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
-import { recordSupplierPayment } from '@/lib/services/payments';
 
 const databaseUrl =
   process.env.SUPPLIER_PAYMENT_CONCURRENCY_DATABASE_URL || process.env.DATABASE_URL;
@@ -17,14 +20,28 @@ const describeConcurrency = canRun ? describe : describe.skip;
 
 describeConcurrency('supplier payment overlapping transactions (Postgres)', () => {
   let prisma: PrismaClient;
+  let recordSupplierPayment: typeof import('@/lib/services/payments').recordSupplierPayment;
+  let SUPPLIER_PAYMENT_ERROR: typeof import('@/lib/services/payments').SUPPLIER_PAYMENT_ERROR;
   const suffix = `sp-conc-${Date.now()}`;
   let businessId = '';
   let storeId = '';
   let invoiceId = '';
   let userId = '';
+  let supplierId = '';
 
   beforeAll(async () => {
     process.env.DATABASE_URL = databaseUrl!;
+    // Drop any prior SQLite-bound singleton so the service uses Postgres.
+    const g = globalThis as unknown as { prisma?: PrismaClient };
+    if (g.prisma) {
+      await g.prisma.$disconnect().catch(() => {});
+      g.prisma = undefined;
+    }
+    vi.resetModules();
+    const payments = await import('@/lib/services/payments');
+    recordSupplierPayment = payments.recordSupplierPayment;
+    SUPPLIER_PAYMENT_ERROR = payments.SUPPLIER_PAYMENT_ERROR;
+
     prisma = new PrismaClient();
     await prisma.$connect();
 
@@ -63,6 +80,7 @@ describeConcurrency('supplier payment overlapping transactions (Postgres)', () =
       data: { storeId, name: `Till ${suffix}` },
     });
 
+    // Opening float GH₵500 + cash sale GH₵1,000 + customer receipt GH₵200 = GH₵1,700 before supplier out.
     await prisma.shift.create({
       data: {
         tillId: till.id,
@@ -76,6 +94,7 @@ describeConcurrency('supplier payment overlapping transactions (Postgres)', () =
     const supplier = await prisma.supplier.create({
       data: { businessId, name: `Supplier ${suffix}` },
     });
+    supplierId = supplier.id;
 
     const invoice = await prisma.purchaseInvoice.create({
       data: {
@@ -89,7 +108,7 @@ describeConcurrency('supplier payment overlapping transactions (Postgres)', () =
       },
     });
     invoiceId = invoice.id;
-  }, 60000);
+  }, 90000);
 
   afterAll(async () => {
     if (!prisma) return;
@@ -107,9 +126,9 @@ describeConcurrency('supplier payment overlapping transactions (Postgres)', () =
     await prisma.store.deleteMany({ where: { businessId } }).catch(() => {});
     await prisma.business.deleteMany({ where: { id: businessId } }).catch(() => {});
     await prisma.$disconnect();
-  }, 60000);
+  }, 90000);
 
-  it('posts exactly once under concurrent identical idempotency keys', async () => {
+  it('posts exactly once under concurrent identical idempotency keys (GH₵1,400)', async () => {
     const key = `conc-key-${suffix}`;
     const opts = {
       recordedByUserId: userId,
@@ -126,6 +145,7 @@ describeConcurrency('supplier payment overlapping transactions (Postgres)', () =
     expect(a.invoice.id).toBe(invoiceId);
     expect(b.invoice.id).toBe(invoiceId);
     expect([a.replayed, b.replayed].filter(Boolean).length).toBeGreaterThanOrEqual(1);
+    expect([a.replayed, b.replayed].some((v) => v === false)).toBe(true);
 
     const payments = await prisma.purchasePayment.findMany({
       where: { businessId, purchaseInvoiceId: invoiceId },
@@ -157,14 +177,74 @@ describeConcurrency('supplier payment overlapping transactions (Postgres)', () =
       where: { userId, status: 'OPEN' },
     });
     expect(shift?.expectedCashPence).toBe(140000);
+
+    const paid = payments.reduce((s, p) => s + p.amountPence, 0);
+    expect(60000 - paid).toBe(30000);
   }, 60000);
 
-  it('allows two intentional payments with distinct keys', async () => {
+  it('rejects concurrent same-key requests with different payloads without a second post', async () => {
+    const invoice = await prisma.purchaseInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        supplierId,
+        totalPence: 80000,
+        subtotalPence: 80000,
+        vatPence: 0,
+        paymentStatus: 'UNPAID',
+      },
+    });
+    const key = `conflict-key-${suffix}`;
+    const baseOpts = {
+      recordedByUserId: userId,
+      actorRole: 'OWNER',
+      actorName: 'Owner',
+      idempotencyKey: key,
+    } as const;
+
+    const results = await Promise.allSettled([
+      recordSupplierPayment(businessId, invoice.id, [{ method: 'TRANSFER', amountPence: 10000 }], baseOpts),
+      recordSupplierPayment(businessId, invoice.id, [{ method: 'TRANSFER', amountPence: 20000 }], baseOpts),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled') as PromiseFulfilledResult<
+      Awaited<ReturnType<typeof recordSupplierPayment>>
+    >[];
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled.length).toBe(1);
+    expect(rejected.length).toBe(1);
+    const err = (rejected[0] as PromiseRejectedResult).reason;
+    expect(err?.code).toBe(SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_CONFLICT);
+
+    const payments = await prisma.purchasePayment.findMany({
+      where: { purchaseInvoiceId: invoice.id },
+    });
+    expect(payments).toHaveLength(1);
+    // Either concurrent payload may win; the other must conflict with no second post.
+    expect([10000, 20000]).toContain(payments[0]!.amountPence);
+    expect(fulfilled[0]!.value.replayed).toBe(false);
+
+    const journals = await prisma.journalEntry.findMany({
+      where: { businessId, referenceType: 'SUPPLIER_PAYMENT', referenceId: invoice.id },
+    });
+    expect(journals).toHaveLength(1);
+
+    const drawers = await prisma.cashDrawerEntry.findMany({
+      where: {
+        businessId,
+        entryType: 'PAID_OUT_SUPPLIER',
+        referenceId: { in: payments.map((p) => p.id) },
+      },
+    });
+    expect(drawers).toHaveLength(0);
+  }, 60000);
+
+  it('allows two concurrent intentional payments with distinct keys', async () => {
     const invoice2 = await prisma.purchaseInvoice.create({
       data: {
         businessId,
         storeId,
-        supplierId: (await prisma.supplier.findFirst({ where: { businessId } }))!.id,
+        supplierId,
         totalPence: 100000,
         subtotalPence: 100000,
         vatPence: 0,
@@ -172,28 +252,33 @@ describeConcurrency('supplier payment overlapping transactions (Postgres)', () =
       },
     });
 
-    await recordSupplierPayment(
-      businessId,
-      invoice2.id,
-      [{ method: 'TRANSFER', amountPence: 10000 }],
-      {
-        recordedByUserId: userId,
-        actorRole: 'OWNER',
-        actorName: 'Owner',
-        idempotencyKey: `distinct-a-${suffix}`,
-      },
-    );
-    await recordSupplierPayment(
-      businessId,
-      invoice2.id,
-      [{ method: 'TRANSFER', amountPence: 10000 }],
-      {
-        recordedByUserId: userId,
-        actorRole: 'OWNER',
-        actorName: 'Owner',
-        idempotencyKey: `distinct-b-${suffix}`,
-      },
-    );
+    const [a, b] = await Promise.all([
+      recordSupplierPayment(
+        businessId,
+        invoice2.id,
+        [{ method: 'TRANSFER', amountPence: 10000 }],
+        {
+          recordedByUserId: userId,
+          actorRole: 'OWNER',
+          actorName: 'Owner',
+          idempotencyKey: `distinct-a-${suffix}`,
+        },
+      ),
+      recordSupplierPayment(
+        businessId,
+        invoice2.id,
+        [{ method: 'TRANSFER', amountPence: 10000 }],
+        {
+          recordedByUserId: userId,
+          actorRole: 'OWNER',
+          actorName: 'Owner',
+          idempotencyKey: `distinct-b-${suffix}`,
+        },
+      ),
+    ]);
+
+    expect(a.replayed).toBe(false);
+    expect(b.replayed).toBe(false);
 
     const payments = await prisma.purchasePayment.findMany({
       where: { purchaseInvoiceId: invoice2.id },
@@ -208,6 +293,185 @@ describeConcurrency('supplier payment overlapping transactions (Postgres)', () =
       },
     });
     expect(drawers).toHaveLength(0);
+  }, 60000);
+
+  it('isolates the same idempotency key across tenants', async () => {
+    const other = await prisma.business.create({
+      data: {
+        name: `SP Other ${suffix}`,
+        currency: 'GHS',
+        accounts: {
+          create: [
+            { code: '1000', name: 'Cash', type: 'ASSET' },
+            { code: '1010', name: 'Bank', type: 'ASSET' },
+            { code: '2000', name: 'Accounts Payable', type: 'LIABILITY' },
+          ],
+        },
+      },
+    });
+    const otherStore = await prisma.store.create({
+      data: { businessId: other.id, name: `Other store ${suffix}` },
+    });
+    const otherUser = await prisma.user.create({
+      data: {
+        businessId: other.id,
+        email: `other-${suffix}@example.com`,
+        name: 'Other Owner',
+        role: 'OWNER',
+        passwordHash: 'x',
+      },
+    });
+    const otherSupplier = await prisma.supplier.create({
+      data: { businessId: other.id, name: `Other supplier ${suffix}` },
+    });
+    const otherInvoice = await prisma.purchaseInvoice.create({
+      data: {
+        businessId: other.id,
+        storeId: otherStore.id,
+        supplierId: otherSupplier.id,
+        totalPence: 50000,
+        subtotalPence: 50000,
+        vatPence: 0,
+        paymentStatus: 'UNPAID',
+      },
+    });
+
+    const sharedKey = `shared-key-${suffix}`;
+    const homeInvoice = await prisma.purchaseInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        supplierId,
+        totalPence: 50000,
+        subtotalPence: 50000,
+        vatPence: 0,
+        paymentStatus: 'UNPAID',
+      },
+    });
+
+    await recordSupplierPayment(
+      businessId,
+      homeInvoice.id,
+      [{ method: 'MOBILE_MONEY', amountPence: 5000 }],
+      {
+        recordedByUserId: userId,
+        actorRole: 'OWNER',
+        actorName: 'Owner',
+        idempotencyKey: sharedKey,
+      },
+    );
+
+    await recordSupplierPayment(
+      other.id,
+      otherInvoice.id,
+      [{ method: 'MOBILE_MONEY', amountPence: 5000 }],
+      {
+        recordedByUserId: otherUser.id,
+        actorRole: 'OWNER',
+        actorName: 'Other Owner',
+        idempotencyKey: sharedKey,
+      },
+    );
+
+    expect(await prisma.purchasePayment.count({ where: { businessId, idempotencyKey: sharedKey } })).toBe(1);
+    expect(
+      await prisma.purchasePayment.count({ where: { businessId: other.id, idempotencyKey: sharedKey } }),
+    ).toBe(1);
+
+    await prisma.purchasePayment.deleteMany({ where: { businessId: other.id } });
+    await prisma.journalLine.deleteMany({ where: { journalEntry: { businessId: other.id } } });
+    await prisma.journalEntry.deleteMany({ where: { businessId: other.id } });
+    await prisma.auditLog.deleteMany({ where: { businessId: other.id } });
+    await prisma.purchaseInvoice.deleteMany({ where: { businessId: other.id } });
+    await prisma.supplier.deleteMany({ where: { businessId: other.id } });
+    await prisma.user.deleteMany({ where: { businessId: other.id } });
+    await prisma.account.deleteMany({ where: { businessId: other.id } });
+    await prisma.store.deleteMany({ where: { businessId: other.id } });
+    await prisma.business.deleteMany({ where: { id: other.id } });
+  }, 60000);
+
+  it('bank and MoMo retries do not touch drawer cash', async () => {
+    const beforeExpected = (
+      await prisma.shift.findFirstOrThrow({ where: { userId, status: 'OPEN' } })
+    ).expectedCashPence;
+
+    const bankInvoice = await prisma.purchaseInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        supplierId,
+        totalPence: 40000,
+        subtotalPence: 40000,
+        vatPence: 0,
+        paymentStatus: 'UNPAID',
+      },
+    });
+    const momoInvoice = await prisma.purchaseInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        supplierId,
+        totalPence: 40000,
+        subtotalPence: 40000,
+        vatPence: 0,
+        paymentStatus: 'UNPAID',
+      },
+    });
+
+    const bankKey = `bank-${suffix}`;
+    const momoKey = `momo-${suffix}`;
+    await Promise.all([
+      recordSupplierPayment(
+        businessId,
+        bankInvoice.id,
+        [{ method: 'TRANSFER', amountPence: 15000 }],
+        { recordedByUserId: userId, actorRole: 'OWNER', actorName: 'Owner', idempotencyKey: bankKey },
+      ),
+      recordSupplierPayment(
+        businessId,
+        momoInvoice.id,
+        [{ method: 'MOBILE_MONEY', amountPence: 15000 }],
+        { recordedByUserId: userId, actorRole: 'OWNER', actorName: 'Owner', idempotencyKey: momoKey },
+      ),
+    ]);
+    await Promise.all([
+      recordSupplierPayment(
+        businessId,
+        bankInvoice.id,
+        [{ method: 'TRANSFER', amountPence: 15000 }],
+        { recordedByUserId: userId, actorRole: 'OWNER', actorName: 'Owner', idempotencyKey: bankKey },
+      ),
+      recordSupplierPayment(
+        businessId,
+        momoInvoice.id,
+        [{ method: 'MOBILE_MONEY', amountPence: 15000 }],
+        { recordedByUserId: userId, actorRole: 'OWNER', actorName: 'Owner', idempotencyKey: momoKey },
+      ),
+    ]);
+
+    expect(await prisma.purchasePayment.count({ where: { purchaseInvoiceId: bankInvoice.id } })).toBe(1);
+    expect(await prisma.purchasePayment.count({ where: { purchaseInvoiceId: momoInvoice.id } })).toBe(1);
+    expect(
+      await prisma.cashDrawerEntry.count({
+        where: {
+          businessId,
+          entryType: 'PAID_OUT_SUPPLIER',
+          referenceId: {
+            in: (
+              await prisma.purchasePayment.findMany({
+                where: { purchaseInvoiceId: { in: [bankInvoice.id, momoInvoice.id] } },
+                select: { id: true },
+              })
+            ).map((p) => p.id),
+          },
+        },
+      }),
+    ).toBe(0);
+
+    const afterExpected = (
+      await prisma.shift.findFirstOrThrow({ where: { userId, status: 'OPEN' } })
+    ).expectedCashPence;
+    expect(afterExpected).toBe(beforeExpected);
   }, 60000);
 });
 

--- a/lib/services/payments-concurrency.test.ts
+++ b/lib/services/payments-concurrency.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Overlapping-transaction concurrency evidence for supplier-payment idempotency.
+ *
+ * Requires a real Postgres DATABASE_URL (or SUPPLIER_PAYMENT_CONCURRENCY_DATABASE_URL).
+ * Without it these tests are skipped — sequential mocks are not labelled as concurrency.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
+import { recordSupplierPayment } from '@/lib/services/payments';
+
+const databaseUrl =
+  process.env.SUPPLIER_PAYMENT_CONCURRENCY_DATABASE_URL || process.env.DATABASE_URL;
+const canRun = !!databaseUrl && isPostgresDatabaseUrl(databaseUrl);
+
+const describeConcurrency = canRun ? describe : describe.skip;
+
+describeConcurrency('supplier payment overlapping transactions (Postgres)', () => {
+  let prisma: PrismaClient;
+  const suffix = `sp-conc-${Date.now()}`;
+  let businessId = '';
+  let storeId = '';
+  let invoiceId = '';
+  let userId = '';
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = databaseUrl!;
+    prisma = new PrismaClient();
+    await prisma.$connect();
+
+    const business = await prisma.business.create({
+      data: {
+        name: `SP Conc ${suffix}`,
+        currency: 'GHS',
+        accounts: {
+          create: [
+            { code: '1000', name: 'Cash', type: 'ASSET' },
+            { code: '1010', name: 'Bank', type: 'ASSET' },
+            { code: '2000', name: 'Accounts Payable', type: 'LIABILITY' },
+          ],
+        },
+      },
+    });
+    businessId = business.id;
+
+    const store = await prisma.store.create({
+      data: { businessId, name: `Store ${suffix}` },
+    });
+    storeId = store.id;
+
+    const user = await prisma.user.create({
+      data: {
+        businessId,
+        email: `${suffix}@example.com`,
+        name: 'Owner',
+        role: 'OWNER',
+        passwordHash: 'x',
+      },
+    });
+    userId = user.id;
+
+    const till = await prisma.till.create({
+      data: { storeId, name: `Till ${suffix}` },
+    });
+
+    await prisma.shift.create({
+      data: {
+        tillId: till.id,
+        userId,
+        status: 'OPEN',
+        openingCashPence: 50000,
+        expectedCashPence: 170000,
+      },
+    });
+
+    const supplier = await prisma.supplier.create({
+      data: { businessId, name: `Supplier ${suffix}` },
+    });
+
+    const invoice = await prisma.purchaseInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        supplierId: supplier.id,
+        totalPence: 60000,
+        subtotalPence: 60000,
+        vatPence: 0,
+        paymentStatus: 'UNPAID',
+      },
+    });
+    invoiceId = invoice.id;
+  }, 60000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await prisma.auditLog.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.journalLine.deleteMany({ where: { journalEntry: { businessId } } }).catch(() => {});
+    await prisma.journalEntry.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.cashDrawerEntry.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.purchasePayment.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.purchaseInvoice.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.shift.deleteMany({ where: { till: { storeId } } }).catch(() => {});
+    await prisma.till.deleteMany({ where: { storeId } }).catch(() => {});
+    await prisma.supplier.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.account.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.store.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.business.deleteMany({ where: { id: businessId } }).catch(() => {});
+    await prisma.$disconnect();
+  }, 60000);
+
+  it('posts exactly once under concurrent identical idempotency keys', async () => {
+    const key = `conc-key-${suffix}`;
+    const opts = {
+      recordedByUserId: userId,
+      actorRole: 'OWNER',
+      actorName: 'Owner',
+      idempotencyKey: key,
+    } as const;
+
+    const [a, b] = await Promise.all([
+      recordSupplierPayment(businessId, invoiceId, [{ method: 'CASH', amountPence: 30000 }], opts),
+      recordSupplierPayment(businessId, invoiceId, [{ method: 'CASH', amountPence: 30000 }], opts),
+    ]);
+
+    expect(a.invoice.id).toBe(invoiceId);
+    expect(b.invoice.id).toBe(invoiceId);
+    expect([a.replayed, b.replayed].filter(Boolean).length).toBeGreaterThanOrEqual(1);
+
+    const payments = await prisma.purchasePayment.findMany({
+      where: { businessId, purchaseInvoiceId: invoiceId },
+    });
+    expect(payments).toHaveLength(1);
+
+    const drawers = await prisma.cashDrawerEntry.findMany({
+      where: {
+        businessId,
+        entryType: 'PAID_OUT_SUPPLIER',
+        referenceType: 'PURCHASE_PAYMENT',
+        referenceId: payments[0]!.id,
+      },
+    });
+    expect(drawers).toHaveLength(1);
+    expect(drawers[0]!.amountPence).toBe(-30000);
+
+    const journals = await prisma.journalEntry.findMany({
+      where: { businessId, referenceType: 'SUPPLIER_PAYMENT', referenceId: invoiceId },
+    });
+    expect(journals).toHaveLength(1);
+
+    const audits = await prisma.auditLog.findMany({
+      where: { businessId, action: 'SUPPLIER_PAYMENT', entityId: payments[0]!.id },
+    });
+    expect(audits).toHaveLength(1);
+
+    const shift = await prisma.shift.findFirst({
+      where: { userId, status: 'OPEN' },
+    });
+    expect(shift?.expectedCashPence).toBe(140000);
+  }, 60000);
+
+  it('allows two intentional payments with distinct keys', async () => {
+    const invoice2 = await prisma.purchaseInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        supplierId: (await prisma.supplier.findFirst({ where: { businessId } }))!.id,
+        totalPence: 100000,
+        subtotalPence: 100000,
+        vatPence: 0,
+        paymentStatus: 'UNPAID',
+      },
+    });
+
+    await recordSupplierPayment(
+      businessId,
+      invoice2.id,
+      [{ method: 'TRANSFER', amountPence: 10000 }],
+      {
+        recordedByUserId: userId,
+        actorRole: 'OWNER',
+        actorName: 'Owner',
+        idempotencyKey: `distinct-a-${suffix}`,
+      },
+    );
+    await recordSupplierPayment(
+      businessId,
+      invoice2.id,
+      [{ method: 'TRANSFER', amountPence: 10000 }],
+      {
+        recordedByUserId: userId,
+        actorRole: 'OWNER',
+        actorName: 'Owner',
+        idempotencyKey: `distinct-b-${suffix}`,
+      },
+    );
+
+    const payments = await prisma.purchasePayment.findMany({
+      where: { purchaseInvoiceId: invoice2.id },
+    });
+    expect(payments).toHaveLength(2);
+
+    const drawers = await prisma.cashDrawerEntry.findMany({
+      where: {
+        businessId,
+        entryType: 'PAID_OUT_SUPPLIER',
+        referenceId: { in: payments.map((p) => p.id) },
+      },
+    });
+    expect(drawers).toHaveLength(0);
+  }, 60000);
+});
+
+describe('supplier payment concurrency suite availability', () => {
+  it('reports when overlapping Postgres tests are skipped', () => {
+    if (!canRun) {
+      expect(canRun).toBe(false);
+    } else {
+      expect(canRun).toBe(true);
+    }
+  });
+});

--- a/lib/services/payments.test.ts
+++ b/lib/services/payments.test.ts
@@ -444,10 +444,32 @@ describe('payments service', () => {
       ),
     ).rejects.toMatchObject({
       code: SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_REQUIRED,
+      message: expect.stringContaining('Refresh the page'),
     });
 
     expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
     expect(prismaMock.purchasePayment.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects a write-freeze rollout flag without creating records', async () => {
+    const prev = process.env.TILLFLOW_SUPPLIER_PAYMENT_WRITES;
+    process.env.TILLFLOW_SUPPLIER_PAYMENT_WRITES = '0';
+    try {
+      await expect(
+        recordSupplierPayment(
+          'biz-1',
+          'purchase-1',
+          [{ method: 'CARD', amountPence: 1000 }],
+          { ...ownerOpts, idempotencyKey: 'idem-frozen' },
+        ),
+      ).rejects.toMatchObject({
+        code: SUPPLIER_PAYMENT_ERROR.TEMPORARILY_UNAVAILABLE,
+      });
+      expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.TILLFLOW_SUPPLIER_PAYMENT_WRITES;
+      else process.env.TILLFLOW_SUPPLIER_PAYMENT_WRITES = prev;
+    }
   });
 
   it('replays after unique-constraint race without duplicate posting', async () => {

--- a/lib/services/payments.test.ts
+++ b/lib/services/payments.test.ts
@@ -17,9 +17,13 @@ const { prismaMock, postJournalEntryMock, recordCashDrawerEntryTxMock } = vi.hoi
     purchasePayment: {
       createMany: vi.fn(),
       create: vi.fn(),
+      findUnique: vi.fn(),
     },
     shift: {
       findFirst: vi.fn(),
+    },
+    auditLog: {
+      create: vi.fn(),
     },
     $transaction: vi.fn(),
   },
@@ -49,12 +53,26 @@ vi.mock('./cash-drawer', async () => {
   };
 });
 
-import { recordCustomerPayment, recordSupplierPayment } from './payments';
+import {
+  recordCustomerPayment,
+  recordSupplierPayment,
+  SupplierPaymentError,
+  SUPPLIER_PAYMENT_ERROR,
+} from './payments';
+
+const ownerOpts = {
+  recordedByUserId: 'user-1',
+  actorRole: 'OWNER',
+  actorName: 'Owner',
+  idempotencyKey: 'idem-1',
+};
 
 describe('payments service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prismaMock.$transaction.mockImplementation(async (callback: any) => callback(prismaMock));
+    prismaMock.purchasePayment.findUnique.mockResolvedValue(null);
+    prismaMock.auditLog.create.mockResolvedValue({ id: 'audit-1' });
     prismaMock.purchasePayment.create.mockImplementation(async ({ data }: any) => ({
       id: `purchase-payment-${data.method.toLowerCase()}`,
       ...data,
@@ -85,6 +103,7 @@ describe('payments service', () => {
       businessId: 'biz-1',
       totalPence: 10000,
       payments: [{ amountPence: 1000 }],
+      supplier: { id: 'supplier-1', name: 'Supplier A' },
     });
 
     prismaMock.purchaseInvoice.update.mockResolvedValue({
@@ -94,7 +113,10 @@ describe('payments service', () => {
     });
 
     const payments: PaymentInput[] = [{ method: 'CARD', amountPence: 2000 }];
-    const result = await recordSupplierPayment('biz-1', 'purchase-1', payments);
+    const result = await recordSupplierPayment('biz-1', 'purchase-1', payments, {
+      ...ownerOpts,
+      idempotencyKey: 'idem-card-1',
+    });
 
     expect(prismaMock.purchaseInvoice.findFirst).toHaveBeenCalledWith({
       where: { id: 'purchase-1', businessId: 'biz-1' },
@@ -105,9 +127,18 @@ describe('payments service', () => {
     });
     expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
     expect(prismaMock.purchasePayment.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.purchasePayment.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        businessId: 'biz-1',
+        idempotencyKey: 'idem-card-1',
+        payloadHash: expect.any(String),
+      }),
+    });
     expect(recordCashDrawerEntryTxMock).not.toHaveBeenCalled();
     expect(postJournalEntryMock).toHaveBeenCalledTimes(1);
-    expect(result).toMatchObject({ id: 'purchase-1' });
+    expect(prismaMock.auditLog.create).toHaveBeenCalledTimes(1);
+    expect(result.replayed).toBe(false);
+    expect(result.invoice).toMatchObject({ id: 'purchase-1' });
   });
 
   it('records supplier cash payments as negative cash drawer movements', async () => {
@@ -130,8 +161,7 @@ describe('payments service', () => {
       'biz-1',
       'purchase-1',
       [{ method: 'CASH', amountPence: 50000 }],
-      undefined,
-      'user-1'
+      { ...ownerOpts, idempotencyKey: 'idem-cash-1' },
     );
 
     expect(prismaMock.purchasePayment.create).toHaveBeenCalledWith({
@@ -140,6 +170,8 @@ describe('payments service', () => {
         method: 'CASH',
         amountPence: 50000,
         recordedByUserId: 'user-1',
+        businessId: 'biz-1',
+        idempotencyKey: 'idem-cash-1',
       }),
     });
     expect(recordCashDrawerEntryTxMock).toHaveBeenCalledWith(
@@ -185,8 +217,7 @@ describe('payments service', () => {
       'biz-1',
       'purchase-1',
       [{ method: 'MOBILE_MONEY', amountPence: 50000 }],
-      undefined,
-      'user-1'
+      { ...ownerOpts, idempotencyKey: 'idem-momo-1' },
     );
 
     expect(recordCashDrawerEntryTxMock).not.toHaveBeenCalled();
@@ -199,6 +230,275 @@ describe('payments service', () => {
       ])
     );
     expect(journalLines.some((line: any) => line.accountCode === '4000')).toBe(false);
+  });
+
+  it('denies Cashier at the service boundary with no financial writes', async () => {
+    await expect(
+      recordSupplierPayment(
+        'biz-1',
+        'purchase-1',
+        [{ method: 'CASH', amountPence: 1000 }],
+        {
+          recordedByUserId: 'cashier-1',
+          actorRole: 'CASHIER',
+          idempotencyKey: 'idem-cashier',
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: SUPPLIER_PAYMENT_ERROR.FORBIDDEN,
+    });
+
+    expect(prismaMock.purchaseInvoice.findFirst).not.toHaveBeenCalled();
+    expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
+    expect(recordCashDrawerEntryTxMock).not.toHaveBeenCalled();
+    expect(postJournalEntryMock).not.toHaveBeenCalled();
+    expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it('denies missing role at the service boundary', async () => {
+    await expect(
+      recordSupplierPayment(
+        'biz-1',
+        'purchase-1',
+        [{ method: 'TRANSFER', amountPence: 1000 }],
+        {
+          recordedByUserId: 'user-1',
+          actorRole: '',
+          idempotencyKey: 'idem-no-role',
+        },
+      ),
+    ).rejects.toBeInstanceOf(SupplierPaymentError);
+
+    expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
+  });
+
+  it('returns a safe not-found for cross-tenant invoice ids with no writes', async () => {
+    prismaMock.purchasePayment.findUnique.mockResolvedValue(null);
+    prismaMock.purchaseInvoice.findFirst.mockResolvedValue(null);
+
+    await expect(
+      recordSupplierPayment(
+        'biz-1',
+        'other-tenant-invoice',
+        [{ method: 'CARD', amountPence: 1000 }],
+        { ...ownerOpts, idempotencyKey: 'idem-xtenant' },
+      ),
+    ).rejects.toMatchObject({
+      code: SUPPLIER_PAYMENT_ERROR.NOT_FOUND,
+      message: 'Invoice not found',
+    });
+
+    expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
+    expect(postJournalEntryMock).not.toHaveBeenCalled();
+  });
+
+  it('replays an identical idempotent request without additional financial effects', async () => {
+    const { buildSupplierPaymentPayloadHash } = await import('./payments');
+    const hash = buildSupplierPaymentPayloadHash({
+      businessId: 'biz-1',
+      invoiceId: 'purchase-1',
+      payments: [{ method: 'CARD', amountPence: 2000, reference: null }],
+      paidAtIso: '',
+      notes: '',
+      recordedByUserId: 'user-1',
+    });
+
+    prismaMock.purchasePayment.findUnique.mockResolvedValue({
+      id: 'pp-1',
+      businessId: 'biz-1',
+      purchaseInvoiceId: 'purchase-1',
+      payloadHash: hash,
+      amountPence: 2000,
+      method: 'CARD',
+    });
+    prismaMock.purchaseInvoice.findFirst.mockResolvedValue({
+      id: 'purchase-1',
+      payments: [{ id: 'pp-1', amountPence: 2000 }],
+    });
+
+    const result = await recordSupplierPayment(
+      'biz-1',
+      'purchase-1',
+      [{ method: 'CARD', amountPence: 2000 }],
+      { ...ownerOpts, idempotencyKey: 'idem-replay' },
+    );
+
+    expect(result.replayed).toBe(true);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
+    expect(recordCashDrawerEntryTxMock).not.toHaveBeenCalled();
+    expect(postJournalEntryMock).not.toHaveBeenCalled();
+    expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects same idempotency key with a different amount', async () => {
+    const { buildSupplierPaymentPayloadHash } = await import('./payments');
+    const hash = buildSupplierPaymentPayloadHash({
+      businessId: 'biz-1',
+      invoiceId: 'purchase-1',
+      payments: [{ method: 'CARD', amountPence: 2000, reference: null }],
+      paidAtIso: '',
+      notes: '',
+      recordedByUserId: 'user-1',
+    });
+
+    prismaMock.purchasePayment.findUnique.mockResolvedValue({
+      id: 'pp-1',
+      businessId: 'biz-1',
+      purchaseInvoiceId: 'purchase-1',
+      payloadHash: hash,
+      amountPence: 2000,
+      method: 'CARD',
+    });
+
+    await expect(
+      recordSupplierPayment(
+        'biz-1',
+        'purchase-1',
+        [{ method: 'CARD', amountPence: 3000 }],
+        { ...ownerOpts, idempotencyKey: 'idem-conflict' },
+      ),
+    ).rejects.toMatchObject({
+      code: SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_CONFLICT,
+    });
+
+    expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects same idempotency key with a different supplier invoice', async () => {
+    const { buildSupplierPaymentPayloadHash } = await import('./payments');
+    const hash = buildSupplierPaymentPayloadHash({
+      businessId: 'biz-1',
+      invoiceId: 'purchase-1',
+      payments: [{ method: 'CARD', amountPence: 2000, reference: null }],
+      paidAtIso: '',
+      notes: '',
+      recordedByUserId: 'user-1',
+    });
+
+    prismaMock.purchasePayment.findUnique.mockResolvedValue({
+      id: 'pp-1',
+      businessId: 'biz-1',
+      purchaseInvoiceId: 'purchase-1',
+      payloadHash: hash,
+      amountPence: 2000,
+      method: 'CARD',
+    });
+
+    await expect(
+      recordSupplierPayment(
+        'biz-1',
+        'purchase-2',
+        [{ method: 'CARD', amountPence: 2000 }],
+        { ...ownerOpts, idempotencyKey: 'idem-conflict-inv' },
+      ),
+    ).rejects.toMatchObject({
+      code: SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_CONFLICT,
+    });
+
+    expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
+  });
+
+  it('allows Manager to record a supplier payment', async () => {
+    prismaMock.purchaseInvoice.findFirst.mockResolvedValue({
+      id: 'purchase-1',
+      businessId: 'biz-1',
+      storeId: 'store-1',
+      totalPence: 10000,
+      payments: [],
+      supplier: { id: 's1', name: 'S' },
+    });
+    prismaMock.purchaseInvoice.update.mockResolvedValue({
+      id: 'purchase-1',
+      paymentStatus: 'PART_PAID',
+      payments: [{ amountPence: 1000 }],
+    });
+
+    const result = await recordSupplierPayment(
+      'biz-1',
+      'purchase-1',
+      [{ method: 'TRANSFER', amountPence: 1000 }],
+      {
+        recordedByUserId: 'mgr-1',
+        actorRole: 'MANAGER',
+        actorName: 'Manager',
+        idempotencyKey: 'idem-mgr',
+      },
+    );
+
+    expect(result.replayed).toBe(false);
+    expect(prismaMock.purchasePayment.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires an idempotency key and does not reserve a success record on validation failure', async () => {
+    await expect(
+      recordSupplierPayment(
+        'biz-1',
+        'purchase-1',
+        [{ method: 'CARD', amountPence: 1000 }],
+        {
+          recordedByUserId: 'user-1',
+          actorRole: 'OWNER',
+          idempotencyKey: '   ',
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_REQUIRED,
+    });
+
+    expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
+    expect(prismaMock.purchasePayment.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('replays after unique-constraint race without duplicate posting', async () => {
+    const { buildSupplierPaymentPayloadHash } = await import('./payments');
+    const hash = buildSupplierPaymentPayloadHash({
+      businessId: 'biz-1',
+      invoiceId: 'purchase-1',
+      payments: [{ method: 'CARD', amountPence: 2000, reference: null }],
+      paidAtIso: '',
+      notes: '',
+      recordedByUserId: 'user-1',
+    });
+
+    prismaMock.purchasePayment.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'pp-winner',
+        businessId: 'biz-1',
+        purchaseInvoiceId: 'purchase-1',
+        payloadHash: hash,
+        amountPence: 2000,
+        method: 'CARD',
+      });
+
+    prismaMock.purchaseInvoice.findFirst
+      .mockResolvedValueOnce({
+        id: 'purchase-1',
+        totalPence: 10000,
+        storeId: 'store-1',
+      })
+      .mockResolvedValueOnce({
+        id: 'purchase-1',
+        payments: [{ id: 'pp-winner', amountPence: 2000 }],
+      });
+
+    const uniqueError = Object.assign(new Error('Unique constraint'), {
+      code: 'P2002',
+      meta: { target: ['businessId', 'idempotencyKey'] },
+    });
+    prismaMock.$transaction.mockRejectedValueOnce(uniqueError);
+
+    const result = await recordSupplierPayment(
+      'biz-1',
+      'purchase-1',
+      [{ method: 'CARD', amountPence: 2000 }],
+      { ...ownerOpts, idempotencyKey: 'idem-race' },
+    );
+
+    expect(result.replayed).toBe(true);
+    expect(prismaMock.purchasePayment.create).not.toHaveBeenCalled();
+    expect(postJournalEntryMock).not.toHaveBeenCalled();
   });
 
   it('records customer cash debt collections as cash drawer inflows without revenue', async () => {
@@ -288,5 +588,111 @@ describe('payments service', () => {
       ])
     );
     expect(journalLines.some((line: any) => line.accountCode === '4000')).toBe(false);
+  });
+});
+
+describe('supplier payment GH₵1,400 expected-cash reconciliation (unit)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (callback: any) => callback(prismaMock));
+    prismaMock.purchasePayment.findUnique.mockResolvedValue(null);
+    prismaMock.auditLog.create.mockResolvedValue({ id: 'audit-1' });
+    prismaMock.purchasePayment.create.mockImplementation(async ({ data }: any) => ({
+      id: 'pp-supplier-300',
+      ...data,
+    }));
+  });
+
+  it('posts till-funded supplier cash-out once and keeps expected cash at GH₵1,400 on replay', async () => {
+    // Scenario (minor units): float 50000 + sale 100000 + receipt 20000 - supplier 30000 = 140000
+    const openingCash = 50000;
+    const cashInflows = 100000 + 20000;
+    const supplierCashOut = 30000;
+    const expectedCash = openingCash + cashInflows - supplierCashOut;
+    expect(expectedCash).toBe(140000);
+
+    let shiftExpected = openingCash + cashInflows;
+    recordCashDrawerEntryTxMock.mockImplementation(async (_tx: unknown, input: { amountPence: number }) => {
+      shiftExpected += input.amountPence;
+      return { entry: { id: 'cde-1' }, afterExpectedCashPence: shiftExpected };
+    });
+
+    prismaMock.purchaseInvoice.findFirst.mockResolvedValue({
+      id: 'purchase-600',
+      businessId: 'biz-1',
+      storeId: 'store-1',
+      totalPence: 60000,
+      payments: [],
+      supplier: { id: 'sup-1', name: 'Supplier' },
+    });
+    prismaMock.shift.findFirst.mockResolvedValue({ id: 'shift-1', tillId: 'till-1' });
+    prismaMock.purchaseInvoice.update.mockResolvedValue({
+      id: 'purchase-600',
+      paymentStatus: 'PART_PAID',
+      payments: [{ id: 'pp-supplier-300', amountPence: 30000 }],
+    });
+
+    const first = await recordSupplierPayment(
+      'biz-1',
+      'purchase-600',
+      [{ method: 'CASH', amountPence: 30000 }],
+      {
+        recordedByUserId: 'user-1',
+        actorRole: 'OWNER',
+        actorName: 'Owner',
+        idempotencyKey: 'idem-1400',
+      },
+    );
+
+    expect(first.replayed).toBe(false);
+    expect(shiftExpected).toBe(140000);
+    expect(recordCashDrawerEntryTxMock).toHaveBeenCalledTimes(1);
+    expect(postJournalEntryMock).toHaveBeenCalledTimes(1);
+    expect(prismaMock.purchasePayment.create).toHaveBeenCalledTimes(1);
+
+    const { buildSupplierPaymentPayloadHash } = await import('./payments');
+    const hash = buildSupplierPaymentPayloadHash({
+      businessId: 'biz-1',
+      invoiceId: 'purchase-600',
+      payments: [{ method: 'CASH', amountPence: 30000, reference: null }],
+      paidAtIso: '',
+      notes: '',
+      recordedByUserId: 'user-1',
+    });
+    prismaMock.purchasePayment.findUnique.mockResolvedValue({
+      id: 'pp-supplier-300',
+      businessId: 'biz-1',
+      purchaseInvoiceId: 'purchase-600',
+      payloadHash: hash,
+      amountPence: 30000,
+      method: 'CASH',
+    });
+    prismaMock.purchaseInvoice.findFirst.mockResolvedValue({
+      id: 'purchase-600',
+      payments: [{ id: 'pp-supplier-300', amountPence: 30000 }],
+      totalPence: 60000,
+    });
+
+    const replay = await recordSupplierPayment(
+      'biz-1',
+      'purchase-600',
+      [{ method: 'CASH', amountPence: 30000 }],
+      {
+        recordedByUserId: 'user-1',
+        actorRole: 'OWNER',
+        actorName: 'Owner',
+        idempotencyKey: 'idem-1400',
+      },
+    );
+
+    expect(replay.replayed).toBe(true);
+    expect(shiftExpected).toBe(140000);
+    expect(recordCashDrawerEntryTxMock).toHaveBeenCalledTimes(1);
+    expect(postJournalEntryMock).toHaveBeenCalledTimes(1);
+    expect(prismaMock.purchasePayment.create).toHaveBeenCalledTimes(1);
+    const outstanding =
+      60000 -
+      (replay.invoice?.payments.reduce((s: number, p: { amountPence: number }) => s + p.amountPence, 0) ?? 0);
+    expect(outstanding).toBe(30000);
   });
 });

--- a/lib/services/payments.ts
+++ b/lib/services/payments.ts
@@ -21,6 +21,7 @@ export const SUPPLIER_PAYMENT_ERROR = {
   IDEMPOTENCY_REQUIRED: 'IDEMPOTENCY_REQUIRED',
   IDEMPOTENCY_CONFLICT: 'IDEMPOTENCY_CONFLICT',
   NOT_FOUND: 'NOT_FOUND',
+  TEMPORARILY_UNAVAILABLE: 'TEMPORARILY_UNAVAILABLE',
 } as const;
 
 export class SupplierPaymentError extends UserError {
@@ -46,6 +47,16 @@ export type RecordSupplierPaymentResult = {
   replayed: boolean;
 };
 
+/** Rollout freeze: set TILLFLOW_SUPPLIER_PAYMENT_WRITES=0 during mixed-version cutover. */
+export function assertSupplierPaymentWritesEnabled() {
+  if (process.env.TILLFLOW_SUPPLIER_PAYMENT_WRITES === '0') {
+    throw new SupplierPaymentError(
+      SUPPLIER_PAYMENT_ERROR.TEMPORARILY_UNAVAILABLE,
+      'Supplier payments are temporarily unavailable during a system update. Refresh the page and try again in a moment.',
+    );
+  }
+}
+
 function assertCanRecordSupplierPayment(actorRole: string | undefined) {
   if (!actorRole || !SUPPLIER_PAYMENT_ROLES.includes(actorRole as Role)) {
     throw new SupplierPaymentError(
@@ -55,18 +66,21 @@ function assertCanRecordSupplierPayment(actorRole: string | undefined) {
   }
 }
 
+const STALE_CLIENT_IDEMPOTENCY_MESSAGE =
+  'This payment form is out of date. Refresh the page or reopen the payment form, then try again.';
+
 function normalizeIdempotencyKey(raw: string | undefined): string {
   const key = raw?.trim() ?? '';
   if (!key) {
     throw new SupplierPaymentError(
       SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_REQUIRED,
-      'Idempotency key is required.',
+      STALE_CLIENT_IDEMPOTENCY_MESSAGE,
     );
   }
-  if (key.length > 128) {
+  if (key.length > 128 || /[\u0000-\u001f]/.test(key)) {
     throw new SupplierPaymentError(
       SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_REQUIRED,
-      'Idempotency key is invalid.',
+      STALE_CLIENT_IDEMPOTENCY_MESSAGE,
     );
   }
   return key;
@@ -273,6 +287,7 @@ async function recordSupplierPaymentImpl(
   payments: PaymentInput[],
   options: RecordSupplierPaymentOptions,
 ): Promise<RecordSupplierPaymentResult> {
+  assertSupplierPaymentWritesEnabled();
   assertCanRecordSupplierPayment(options.actorRole);
   const idempotencyKey = normalizeIdempotencyKey(options.idempotencyKey);
   const recordedByUserId = options.recordedByUserId;

--- a/lib/services/payments.ts
+++ b/lib/services/payments.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { prisma } from '@/lib/prisma';
 import { ACCOUNT_CODES, postJournalEntry } from '@/lib/accounting';
 import {
@@ -10,6 +11,121 @@ import {
 } from './shared';
 import { getOpenCashShiftForPayment, recordCashDrawerEntryTx } from './cash-drawer';
 import { measureServerOperation, PERFORMANCE_THRESHOLDS_MS } from '@/lib/observability';
+import { UserError } from '@/lib/action-utils';
+import type { Role } from '@/lib/auth';
+
+const SUPPLIER_PAYMENT_ROLES: readonly Role[] = ['OWNER', 'MANAGER'];
+
+export const SUPPLIER_PAYMENT_ERROR = {
+  FORBIDDEN: 'FORBIDDEN',
+  IDEMPOTENCY_REQUIRED: 'IDEMPOTENCY_REQUIRED',
+  IDEMPOTENCY_CONFLICT: 'IDEMPOTENCY_CONFLICT',
+  NOT_FOUND: 'NOT_FOUND',
+} as const;
+
+export class SupplierPaymentError extends UserError {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = 'SupplierPaymentError';
+  }
+}
+
+export type RecordSupplierPaymentOptions = {
+  paidAt?: Date;
+  recordedByUserId: string;
+  actorRole: string;
+  actorName?: string | null;
+  notes?: string;
+  idempotencyKey: string;
+};
+
+export type RecordSupplierPaymentResult = {
+  invoice: Awaited<ReturnType<typeof loadPurchaseInvoiceWithPayments>>;
+  replayed: boolean;
+};
+
+function assertCanRecordSupplierPayment(actorRole: string | undefined) {
+  if (!actorRole || !SUPPLIER_PAYMENT_ROLES.includes(actorRole as Role)) {
+    throw new SupplierPaymentError(
+      SUPPLIER_PAYMENT_ERROR.FORBIDDEN,
+      'You do not have permission to record supplier payments.',
+    );
+  }
+}
+
+function normalizeIdempotencyKey(raw: string | undefined): string {
+  const key = raw?.trim() ?? '';
+  if (!key) {
+    throw new SupplierPaymentError(
+      SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_REQUIRED,
+      'Idempotency key is required.',
+    );
+  }
+  if (key.length > 128) {
+    throw new SupplierPaymentError(
+      SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_REQUIRED,
+      'Idempotency key is invalid.',
+    );
+  }
+  return key;
+}
+
+/** Canonical hash binding business, invoice, amounts, methods, funding, and payment date. */
+export function buildSupplierPaymentPayloadHash(parts: {
+  businessId: string;
+  invoiceId: string;
+  payments: Array<{ method: string; amountPence: number; reference?: string | null }>;
+  paidAtIso: string;
+  notes: string;
+  recordedByUserId: string;
+}): string {
+  const paymentCanon = parts.payments
+    .map((p) => `${p.method}:${p.amountPence}:${p.reference ?? ''}`)
+    .join('|');
+  const canonical = [
+    parts.businessId,
+    'SUPPLIER_PAYMENT',
+    parts.invoiceId,
+    paymentCanon,
+    parts.paidAtIso,
+    parts.notes,
+    parts.recordedByUserId,
+  ].join('\0');
+  return createHash('sha256').update(canonical, 'utf8').digest('hex');
+}
+
+function isPrismaUniqueConstraintOn(error: unknown, fields: string[]): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const e = error as { code?: string; meta?: { target?: string[] | string } };
+  if (e.code !== 'P2002') return false;
+  const target = e.meta?.target;
+  if (!target) return false;
+  const targets = Array.isArray(target) ? target : [target];
+  return fields.every((field) => targets.some((t) => String(t).includes(field)));
+}
+
+async function loadPurchaseInvoiceWithPayments(businessId: string, invoiceId: string, tx: typeof prisma | any = prisma) {
+  return tx.purchaseInvoice.findFirst({
+    where: { id: invoiceId, businessId },
+    include: { payments: true },
+  });
+}
+
+async function findByIdempotencyKey(businessId: string, idempotencyKey: string, tx: typeof prisma | any = prisma) {
+  return tx.purchasePayment.findUnique({
+    where: { businessId_idempotencyKey: { businessId, idempotencyKey } },
+    select: {
+      id: true,
+      businessId: true,
+      purchaseInvoiceId: true,
+      payloadHash: true,
+      amountPence: true,
+      method: true,
+    },
+  });
+}
 
 /**
  * Record additional payment(s) against an existing sales invoice.
@@ -130,18 +246,17 @@ async function recordCustomerPaymentImpl(
 
 /**
  * Record additional payment(s) against an existing purchase invoice.
+ * Owner/Manager only. Durable idempotency covers payment, allocation, drawer, journal, and audit.
  */
 export async function recordSupplierPayment(
   businessId: string,
   invoiceId: string,
   payments: PaymentInput[],
-  paidAt?: Date,
-  recordedByUserId?: string,
-  notes?: string
-) {
+  options: RecordSupplierPaymentOptions,
+): Promise<RecordSupplierPaymentResult> {
   return measureServerOperation(
     'action.supplier-payment.record',
-    () => recordSupplierPaymentImpl(businessId, invoiceId, payments, paidAt, recordedByUserId, notes),
+    () => recordSupplierPaymentImpl(businessId, invoiceId, payments, options),
     {
       businessId,
       action: 'recordSupplierPaymentAction',
@@ -156,108 +271,231 @@ async function recordSupplierPaymentImpl(
   businessId: string,
   invoiceId: string,
   payments: PaymentInput[],
-  paidAt?: Date,
-  recordedByUserId?: string,
-  notes?: string
-) {
+  options: RecordSupplierPaymentOptions,
+): Promise<RecordSupplierPaymentResult> {
+  assertCanRecordSupplierPayment(options.actorRole);
+  const idempotencyKey = normalizeIdempotencyKey(options.idempotencyKey);
+  const recordedByUserId = options.recordedByUserId;
+  if (!recordedByUserId) {
+    throw new SupplierPaymentError(SUPPLIER_PAYMENT_ERROR.FORBIDDEN, 'You do not have permission to record supplier payments.');
+  }
+
+  const newPayments = filterPositivePayments(payments);
+  if (newPayments.length === 0) {
+    const invoice = await loadPurchaseInvoiceWithPayments(businessId, invoiceId);
+    if (!invoice) {
+      throw new SupplierPaymentError(SUPPLIER_PAYMENT_ERROR.NOT_FOUND, 'Invoice not found');
+    }
+    return { invoice, replayed: false };
+  }
+
+  const paidAt = options.paidAt;
+  const notes = options.notes?.trim() || '';
+  const paidAtIso = paidAt ? paidAt.toISOString().slice(0, 10) : '';
+  const payloadHash = buildSupplierPaymentPayloadHash({
+    businessId,
+    invoiceId,
+    payments: newPayments.map((p) => ({
+      method: p.method,
+      amountPence: p.amountPence,
+      reference: p.reference ?? null,
+    })),
+    paidAtIso,
+    notes,
+    recordedByUserId,
+  });
+
+  const existing = await findByIdempotencyKey(businessId, idempotencyKey);
+  if (existing) {
+    if (existing.payloadHash === payloadHash && existing.purchaseInvoiceId === invoiceId) {
+      const invoice = await loadPurchaseInvoiceWithPayments(businessId, invoiceId);
+      if (!invoice) {
+        throw new SupplierPaymentError(SUPPLIER_PAYMENT_ERROR.NOT_FOUND, 'Invoice not found');
+      }
+      return { invoice, replayed: true };
+    }
+    throw new SupplierPaymentError(
+      SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_CONFLICT,
+      'This payment request conflicts with a previous submission.',
+    );
+  }
+
   const invoiceBase = await prisma.purchaseInvoice.findFirst({
     where: { id: invoiceId, businessId },
     select: { id: true, totalPence: true, storeId: true },
   });
-  if (!invoiceBase) throw new Error('Invoice not found');
-
-  const newPayments = filterPositivePayments(payments);
-  if (newPayments.length === 0) return prisma.purchaseInvoice.findFirst({ where: { id: invoiceId }, include: { payments: true } });
+  if (!invoiceBase) {
+    throw new SupplierPaymentError(SUPPLIER_PAYMENT_ERROR.NOT_FOUND, 'Invoice not found');
+  }
 
   const split = splitPayments(newPayments);
-  const updated = await prisma.$transaction(async (tx) => {
-    // Re-read payments inside the transaction to prevent concurrent overpayment.
-    const invoice = await tx.purchaseInvoice.findFirst({
-      where: { id: invoiceId, businessId },
-      include: {
-        payments: true,
-        supplier: { select: { id: true, name: true } },
-      },
-    });
-    if (!invoice) throw new Error('Invoice not found');
 
-    const previouslyPaid = invoice.payments.reduce((s, p) => s + p.amountPence, 0);
-    const newPaid = newPayments.reduce((s, p) => s + p.amountPence, 0);
-    const totalPaid = previouslyPaid + newPaid;
-    if (totalPaid > invoice.totalPence) throw new Error('Payment exceeds outstanding balance');
+  try {
+    const updated = await prisma.$transaction(async (tx) => {
+      // Re-check idempotency inside the transaction for concurrent races.
+      const existingInTx = await findByIdempotencyKey(businessId, idempotencyKey, tx);
+      if (existingInTx) {
+        if (existingInTx.payloadHash === payloadHash && existingInTx.purchaseInvoiceId === invoiceId) {
+          const invoice = await loadPurchaseInvoiceWithPayments(businessId, invoiceId, tx);
+          if (!invoice) {
+            throw new SupplierPaymentError(SUPPLIER_PAYMENT_ERROR.NOT_FOUND, 'Invoice not found');
+          }
+          return { invoice, replayed: true as const };
+        }
+        throw new SupplierPaymentError(
+          SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_CONFLICT,
+          'This payment request conflicts with a previous submission.',
+        );
+      }
 
-    const status = derivePaymentStatus(invoice.totalPence, totalPaid);
-
-    const openShift = split.cashPence > 0
-      ? await getOpenCashShiftForPayment(tx, {
-          businessId,
-          storeId: invoice.storeId,
-          userId: recordedByUserId,
-        })
-      : null;
-
-    if (split.cashPence > 0 && (!recordedByUserId || !openShift)) {
-      throw new Error('Open shift is required before recording cash supplier payments.');
-    }
-
-    const createdPayments = [];
-    for (const p of newPayments) {
-      const createdPayment = await tx.purchasePayment.create({
-        data: {
-          purchaseInvoiceId: invoice.id,
-          method: p.method,
-          amountPence: p.amountPence,
-          reference: p.reference ?? null,
-          ...(paidAt ? { paidAt } : {}),
-          ...(recordedByUserId ? { recordedByUserId } : {}),
-          ...(notes ? { notes } : {}),
+      const invoice = await tx.purchaseInvoice.findFirst({
+        where: { id: invoiceId, businessId },
+        include: {
+          payments: true,
+          supplier: { select: { id: true, name: true } },
         },
       });
-      createdPayments.push(createdPayment);
-    }
-
-    if (openShift && recordedByUserId) {
-      for (const payment of createdPayments.filter((p) => p.method === 'CASH' && p.amountPence > 0)) {
-        await recordCashDrawerEntryTx(tx, {
-          businessId,
-          storeId: invoice.storeId,
-          tillId: openShift.tillId,
-          shiftId: openShift.id,
-          createdByUserId: recordedByUserId,
-          cashierUserId: recordedByUserId,
-          entryType: 'PAID_OUT_SUPPLIER',
-          amountPence: -payment.amountPence,
-          reasonCode: 'SUPPLIER_PAYMENT',
-          reason: invoice.supplier?.name
-            ? `Cash paid to supplier: ${invoice.supplier.name}`
-            : 'Cash paid to supplier',
-          referenceType: 'PURCHASE_PAYMENT',
-          referenceId: payment.id,
-        });
+      if (!invoice) {
+        throw new SupplierPaymentError(SUPPLIER_PAYMENT_ERROR.NOT_FOUND, 'Invoice not found');
       }
+
+      const previouslyPaid = invoice.payments.reduce((s, p) => s + p.amountPence, 0);
+      const newPaid = newPayments.reduce((s, p) => s + p.amountPence, 0);
+      const totalPaid = previouslyPaid + newPaid;
+      if (totalPaid > invoice.totalPence) throw new Error('Payment exceeds outstanding balance');
+
+      const status = derivePaymentStatus(invoice.totalPence, totalPaid);
+
+      const openShift = split.cashPence > 0
+        ? await getOpenCashShiftForPayment(tx, {
+            businessId,
+            storeId: invoice.storeId,
+            userId: recordedByUserId,
+          })
+        : null;
+
+      if (split.cashPence > 0 && !openShift) {
+        throw new Error('Open shift is required before recording cash supplier payments.');
+      }
+
+      const createdPayments = [];
+      for (let i = 0; i < newPayments.length; i++) {
+        const p = newPayments[i]!;
+        const createdPayment = await tx.purchasePayment.create({
+          data: {
+            businessId,
+            purchaseInvoiceId: invoice.id,
+            method: p.method,
+            amountPence: p.amountPence,
+            reference: p.reference ?? null,
+            ...(paidAt ? { paidAt } : {}),
+            recordedByUserId,
+            ...(notes ? { notes } : {}),
+            // Bind the durable key to the first payment row of this economic event.
+            ...(i === 0
+              ? { idempotencyKey, payloadHash }
+              : {}),
+          },
+        });
+        createdPayments.push(createdPayment);
+      }
+
+      if (openShift) {
+        for (const payment of createdPayments.filter((p) => p.method === 'CASH' && p.amountPence > 0)) {
+          await recordCashDrawerEntryTx(tx, {
+            businessId,
+            storeId: invoice.storeId,
+            tillId: openShift.tillId,
+            shiftId: openShift.id,
+            createdByUserId: recordedByUserId,
+            cashierUserId: recordedByUserId,
+            entryType: 'PAID_OUT_SUPPLIER',
+            amountPence: -payment.amountPence,
+            reasonCode: 'SUPPLIER_PAYMENT',
+            reason: invoice.supplier?.name
+              ? `Cash paid to supplier: ${invoice.supplier.name}`
+              : 'Cash paid to supplier',
+            referenceType: 'PURCHASE_PAYMENT',
+            referenceId: payment.id,
+            actor: {
+              userId: recordedByUserId,
+              userName: options.actorName ?? 'Unknown',
+              userRole: options.actorRole,
+            },
+          });
+        }
+      }
+
+      const updatedInvoice = await tx.purchaseInvoice.update({
+        where: { id: invoice.id },
+        data: { paymentStatus: status },
+        include: { payments: true }
+      });
+
+      await postJournalEntry({
+        businessId,
+        description: `Supplier payment ${invoice.id}`,
+        referenceType: 'SUPPLIER_PAYMENT',
+        referenceId: invoice.id,
+        lines: [
+          { accountCode: ACCOUNT_CODES.ap, debitPence: split.totalPence },
+          ...(split.cashPence > 0 ? [{ accountCode: ACCOUNT_CODES.cash, creditPence: split.cashPence }] : []),
+          ...(split.bankPence > 0 ? [{ accountCode: ACCOUNT_CODES.bank, creditPence: split.bankPence }] : [])
+        ],
+        prismaClient: tx as any
+      });
+
+      const primaryPayment = createdPayments[0]!;
+      await tx.auditLog.create({
+        data: {
+          businessId,
+          userId: recordedByUserId,
+          userName: options.actorName ?? 'Unknown',
+          userRole: options.actorRole,
+          action: 'SUPPLIER_PAYMENT',
+          entity: 'PurchasePayment',
+          entityId: primaryPayment.id,
+          beforeState: null,
+          afterState: JSON.stringify({
+            purchaseInvoiceId: invoice.id,
+            amountPence: split.totalPence,
+            methods: newPayments.map((p) => p.method),
+            idempotencyKey,
+            payloadHash,
+            cashDrawer: Boolean(openShift && split.cashPence > 0),
+          }),
+          reason: notes || null,
+          details: JSON.stringify({
+            purchaseInvoiceId: invoice.id,
+            supplierId: invoice.supplier?.id ?? null,
+            paymentIds: createdPayments.map((p) => p.id),
+            replayed: false,
+          }),
+          branchId: null,
+          actionType: 'PAYMENT',
+          entityType: 'PURCHASE_PAYMENT',
+        },
+      });
+
+      return { invoice: updatedInvoice, replayed: false as const };
+    });
+
+    return updated;
+  } catch (error) {
+    if (isPrismaUniqueConstraintOn(error, ['businessId', 'idempotencyKey'])) {
+      const winner = await findByIdempotencyKey(businessId, idempotencyKey);
+      if (winner && winner.payloadHash === payloadHash && winner.purchaseInvoiceId === invoiceId) {
+        const invoice = await loadPurchaseInvoiceWithPayments(businessId, invoiceId);
+        if (!invoice) {
+          throw new SupplierPaymentError(SUPPLIER_PAYMENT_ERROR.NOT_FOUND, 'Invoice not found');
+        }
+        return { invoice, replayed: true };
+      }
+      throw new SupplierPaymentError(
+        SUPPLIER_PAYMENT_ERROR.IDEMPOTENCY_CONFLICT,
+        'This payment request conflicts with a previous submission.',
+      );
     }
-
-    const updatedInvoice = await tx.purchaseInvoice.update({
-      where: { id: invoice.id },
-      data: { paymentStatus: status },
-      include: { payments: true }
-    });
-
-    await postJournalEntry({
-      businessId,
-      description: `Supplier payment ${invoice.id}`,
-      referenceType: 'SUPPLIER_PAYMENT',
-      referenceId: invoice.id,
-      lines: [
-        { accountCode: ACCOUNT_CODES.ap, debitPence: split.totalPence },
-        ...(split.cashPence > 0 ? [{ accountCode: ACCOUNT_CODES.cash, creditPence: split.cashPence }] : []),
-        ...(split.bankPence > 0 ? [{ accountCode: ACCOUNT_CODES.bank, creditPence: split.bankPence }] : [])
-      ],
-      prismaClient: tx as any
-    });
-
-    return updatedInvoice;
-  });
-
-  return updated;
+    throw error;
+  }
 }

--- a/lib/services/people-clarity.test.ts
+++ b/lib/services/people-clarity.test.ts
@@ -7,6 +7,7 @@ describe('Customer and Supplier reporting clarity', () => {
   const supplierListSrc   = readFileSync(join(process.cwd(), 'app/(protected)/suppliers/page.tsx'), 'utf8');
   const customerReceiptsSrc = readFileSync(join(process.cwd(), 'app/(protected)/payments/customer-receipts/page.tsx'), 'utf8');
   const supplierPaymentsSrc = readFileSync(join(process.cwd(), 'app/(protected)/payments/supplier-payments/page.tsx'), 'utf8');
+  const supplierPaymentFormSrc = readFileSync(join(process.cwd(), 'components/SupplierPaymentForm.tsx'), 'utf8');
   const customerDetailSrc = readFileSync(join(process.cwd(), 'app/(protected)/customers/[id]/page.tsx'), 'utf8');
   const supplierDetailSrc = readFileSync(join(process.cwd(), 'app/(protected)/suppliers/[id]/page.tsx'), 'utf8');
   const supplierAgingSrc  = readFileSync(join(process.cwd(), 'app/(protected)/payments/supplier-aging/page.tsx'), 'utf8');
@@ -106,28 +107,30 @@ describe('Customer and Supplier reporting clarity', () => {
   });
 
   it('22. "Mobile Money (MoMo)" option label is present', () => {
-    expect(supplierPaymentsSrc).toContain('Mobile Money (MoMo)');
+    expect(supplierPaymentFormSrc).toContain('Mobile Money (MoMo)');
   });
 
   it('23. "Bank Transfer" option label is present', () => {
-    expect(supplierPaymentsSrc).toContain('Bank Transfer');
+    expect(supplierPaymentFormSrc).toContain('Bank Transfer');
   });
 
   it('24. value="TRANSFER" remains present (form value unchanged)', () => {
-    expect(supplierPaymentsSrc).toContain('value="TRANSFER"');
+    expect(supplierPaymentFormSrc).toContain('value="TRANSFER"');
   });
 
   it('25. value="MOBILE_MONEY" remains present (form value unchanged)', () => {
-    expect(supplierPaymentsSrc).toContain('value="MOBILE_MONEY"');
+    expect(supplierPaymentFormSrc).toContain('value="MOBILE_MONEY"');
   });
 
   it('26. Recent payments do not display raw payment method strings as text', () => {
     expect(supplierPaymentsSrc).not.toContain('{payment.method}');
   });
 
-  it('27. recordSupplierPaymentAction import remains unchanged', () => {
-    expect(supplierPaymentsSrc).toContain("from '@/app/actions/payments'");
-    expect(supplierPaymentsSrc).toContain('recordSupplierPaymentAction');
+  it('27. recordSupplierPaymentAction remains wired through SupplierPaymentForm', () => {
+    expect(supplierPaymentsSrc).toContain('SupplierPaymentForm');
+    expect(supplierPaymentFormSrc).toContain("from '@/app/actions/payments'");
+    expect(supplierPaymentFormSrc).toContain('recordSupplierPaymentAction');
+    expect(supplierPaymentFormSrc).toContain('name="idempotencyKey"');
   });
 
   // ── Customer detail page ───────────────────────────────────────────────

--- a/lib/services/purchase-cash-drawer.test.ts
+++ b/lib/services/purchase-cash-drawer.test.ts
@@ -56,7 +56,7 @@ vi.mock('./shared', async () => {
 });
 
 import { createPurchase } from './purchases';
-import { findOrphanCashPurchasePayments, summarizeCashDrawerEntries } from './cash-drawer';
+import { findOrphanCashPurchasePayments, summarizeCashDrawerEntries, assessHistoricalCashSupplierPayments } from './cash-drawer';
 
 const bizId = 'biz-1';
 const storeId = 'store-1';
@@ -304,5 +304,78 @@ describe('purchase invoice cash drawer linkage', () => {
     );
 
     expect(orphans.map((payment) => payment.id)).toEqual(['pay-1']);
+  });
+
+  it('classifies historical cash supplier payments without treating missing idempotency as orphan', () => {
+    const aggregates = assessHistoricalCashSupplierPayments([
+      {
+        id: 'a',
+        amountPence: 1000,
+        paidAt: new Date(),
+        recordedByUserId: 'u1',
+        linkedDrawerCount: 1,
+        shiftStatus: 'CLOSED',
+      },
+      {
+        id: 'b',
+        amountPence: 2000,
+        paidAt: new Date(),
+        recordedByUserId: 'u1',
+        linkedDrawerCount: 0,
+        shiftStatus: 'NONE',
+      },
+      {
+        id: 'c',
+        amountPence: 3000,
+        paidAt: new Date(),
+        recordedByUserId: 'u1',
+        linkedDrawerCount: 2,
+        shiftStatus: 'MIXED',
+      },
+      {
+        id: 'd',
+        amountPence: 4000,
+        paidAt: new Date(),
+        recordedByUserId: null,
+        linkedDrawerCount: 0,
+        shiftStatus: 'NONE',
+      },
+      {
+        id: 'e',
+        amountPence: 5000,
+        paidAt: new Date(),
+        recordedByUserId: 'u1',
+        linkedDrawerCount: 1,
+        shiftStatus: 'NONE',
+      },
+    ]);
+
+    const byCat = Object.fromEntries(aggregates.map((a) => [a.category, a]));
+    expect(byCat.properly_linked).toMatchObject({
+      recordCount: 1,
+      aggregateValuePence: 1000,
+      closedShiftExposureCount: 1,
+      deterministic: true,
+    });
+    expect(byCat.missing_drawer_link).toMatchObject({
+      recordCount: 1,
+      aggregateValuePence: 2000,
+      deterministic: true,
+    });
+    expect(byCat.duplicate_drawer_links).toMatchObject({
+      recordCount: 1,
+      aggregateValuePence: 3000,
+      closedShiftExposureCount: 1,
+    });
+    expect(byCat.funding_source_ambiguous).toMatchObject({
+      recordCount: 1,
+      aggregateValuePence: 4000,
+      deterministic: false,
+    });
+    expect(byCat.shift_association_unavailable).toMatchObject({
+      recordCount: 1,
+      aggregateValuePence: 5000,
+      deterministic: false,
+    });
   });
 });

--- a/lib/services/suppliers-ledger.test.ts
+++ b/lib/services/suppliers-ledger.test.ts
@@ -236,8 +236,8 @@ describe('supplier payments page — supplierId support', () => {
   });
 
   it('returns to the supplier profile after recording a filtered payment', () => {
-    expect(src).toContain('name="returnTo"');
-    expect(src).toContain('value={`/suppliers/${linkedSupplier.id}`}');
+    expect(src).toContain('SupplierPaymentForm');
+    expect(src).toContain('returnTo={linkedSupplier ? `/suppliers/${linkedSupplier.id}` : undefined}');
   });
 
   it('uses owner-friendly page title and subtitle', () => {
@@ -253,12 +253,19 @@ describe('supplier payments page — supplierId support', () => {
     expect(src).toContain('mode="cards"');
     expect(src).toContain('active:scale-[0.98]');
     expect(src).toContain('hover:-translate-y-px');
-    expect(src).toContain('action={recordSupplierPaymentAction}');
-    expect(src).toContain('name="invoiceId"');
-    expect(src).toContain('name="paymentMethod"');
-    expect(src).toContain('name="amount"');
-    expect(src).toContain('name="paidAt"');
-    expect(src).toContain('name="notes"');
+    expect(src).toContain('<SupplierPaymentForm');
+    expect(src).toContain('invoiceId={invoiceId}');
+  });
+
+  it('SupplierPaymentForm carries method/amount fields and idempotency key', () => {
+    const formSrc = readFileSync(join(process.cwd(), 'components/SupplierPaymentForm.tsx'), 'utf8');
+    expect(formSrc).toContain('action={recordSupplierPaymentAction}');
+    expect(formSrc).toContain('name="invoiceId"');
+    expect(formSrc).toContain('name="idempotencyKey"');
+    expect(formSrc).toContain('name="paymentMethod"');
+    expect(formSrc).toContain('name="amount"');
+    expect(formSrc).toContain('name="paidAt"');
+    expect(formSrc).toContain('name="notes"');
   });
 
   it('keeps recent supplier payments visible with a helpful empty state', () => {

--- a/prisma/migrations/20260805190000_supplier_payment_idempotency/migration.sql
+++ b/prisma/migrations/20260805190000_supplier_payment_idempotency/migration.sql
@@ -1,0 +1,24 @@
+-- Additive supplier-payment idempotency support.
+-- Historical rows keep NULL idempotencyKey / payloadHash and are not reinterpreted.
+-- businessId is denormalized for tenant-scoped uniqueness (NULL keys do not collide).
+
+ALTER TABLE "PurchasePayment" ADD COLUMN "businessId" TEXT;
+ALTER TABLE "PurchasePayment" ADD COLUMN "idempotencyKey" TEXT;
+ALTER TABLE "PurchasePayment" ADD COLUMN "payloadHash" TEXT;
+
+UPDATE "PurchasePayment" AS pp
+SET "businessId" = pi."businessId"
+FROM "PurchaseInvoice" AS pi
+WHERE pp."purchaseInvoiceId" = pi."id"
+  AND pp."businessId" IS NULL;
+
+ALTER TABLE "PurchasePayment"
+  ADD CONSTRAINT "PurchasePayment_businessId_fkey"
+  FOREIGN KEY ("businessId") REFERENCES "Business"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "PurchasePayment_businessId_idempotencyKey_key"
+  ON "PurchasePayment"("businessId", "idempotencyKey");
+
+CREATE INDEX "PurchasePayment_businessId_paidAt_idx"
+  ON "PurchasePayment"("businessId", "paidAt");

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -183,6 +183,7 @@ model Business {
   expensePayments        ExpensePayment[]
   salesInvoices          SalesInvoice[]
   purchaseInvoices       PurchaseInvoice[]
+  purchasePayments       PurchasePayment[]
   mobileMoneyCollections MobileMoneyCollection[]
   cashDrawerEntries      CashDrawerEntry[]
   riskAlerts             RiskAlert[]
@@ -1191,6 +1192,7 @@ model PurchaseInvoiceLine {
 
 model PurchasePayment {
   id                String   @id @default(cuid())
+  businessId        String?
   purchaseInvoiceId String
   method            String
   amountPence       Int
@@ -1198,14 +1200,21 @@ model PurchasePayment {
   reference         String?
   recordedByUserId  String?
   notes             String?
+  /// Client/server idempotency key; unique per business when set. Null on pre-hardening rows.
+  idempotencyKey    String?
+  /// SHA-256 of the canonical supplier-payment request payload.
+  payloadHash       String?
   qaTag             String?
   qaRunId           String?
 
+  business        Business?       @relation(fields: [businessId], references: [id], onDelete: SetNull)
   purchaseInvoice PurchaseInvoice @relation(fields: [purchaseInvoiceId], references: [id], onDelete: Cascade)
   recordedBy      User?           @relation("PurchasePaymentRecordedBy", fields: [recordedByUserId], references: [id])
 
+  @@unique([businessId, idempotencyKey])
   @@index([purchaseInvoiceId, paidAt])
   @@index([paidAt])
+  @@index([businessId, paidAt])
 }
 
 model Account {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -185,6 +185,7 @@ model Business {
   expensePayments        ExpensePayment[]
   salesInvoices          SalesInvoice[]
   purchaseInvoices       PurchaseInvoice[]
+  purchasePayments       PurchasePayment[]
   mobileMoneyCollections MobileMoneyCollection[]
   cashDrawerEntries      CashDrawerEntry[]
   riskAlerts             RiskAlert[]
@@ -1222,6 +1223,7 @@ model PurchaseInvoiceLine {
 
 model PurchasePayment {
   id                String   @id @default(cuid())
+  businessId        String?
   purchaseInvoiceId String
   method            String
   amountPence       Int
@@ -1229,14 +1231,21 @@ model PurchasePayment {
   reference         String?
   recordedByUserId  String?
   notes             String?
+  /// Client/server idempotency key; unique per business when set. Null on pre-hardening rows.
+  idempotencyKey    String?
+  /// SHA-256 of the canonical supplier-payment request payload.
+  payloadHash       String?
   qaTag             String?
   qaRunId           String?
 
+  business        Business?       @relation(fields: [businessId], references: [id], onDelete: SetNull)
   purchaseInvoice PurchaseInvoice @relation(fields: [purchaseInvoiceId], references: [id], onDelete: Cascade)
   recordedBy      User?           @relation("PurchasePaymentRecordedBy", fields: [recordedByUserId], references: [id])
 
+  @@unique([businessId, idempotencyKey])
   @@index([purchaseInvoiceId, paidAt])
   @@index([paidAt])
+  @@index([businessId, paidAt])
 }
 
 model Account {

--- a/scripts/assess-supplier-payment-orphans.ts
+++ b/scripts/assess-supplier-payment-orphans.ts
@@ -1,0 +1,194 @@
+/**
+ * Read-only historical assessment: cash supplier payments vs linked drawer cash-outs.
+ *
+ * Performs no inserts, updates, or deletes.
+ * Tenant-scoped. Does not expose customer PII.
+ *
+ * Usage (authorised isolated or Production read-only when separately approved):
+ *   npx tsx scripts/assess-supplier-payment-orphans.ts --businessId=<id>
+ *
+ * Optional:
+ *   --json   machine-readable aggregates only
+ *
+ * Do NOT run against Production unless authorised read-only connectivity already exists.
+ */
+import { PrismaClient } from '@prisma/client';
+import {
+  assessHistoricalCashSupplierPayments,
+  type HistoricalCashSupplierPaymentAssessmentRow,
+} from '../lib/services/cash-drawer';
+
+function formatGhs(pence: number) {
+  return `GH₵${(pence / 100).toFixed(2)}`;
+}
+
+function parseArgs(argv: string[]) {
+  const businessId = argv.find((a) => a.startsWith('--businessId='))?.slice('--businessId='.length)?.trim();
+  const asJson = argv.includes('--json');
+  return { businessId, asJson };
+}
+
+async function main() {
+  const { businessId, asJson } = parseArgs(process.argv.slice(2));
+  if (!businessId) {
+    console.error('Usage: npx tsx scripts/assess-supplier-payment-orphans.ts --businessId=<id> [--json]');
+    process.exit(2);
+  }
+
+  const prisma = new PrismaClient({
+    datasources: process.env.DATABASE_URL ? { db: { url: process.env.DATABASE_URL } } : undefined,
+  });
+
+  try {
+    const business = await prisma.business.findUnique({
+      where: { id: businessId },
+      select: { id: true, name: true, currency: true },
+    });
+    if (!business) {
+      console.error('Business not found for the provided id (existence not disclosed beyond this message).');
+      process.exit(1);
+    }
+
+    const payments = await prisma.purchasePayment.findMany({
+      where: {
+        method: 'CASH',
+        amountPence: { gt: 0 },
+        OR: [
+          { businessId },
+          { purchaseInvoice: { businessId } },
+        ],
+      },
+      select: {
+        id: true,
+        amountPence: true,
+        paidAt: true,
+        recordedByUserId: true,
+      },
+      orderBy: { paidAt: 'asc' },
+    });
+
+    const paymentIds = payments.map((p) => p.id);
+    const drawerEntries =
+      paymentIds.length === 0
+        ? []
+        : await prisma.cashDrawerEntry.findMany({
+            where: {
+              businessId,
+              entryType: 'PAID_OUT_SUPPLIER',
+              referenceType: 'PURCHASE_PAYMENT',
+              referenceId: { in: paymentIds },
+            },
+            select: {
+              id: true,
+              referenceId: true,
+              shiftId: true,
+              shift: { select: { status: true } },
+            },
+          });
+
+    const byPayment = new Map<string, typeof drawerEntries>();
+    for (const entry of drawerEntries) {
+      if (!entry.referenceId) continue;
+      const list = byPayment.get(entry.referenceId) ?? [];
+      list.push(entry);
+      byPayment.set(entry.referenceId, list);
+    }
+
+    const rows: HistoricalCashSupplierPaymentAssessmentRow[] = payments.map((payment) => {
+      const links = byPayment.get(payment.id) ?? [];
+      const statuses = links
+        .map((l) => l.shift?.status)
+        .filter((s): s is string => Boolean(s));
+      let shiftStatus: HistoricalCashSupplierPaymentAssessmentRow['shiftStatus'] = null;
+      if (links.length === 0) {
+        shiftStatus = 'NONE';
+      } else if (statuses.length === 0) {
+        shiftStatus = 'NONE';
+      } else if (statuses.every((s) => s === 'OPEN')) {
+        shiftStatus = 'OPEN';
+      } else if (statuses.every((s) => s === 'CLOSED')) {
+        shiftStatus = 'CLOSED';
+      } else {
+        shiftStatus = 'MIXED';
+      }
+
+      return {
+        id: payment.id,
+        amountPence: payment.amountPence,
+        paidAt: payment.paidAt,
+        recordedByUserId: payment.recordedByUserId,
+        linkedDrawerCount: links.length,
+        shiftStatus,
+      };
+    });
+
+    const aggregates = assessHistoricalCashSupplierPayments(rows);
+
+    if (asJson) {
+      console.log(
+        JSON.stringify(
+          {
+            readOnly: true,
+            businessId: business.id,
+            currency: business.currency,
+            aggregates: aggregates.map((a) => ({
+              ...a,
+              aggregateValueFormatted: formatGhs(a.aggregateValuePence),
+            })),
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    console.log('TillFlow — read-only cash supplier-payment orphan assessment');
+    console.log(`Business: ${business.id}`);
+    console.log('Mode: READ-ONLY (no writes)');
+    console.log('');
+    console.log(
+      [
+        'Category'.padEnd(32),
+        'Count'.padStart(8),
+        'Aggregate'.padStart(14),
+        'Closed-shift'.padStart(14),
+        'Deterministic?'.padStart(14),
+      ].join(' '),
+    );
+    console.log('-'.repeat(86));
+
+    const labels: Record<string, string> = {
+      properly_linked: 'Properly linked',
+      missing_drawer_link: 'Missing drawer link',
+      duplicate_drawer_links: 'Duplicate drawer links',
+      funding_source_ambiguous: 'Funding source ambiguous',
+      shift_association_unavailable: 'Shift association unavailable',
+    };
+
+    for (const row of aggregates) {
+      console.log(
+        [
+          (labels[row.category] ?? row.category).padEnd(32),
+          String(row.recordCount).padStart(8),
+          formatGhs(row.aggregateValuePence).padStart(14),
+          String(row.closedShiftExposureCount).padStart(14),
+          (row.deterministic ? 'yes' : 'no').padStart(14),
+        ].join(' '),
+      );
+    }
+
+    console.log('');
+    console.log('Notes:');
+    console.log('- Missing idempotency keys are not treated as orphans.');
+    console.log('- Ambiguous funding is not classified as a confirmed orphan.');
+    console.log('- No automatic remediation is proposed or performed.');
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Enforce Owner/Manager authorisation at `recordSupplierPaymentAction` and `recordSupplierPayment` service boundaries; Cashier/unauthenticated/cross-tenant paths create no financial records.
- Add durable, tenant-scoped idempotency on `PurchasePayment` (`businessId` + `idempotencyKey` unique, `payloadHash`) covering payment, allocation, drawer cash-out, journal, and audit atomically, with race-safe unique-constraint replay.
- Client forms generate one idempotency key per intentional submission and disable while pending (`SupplierPaymentForm`, inline supplier path).
- Add auth/idempotency/accounting regression tests (including GH₵1,400 expected-cash scenario) and Postgres concurrency tests (skip without Postgres URL).
- Deliver read-only historical orphan assessment via `scripts/assess-supplier-payment-orphans.ts` (not run against Production).

## Migration / rollback notes
- Additive migration `20260805190000_supplier_payment_idempotency`: nullable `businessId`, `idempotencyKey`, `payloadHash`; backfill `businessId` from invoice; unique index `(businessId, idempotencyKey)`.
- Historical rows keep null keys and are not reinterpreted as idempotent requests.
- Code rollback is safe with migration left in place (nullable columns unused). Prefer migrate-then-deploy so all instances enforce uniqueness.
- **Production deployment and Production migration are NOT authorised by this PR.**

## Test evidence
- `npx vitest run` focused supplier-payment suites: pass
- `npm run test:pos-safety:unit`: 130 passed
- `npm test`: **2042 passed | 5 skipped** (208 files) — concurrency suite skipped locally (no Postgres `DATABASE_URL`)
- `npm run typecheck`: exit 0
- `npm run lint`: exit 0 (3 pre-existing warnings unrelated)
- `npm run build`: exit 0
- `npx prisma validate --schema=prisma/schema.postgres.prisma`: valid

## Orphan assessment
```bash
npx tsx scripts/assess-supplier-payment-orphans.ts --businessId=<id>
```
Do not run against Production unless authorised read-only access already exists.

## Test plan
- [ ] Owner: record partial cash supplier payment; verify AP ↓, drawer cash-out once, expected cash; replay same key → no second effect
- [ ] Manager: same authorised path
- [ ] Cashier: direct action denied; no records
- [ ] Bank/MoMo: AP ↓, no drawer effect; distinct keys allow intentional double payments
- [ ] CI with Postgres: confirm `payments-concurrency.test.ts` posts once under `Promise.all`
- [ ] Review migration on staging before any Production deploy (separate authorisation)

## Out of scope
Mobile Parity P2, historical backfill, reversals, petty cash, Production deploy/migrate.