### PR TITLE
Mobile Parity P2: navigation and core workflow responsiveness

### DIFF
--- a/app/(protected)/products/labels/LabelPrintClient.tsx
+++ b/app/(protected)/products/labels/LabelPrintClient.tsx
@@ -119,7 +119,8 @@ export default function LabelPrintClient({
   const [currentPage, setCurrentPage] = useState(Math.max(1, initialPage));
   const [previewError, setPreviewError] = useState<string | undefined>();
   const [previewPending, startPreview] = useTransition();
-  const selectAllRef = useRef<HTMLInputElement>(null);
+  const selectAllMobileRef = useRef<HTMLInputElement>(null);
+  const selectAllDesktopRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setCurrentPage(1);
@@ -167,8 +168,12 @@ export default function LabelPrintClient({
   const someVisibleSelected = visibleIds.some((id) => selectedIdSet.has(id));
 
   useEffect(() => {
-    if (selectAllRef.current) {
-      selectAllRef.current.indeterminate = someVisibleSelected && !allVisibleSelected;
+    const indeterminate = someVisibleSelected && !allVisibleSelected;
+    if (selectAllMobileRef.current) {
+      selectAllMobileRef.current.indeterminate = indeterminate;
+    }
+    if (selectAllDesktopRef.current) {
+      selectAllDesktopRef.current.indeterminate = indeterminate;
     }
   }, [allVisibleSelected, someVisibleSelected]);
 
@@ -382,7 +387,7 @@ export default function LabelPrintClient({
             </div>
           </div>
 
-          <div className="card p-6 overflow-x-auto">
+          <div className="card p-6" data-label-print-queue>
             <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
               <div>
                 <h2 className="text-lg font-display font-semibold">Product label queue</h2>
@@ -403,84 +408,169 @@ export default function LabelPrintClient({
               />
             ) : (
               <>
-                <table className="table w-full border-separate border-spacing-y-2">
-                  <thead>
-                    <tr>
-                      <th className="w-12 px-3 py-2 text-left">
-                        <input
-                          ref={selectAllRef}
-                          type="checkbox"
-                          className="h-4 w-4"
-                          checked={allVisibleSelected}
-                          onChange={(event) => toggleAllVisible(event.target.checked)}
-                          aria-label="Select all products on this page"
-                        />
-                      </th>
-                      <th className="px-3 py-2 text-left">Product</th>
-                      <th className="px-3 py-2 text-left">Barcode</th>
-                      <th className="px-3 py-2 text-left">Price</th>
-                      <th className="px-3 py-2 text-left">Category</th>
-                      <th className="px-3 py-2 text-left">Qty</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {visibleProducts.map((product) => {
-                      const isSelected = selectedIdSet.has(product.id);
-                      const quantity = clampQuantity(quantities[product.id]);
+                <div className="mb-3 flex items-center gap-2 lg:hidden">
+                  <input
+                    ref={selectAllMobileRef}
+                    type="checkbox"
+                    className="h-5 w-5"
+                    checked={allVisibleSelected}
+                    onChange={(event) => toggleAllVisible(event.target.checked)}
+                    aria-label="Select all products on this page"
+                    id="label-select-all-mobile"
+                  />
+                  <label htmlFor="label-select-all-mobile" className="text-sm font-medium text-ink">
+                    Select all on this page
+                  </label>
+                </div>
 
-                      return (
-                        <tr key={product.id} className={`rounded-xl ${isSelected ? 'bg-blue-50/70' : 'bg-white'}`}>
-                          <td className="px-3 py-3 align-top">
-                            <input
-                              type="checkbox"
-                              className="mt-1 h-4 w-4"
-                              checked={isSelected}
-                              onChange={(event) => toggleProduct(product.id, event.target.checked)}
-                              aria-label={`Select ${product.name}`}
-                            />
-                          </td>
-                          <td className="px-3 py-3 align-top">
-                            <div className="font-semibold text-ink">
+                <div className="space-y-3 lg:hidden" data-label-print-mobile-queue>
+                  {visibleProducts.map((product) => {
+                    const isSelected = selectedIdSet.has(product.id);
+                    const quantity = clampQuantity(quantities[product.id]);
+
+                    return (
+                      <div
+                        key={product.id}
+                        className={`rounded-2xl border px-4 py-4 shadow-sm ${
+                          isSelected ? 'border-blue-200 bg-blue-50/70' : 'border-black/5 bg-white'
+                        }`}
+                      >
+                        <div className="flex items-start gap-3">
+                          <input
+                            type="checkbox"
+                            className="mt-1 h-5 w-5 shrink-0"
+                            checked={isSelected}
+                            onChange={(event) => toggleProduct(product.id, event.target.checked)}
+                            aria-label={`Select ${product.name}`}
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="font-semibold text-ink break-words [overflow-wrap:anywhere]">
                               <Link href={`/products/${product.id}`} className="hover:underline">
                                 {product.name}
                               </Link>
                             </div>
                             {product.sku ? <div className="mt-1 text-xs text-black/45">SKU: {product.sku}</div> : null}
-                          </td>
-                          <td className="px-3 py-3 align-top text-sm text-black/65">
-                            {product.barcode || <span className="text-black/30">—</span>}
-                          </td>
-                          <td className="px-3 py-3 align-top">{formatMoney(product.sellingPriceBasePence, currency)}</td>
-                          <td className="px-3 py-3 align-top">
-                            {product.category ? (
-                              <span
-                                className="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium text-white"
-                                style={{ backgroundColor: product.category.colour }}
-                              >
-                                {product.category.name}
-                              </span>
-                            ) : (
-                              <span className="text-xs text-black/35">Uncategorised</span>
-                            )}
-                          </td>
-                          <td className="px-3 py-3 align-top">
-                            <input
-                              type="number"
-                              min={1}
-                              max={500}
-                              inputMode="numeric"
-                              className="input min-w-[88px]"
-                              value={quantity}
-                              disabled={!isSelected}
-                              onChange={(event) => updateQuantity(product.id, event.target.value)}
-                              aria-label={`Quantity for ${product.name}`}
-                            />
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                            <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-black/65">
+                              <span className="tabular-nums">{formatMoney(product.sellingPriceBasePence, currency)}</span>
+                              <span className="text-black/30">·</span>
+                              <span className="break-all">{product.barcode || 'No barcode'}</span>
+                            </div>
+                            <div className="mt-2">
+                              {product.category ? (
+                                <span
+                                  className="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium text-white"
+                                  style={{ backgroundColor: product.category.colour }}
+                                >
+                                  {product.category.name}
+                                </span>
+                              ) : (
+                                <span className="text-xs text-black/35">Uncategorised</span>
+                              )}
+                            </div>
+                            <div className="mt-3">
+                              <label className="label" htmlFor={`label-qty-mobile-${product.id}`}>
+                                Quantity
+                              </label>
+                              <input
+                                id={`label-qty-mobile-${product.id}`}
+                                type="number"
+                                min={1}
+                                max={500}
+                                inputMode="numeric"
+                                className="input min-h-11 w-full max-w-[8rem]"
+                                value={quantity}
+                                disabled={!isSelected}
+                                onChange={(event) => updateQuantity(product.id, event.target.value)}
+                                aria-label={`Quantity for ${product.name}`}
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div className="hidden overflow-x-auto lg:block">
+                  <table className="table w-full border-separate border-spacing-y-2">
+                    <thead>
+                      <tr>
+                        <th className="w-12 px-3 py-2 text-left">
+                          <input
+                            ref={selectAllDesktopRef}
+                            type="checkbox"
+                            className="h-4 w-4"
+                            checked={allVisibleSelected}
+                            onChange={(event) => toggleAllVisible(event.target.checked)}
+                            aria-label="Select all products on this page"
+                          />
+                        </th>
+                        <th className="px-3 py-2 text-left">Product</th>
+                        <th className="px-3 py-2 text-left">Barcode</th>
+                        <th className="px-3 py-2 text-left">Price</th>
+                        <th className="px-3 py-2 text-left">Category</th>
+                        <th className="px-3 py-2 text-left">Qty</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {visibleProducts.map((product) => {
+                        const isSelected = selectedIdSet.has(product.id);
+                        const quantity = clampQuantity(quantities[product.id]);
+
+                        return (
+                          <tr key={product.id} className={`rounded-xl ${isSelected ? 'bg-blue-50/70' : 'bg-white'}`}>
+                            <td className="px-3 py-3 align-top">
+                              <input
+                                type="checkbox"
+                                className="mt-1 h-4 w-4"
+                                checked={isSelected}
+                                onChange={(event) => toggleProduct(product.id, event.target.checked)}
+                                aria-label={`Select ${product.name}`}
+                              />
+                            </td>
+                            <td className="px-3 py-3 align-top">
+                              <div className="font-semibold text-ink">
+                                <Link href={`/products/${product.id}`} className="hover:underline">
+                                  {product.name}
+                                </Link>
+                              </div>
+                              {product.sku ? <div className="mt-1 text-xs text-black/45">SKU: {product.sku}</div> : null}
+                            </td>
+                            <td className="px-3 py-3 align-top text-sm text-black/65">
+                              {product.barcode || <span className="text-black/30">—</span>}
+                            </td>
+                            <td className="px-3 py-3 align-top">{formatMoney(product.sellingPriceBasePence, currency)}</td>
+                            <td className="px-3 py-3 align-top">
+                              {product.category ? (
+                                <span
+                                  className="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium text-white"
+                                  style={{ backgroundColor: product.category.colour }}
+                                >
+                                  {product.category.name}
+                                </span>
+                              ) : (
+                                <span className="text-xs text-black/35">Uncategorised</span>
+                              )}
+                            </td>
+                            <td className="px-3 py-3 align-top">
+                              <input
+                                type="number"
+                                min={1}
+                                max={500}
+                                inputMode="numeric"
+                                className="input min-w-[88px]"
+                                value={quantity}
+                                disabled={!isSelected}
+                                onChange={(event) => updateQuantity(product.id, event.target.value)}
+                                aria-label={`Quantity for ${product.name}`}
+                              />
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
 
                 <Pagination
                   currentPage={safeCurrentPage}
@@ -497,7 +587,7 @@ export default function LabelPrintClient({
           </div>
         </div>
 
-        <div className="space-y-6">
+        <div className="space-y-6 pb-28 lg:pb-0" data-label-print-actions>
           <LabelPreview data={previewLabel} size={template} />
 
           <div className="card p-6">
@@ -552,7 +642,7 @@ export default function LabelPrintClient({
               <FormError error={previewError} />
             </div>
 
-            <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+            <div className="mt-5 hidden flex-col gap-3 sm:flex-row lg:flex">
               <button
                 type="button"
                 className="btn-secondary justify-center"
@@ -572,6 +662,37 @@ export default function LabelPrintClient({
             <div className="mt-4 text-xs text-black/45">
               Preview opens a new tab with the rendered HTML. Print opens the same type of view and immediately starts the browser print dialog.
             </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Sticky mobile primary actions — clear of bottom navigation */}
+      <div
+        className="fixed inset-x-0 z-30 border-t border-black/10 bg-white/95 px-4 py-3 shadow-[0_-8px_24px_rgba(15,23,42,0.08)] backdrop-blur lg:hidden"
+        style={{ bottom: 'var(--mobile-bottom-nav-height)' }}
+        data-label-print-sticky-actions
+      >
+        <div className="mx-auto flex max-w-lg flex-col gap-2">
+          <div className="text-center text-xs text-black/55">
+            {selectedProducts.length > 0
+              ? `${selectedProducts.length} selected · ${totalLabels} label${totalLabels === 1 ? '' : 's'}`
+              : 'Select products to enable preview and print'}
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="btn-secondary min-h-11 flex-1 justify-center"
+              onClick={handlePreview}
+              disabled={selectedProducts.length === 0 || previewPending}
+            >
+              {previewPending ? 'Generating…' : 'Preview'}
+            </button>
+            <PrintLabelsButton
+              selectedProducts={selectedProducts}
+              template={template}
+              className="btn-primary min-h-11 flex-1 justify-center"
+              onError={setPreviewError}
+            />
           </div>
         </div>
       </div>

--- a/app/(protected)/products/labels/mobile-parity-p2.test.ts
+++ b/app/(protected)/products/labels/mobile-parity-p2.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+
+describe('P2 product labels mobile workflow', () => {
+  const client = read('app/(protected)/products/labels/LabelPrintClient.tsx');
+  const page = read('app/(protected)/products/labels/page.tsx');
+
+  it('adapts the selection queue for mobile with sticky primary actions', () => {
+    expect(client).toContain('data-label-print-mobile-queue');
+    expect(client).toContain('data-label-print-sticky-actions');
+    expect(client).toContain('lg:hidden');
+    expect(client).toContain('hidden overflow-x-auto lg:block');
+    expect(client).toContain('--mobile-bottom-nav-height');
+    expect(client).toContain('inputMode="numeric"');
+    expect(client).toContain('Select all on this page');
+  });
+
+  it('preserves desktop table selection and print generation behaviour', () => {
+    expect(client).toContain('<table');
+    expect(client).toContain('generateLabelsHtmlAction');
+    expect(client).toContain('PrintLabelsButton');
+    expect(client).toContain('clampQuantity');
+    expect(client).toContain('PAGE_SIZE');
+  });
+
+  it('does not expand Cashier into mobile navigation while route auth stays unchanged', () => {
+    expect(page).toContain("requireBusiness(['CASHIER', 'MANAGER', 'OWNER'])");
+    const mobileNav = read('lib/navigation/mobile-menu-config.ts');
+    expect(mobileNav).toContain("href: '/products/labels'");
+    expect(mobileNav).not.toMatch(/href: '\/products\/labels'[\s\S]{0,120}roles: \[[^\]]*CASHIER/);
+    const cashierBlock = mobileNav.slice(
+      mobileNav.indexOf('CASHIER_MENU_ITEMS'),
+      mobileNav.indexOf('MOBILE_TAB_NAV_HREFS_BY_ROLE'),
+    );
+    expect(cashierBlock).not.toContain('/products/labels');
+  });
+});

--- a/app/(protected)/purchases/[id]/mobile-parity-p2.test.ts
+++ b/app/(protected)/purchases/[id]/mobile-parity-p2.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+
+describe('P2 purchase-detail mobile presentation', () => {
+  const src = read('app/(protected)/purchases/[id]/page.tsx');
+  const paymentForm = read('components/SupplierPaymentForm.tsx');
+
+  it('adapts purchase lines and payment history for mobile without removing desktop tables', () => {
+    expect(src).toContain('data-purchase-detail-lines');
+    expect(src).toContain('data-purchase-detail-payments');
+    expect(src).toContain('DataCard');
+    expect(src).toContain('lg:hidden');
+    expect(src).toContain('hidden overflow-x-auto lg:block');
+    expect(src).toContain('Items purchased');
+    expect(src).toContain('Payment history');
+    expect(src).toContain('Unit Cost');
+    expect(src).toContain('Recorded by');
+  });
+
+  it('preserves role gate and outstanding/total meanings from server values', () => {
+    expect(src).toContain("requireBusiness(['MANAGER', 'OWNER'])");
+    expect(src).toContain('invoice.payments.reduce');
+    expect(src).toContain('invoice.totalPence - totalPaid');
+    expect(src).toContain('formatMoney(invoice.totalPence');
+    expect(src).toContain('formatMoney(outstanding');
+  });
+
+  it('keeps SupplierPaymentForm / PR #78 controls intact on the detail page', () => {
+    expect(src).toContain('SupplierPaymentForm');
+    expect(src).toContain('data-purchase-payment-form');
+    expect(src).toContain('pb-24');
+    expect(paymentForm).toContain('idempotencyKey');
+    expect(paymentForm).toContain('recordSupplierPaymentAction');
+    expect(paymentForm).not.toContain('freeze'); // freeze lives in the action/service layer
+  });
+});

--- a/app/(protected)/purchases/[id]/mobile-parity-p2.test.ts
+++ b/app/(protected)/purchases/[id]/mobile-parity-p2.test.ts
@@ -31,9 +31,17 @@ describe('P2 purchase-detail mobile presentation', () => {
   it('keeps SupplierPaymentForm / PR #78 controls intact on the detail page', () => {
     expect(src).toContain('SupplierPaymentForm');
     expect(src).toContain('data-purchase-payment-form');
-    expect(src).toContain('pb-24');
+    expect(src).toContain('pb-28 lg:pb-6');
+    expect(src).toContain('pb-24 lg:pb-0');
+    expect(src).not.toContain('pb-24 sm:pb-6');
     expect(paymentForm).toContain('idempotencyKey');
     expect(paymentForm).toContain('recordSupplierPaymentAction');
     expect(paymentForm).not.toContain('freeze'); // freeze lives in the action/service layer
+  });
+
+  it('keeps bottom-nav clearance until lg where the mobile tab bar hides', () => {
+    // Bottom tab bar uses lg:hidden; padding must not collapse at sm/md.
+    expect(src).toMatch(/pb-28\s+lg:pb-6/);
+    expect(src).toMatch(/pb-24\s+lg:pb-0/);
   });
 });

--- a/app/(protected)/purchases/[id]/page.tsx
+++ b/app/(protected)/purchases/[id]/page.tsx
@@ -314,7 +314,7 @@ export default async function PurchaseInvoicePage({
       </div>
 
       {/* Payment history */}
-      <div className="card p-6 pb-24 sm:pb-6" data-purchase-detail-payments>
+      <div className="card p-6 pb-28 lg:pb-6" data-purchase-detail-payments>
         <h2 className="text-base font-semibold">Payment history</h2>
         {invoice.payments.length === 0 ? (
           <p className="mt-3 text-sm text-black/50">No payments recorded yet.</p>
@@ -393,7 +393,7 @@ export default async function PurchaseInvoicePage({
         )}
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2 pb-24 lg:pb-0">
         <Link href="/purchases" className="btn-ghost text-sm">← Back to purchases</Link>
         {invoice.supplier && (
           <Link href={`/suppliers/${invoice.supplier.id}`} className="btn-ghost text-sm">

--- a/app/(protected)/purchases/[id]/page.tsx
+++ b/app/(protected)/purchases/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import PageHeader from '@/components/PageHeader';
 import SubmitButton from '@/components/SubmitButton';
 import FormError from '@/components/FormError';
+import { DataCard, DataCardField, DataCardHeader } from '@/components/DataCard';
 import { prisma } from '@/lib/prisma';
 import { requireBusiness } from '@/lib/auth';
 import { formatMoney, formatDateTime, formatDate } from '@/lib/format';
@@ -251,9 +252,40 @@ export default async function PurchaseInvoicePage({
       )}
 
       {/* Invoice lines */}
-      <div className="card p-6">
+      <div className="card p-6" data-purchase-detail-lines>
         <h2 className="text-base font-semibold">Items purchased</h2>
-        <div className="overflow-x-auto">
+        <div className="mt-4 space-y-3 lg:hidden">
+          {invoice.lines.map((line) => (
+            <DataCard key={line.id}>
+              <DataCardHeader
+                title={line.product.name}
+                subtitle={`${line.qtyInUnit} ${line.unit.name}`}
+                aside={
+                  <span className="text-sm font-semibold tabular-nums">
+                    {formatMoney(line.lineTotalPence, business.currency)}
+                  </span>
+                }
+              />
+              <div className="mt-3 grid grid-cols-2 gap-3">
+                <DataCardField
+                  label="Unit cost"
+                  value={formatMoney(line.unitCostPence, business.currency)}
+                  valueClassName="text-sm tabular-nums"
+                />
+                <DataCardField
+                  label="Line total"
+                  value={formatMoney(line.lineTotalPence, business.currency)}
+                  valueClassName="text-sm font-semibold tabular-nums"
+                />
+              </div>
+            </DataCard>
+          ))}
+          <div className="flex items-center justify-between gap-3 rounded-xl border border-black/5 bg-black/[0.02] px-4 py-3">
+            <span className="text-xs uppercase tracking-wider text-black/40">Total (incl. VAT)</span>
+            <span className="text-sm font-bold tabular-nums">{formatMoney(invoice.totalPence, business.currency)}</span>
+          </div>
+        </div>
+        <div className="hidden overflow-x-auto lg:block">
           <table className="table mt-4 w-full border-separate border-spacing-y-1 text-sm">
             <thead>
               <tr>
@@ -282,40 +314,71 @@ export default async function PurchaseInvoicePage({
       </div>
 
       {/* Payment history */}
-      <div className="card p-6">
+      <div className="card p-6 pb-24 sm:pb-6" data-purchase-detail-payments>
         <h2 className="text-base font-semibold">Payment history</h2>
         {invoice.payments.length === 0 ? (
           <p className="mt-3 text-sm text-black/50">No payments recorded yet.</p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="table mt-4 w-full border-separate border-spacing-y-1 text-sm">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Method</th>
-                  <th className="text-right">Amount</th>
-                  <th>Notes</th>
-                  <th>Recorded by</th>
-                </tr>
-              </thead>
-              <tbody>
-                {invoice.payments.map((payment) => (
-                  <tr key={payment.id} className="rounded-xl bg-white">
-                    <td className="px-3 py-2">{formatDate(payment.paidAt)}</td>
-                    <td className="px-3 py-2">{payment.method}</td>
-                    <td className="px-3 py-2 text-right font-semibold">{formatMoney(payment.amountPence, business.currency)}</td>
-                    <td className="px-3 py-2 text-black/50">{payment.notes ?? '—'}</td>
-                    <td className="px-3 py-2 text-black/50">{payment.recordedBy?.name ?? '—'}</td>
+          <>
+            <div className="mt-4 space-y-3 lg:hidden">
+              {invoice.payments.map((payment) => (
+                <DataCard key={payment.id}>
+                  <DataCardHeader
+                    title={formatDate(payment.paidAt)}
+                    subtitle={payment.method}
+                    aside={
+                      <span className="text-sm font-semibold tabular-nums">
+                        {formatMoney(payment.amountPence, business.currency)}
+                      </span>
+                    }
+                  />
+                  <div className="mt-3 grid grid-cols-2 gap-3">
+                    <DataCardField
+                      label="Notes"
+                      value={payment.notes ?? '—'}
+                      className="col-span-2"
+                      valueClassName="text-sm break-words [overflow-wrap:anywhere]"
+                    />
+                    <DataCardField
+                      label="Recorded by"
+                      value={payment.recordedBy?.name ?? '—'}
+                      className="col-span-2"
+                      valueClassName="text-sm"
+                    />
+                  </div>
+                </DataCard>
+              ))}
+            </div>
+            <div className="hidden overflow-x-auto lg:block">
+              <table className="table mt-4 w-full border-separate border-spacing-y-1 text-sm">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Method</th>
+                    <th className="text-right">Amount</th>
+                    <th>Notes</th>
+                    <th>Recorded by</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {invoice.payments.map((payment) => (
+                    <tr key={payment.id} className="rounded-xl bg-white">
+                      <td className="px-3 py-2">{formatDate(payment.paidAt)}</td>
+                      <td className="px-3 py-2">{payment.method}</td>
+                      <td className="px-3 py-2 text-right font-semibold">{formatMoney(payment.amountPence, business.currency)}</td>
+                      <td className="px-3 py-2 text-black/50">{payment.notes ?? '—'}</td>
+                      <td className="px-3 py-2 text-black/50">{payment.recordedBy?.name ?? '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
         )}
 
-        {/* Record payment form */}
+        {/* Record payment form — unchanged SupplierPaymentForm (PR #78 controls). */}
         {!isClosed && outstanding > 0 && (
-          <div className="mt-6">
+          <div className="mt-6 scroll-mb-28" data-purchase-payment-form>
             <h3 className="text-sm font-semibold">Record a payment</h3>
             <div className="mt-3">
               <SupplierPaymentForm

--- a/app/(protected)/reports/cash-drawer/mobile-parity-p2.test.ts
+++ b/app/(protected)/reports/cash-drawer/mobile-parity-p2.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+
+describe('P2 cash drawer mobile shift ledger', () => {
+  const src = read('app/(protected)/reports/cash-drawer/page.tsx');
+
+  it('renders a dedicated mobile shift ledger with essential fields', () => {
+    expect(src).toContain('data-cash-drawer-mobile-ledger');
+    expect(src).toContain('lg:hidden');
+    expect(src).toContain('DataCard');
+    expect(src).toContain('Cash expected');
+    expect(src).toContain('Cash counted');
+    expect(src).toContain('Difference');
+    expect(src).toContain('Manager approval');
+    expect(src).toContain('Drawer movements');
+    expect(src).toContain('No shifts found in this date range.');
+    expect(src).toContain('break-words');
+    expect(src).toContain('tabular-nums');
+  });
+
+  it('preserves the desktop shift table behind lg breakpoint', () => {
+    expect(src).toContain('hidden lg:block');
+    expect(src).toContain('ReportTableCard');
+    expect(src).toContain('min-w-[56rem]');
+    expect(src).toContain('Opening float');
+    expect(src).toContain('Cash sales');
+  });
+
+  it('does not introduce client-side financial recalculation', () => {
+    expect(src).not.toContain("'use client'");
+    expect(src).toContain('summarizeCashDrawerEntries');
+    expect(src).toContain('expectedCashPence');
+    expect(src).toContain('actualCashPence');
+    expect(src).toContain('shift.variance');
+    // Totals still come from server-side reduce over persisted shift values.
+    expect(src).toContain('shifts.reduce((sum, shift) => sum + shift.expectedCashPence, 0)');
+    expect(src).toContain("requireBusiness(['MANAGER', 'OWNER'])");
+  });
+});

--- a/app/(protected)/reports/cash-drawer/page.tsx
+++ b/app/(protected)/reports/cash-drawer/page.tsx
@@ -2,6 +2,7 @@ import DownloadLink from '@/components/DownloadLink';
 import Pagination from '@/components/Pagination';
 import PageHeader from '@/components/PageHeader';
 import StatCard from '@/components/StatCard';
+import { DataCard, DataCardField, DataCardHeader } from '@/components/DataCard';
 import ReportFilterCard from '@/components/reports/ReportFilterCard';
 import ReportTableCard, { ReportTableEmptyRow } from '@/components/reports/ReportTableCard';
 import NotesCell from './NotesCell';
@@ -278,98 +279,215 @@ export default async function CashDrawerReportPage({
         </div>
       </div>
 
-      <ReportTableCard tableClassName="table w-full min-w-[56rem] border-separate border-spacing-y-2 xl:min-w-[104rem]">
-        <thead>
-          <tr>
-            <th>Date</th>
-            <th>Branch</th>
-            <th>Till</th>
-            <th>Cashier</th>
-            <th className="hidden xl:table-cell">Opening float</th>
-            <th className="hidden xl:table-cell">Cash sales</th>
-            <th className="hidden xl:table-cell">Customer payments</th>
-            <th className="hidden xl:table-cell">Supplier cash paid out</th>
-            <th className="hidden xl:table-cell">Expenses paid out</th>
-            <th className="hidden xl:table-cell">Refunds</th>
-            <th className="hidden xl:table-cell">Cash added</th>
-            <th>Cash expected</th>
-            <th>Cash counted</th>
-            <th>Difference</th>
-            <th>Reason</th>
-            <th>Notes</th>
-            <th>Manager approval</th>
-          </tr>
-        </thead>
-        <tbody>
-          {shifts.map((shift) => {
+      {/* Mobile shift ledger — same server values as the desktop table; presentation only. */}
+      <div className="space-y-3 lg:hidden" data-cash-drawer-mobile-ledger>
+        <h2 className="text-base font-display font-semibold">Shift ledger</h2>
+        {shifts.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500">
+            No shifts found in this date range.
+          </div>
+        ) : (
+          shifts.map((shift) => {
             const byType = summarizeCashDrawerEntries(shift.cashDrawerEntries).byType;
+            const countedLabel =
+              shift.status === 'OPEN'
+                ? 'Not counted yet'
+                : shift.actualCashPence !== null
+                  ? formatMoney(shift.actualCashPence, business.currency)
+                  : '-';
+            const varianceNode =
+              shift.status === 'OPEN' ? (
+                <span className="text-amber-600">Pending close</span>
+              ) : shift.variance !== null ? (
+                <span
+                  className={
+                    shift.variance === 0
+                      ? 'text-emerald-700'
+                      : shift.variance > 0
+                        ? 'text-accent'
+                        : 'text-rose'
+                  }
+                >
+                  {formatMoney(shift.variance, business.currency)}
+                </span>
+              ) : (
+                <span className="text-black/40">-</span>
+              );
+            const movementChips = (
+              [
+                ['OPEN_FLOAT', 'Opening float'],
+                ['CASH_SALE', 'Cash sales'],
+                ['CASH_DEBTOR_PAYMENT', 'Customer payments'],
+                ['PAID_OUT_SUPPLIER', 'Supplier cash paid out'],
+                ['PAID_OUT_EXPENSE', 'Expenses paid out'],
+                ['CASH_REFUND', 'Refunds'],
+                ['CASH_ADJUSTMENT', 'Cash added'],
+              ] as const
+            )
+              .map(([entryType, label]) => ({
+                label,
+                amount: byType[entryType] ?? 0,
+              }))
+              .filter((row) => row.amount !== 0);
+
             return (
-              <tr key={shift.id} className="rounded-xl bg-white">
-                <td className="px-3 py-3 text-xs">{formatDateTime(shift.openedAt)}</td>
-                <td className="px-3 py-3 text-sm">{shift.till.store.name}</td>
-                <td className="px-3 py-3 text-sm">{shift.till.name}</td>
-                <td className="px-3 py-3 text-sm">{shift.user.name}</td>
-                <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.OPEN_FLOAT ?? 0, business.currency)}</td>
-                <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.CASH_SALE ?? 0, business.currency)}</td>
-                <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.CASH_DEBTOR_PAYMENT ?? 0, business.currency)}</td>
-                <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.PAID_OUT_SUPPLIER ?? 0, business.currency)}</td>
-                <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.PAID_OUT_EXPENSE ?? 0, business.currency)}</td>
-                <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.CASH_REFUND ?? 0, business.currency)}</td>
-                <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.CASH_ADJUSTMENT ?? 0, business.currency)}</td>
-                <td className="px-3 py-3 text-sm font-semibold">
-                  {formatMoney(shift.expectedCashPence, business.currency)}
-                </td>
-                <td className="px-3 py-3 text-sm font-semibold">
-                  {shift.status === 'OPEN' ? (
-                    <span className="text-amber-600">Not counted yet</span>
-                  ) : shift.actualCashPence !== null ? (
-                    formatMoney(shift.actualCashPence, business.currency)
-                  ) : (
-                    '-'
-                  )}
-                </td>
-                <td className="px-3 py-3 text-sm">
-                  {shift.status === 'OPEN' ? (
-                    <span className="text-amber-600">Pending close</span>
-                  ) : shift.variance !== null ? (
-                    <span
-                      className={
-                        shift.variance === 0
-                          ? 'text-emerald-700'
-                          : shift.variance > 0
-                            ? 'text-accent'
-                            : 'text-rose'
-                      }
-                    >
-                      {formatMoney(shift.variance, business.currency)}
+              <DataCard key={shift.id}>
+                <DataCardHeader
+                  title={formatDateTime(shift.openedAt)}
+                  subtitle={`${shift.till.store.name} · ${shift.till.name} · ${shift.user.name}`}
+                  aside={
+                    <span className="text-xs font-semibold uppercase tracking-wide text-black/45">
+                      {shift.status === 'OPEN' ? 'Open' : 'Closed'}
                     </span>
-                  ) : (
-                    <span className="text-black/40">-</span>
-                  )}
-                </td>
-                <td className="px-3 py-3 text-sm">
-                  {shift.varianceReasonCode ? (
-                    <span className="inline-flex items-center rounded-full bg-black/5 px-2 py-0.5 text-xs font-medium text-black/50">
-                      {reasonCodeLabel(shift.varianceReasonCode)}
-                    </span>
-                  ) : (
-                    <span className="text-black/40">-</span>
-                  )}
-                </td>
-                <td className="px-3 py-3 align-top text-sm">
-                  <NotesCell text={notesText(shift.varianceReason, shift.notes)} />
-                </td>
-                <td className="px-3 py-3 text-xs">
-                  {shift.closeManagerApprovedBy?.name ?? (shift.status === 'OPEN' ? 'Shift open' : '—')}
-                </td>
-              </tr>
+                  }
+                />
+                <div className="mt-3 grid grid-cols-2 gap-3">
+                  <DataCardField
+                    label="Cash expected"
+                    value={formatMoney(shift.expectedCashPence, business.currency)}
+                    valueClassName="text-sm font-semibold tabular-nums"
+                  />
+                  <DataCardField
+                    label="Cash counted"
+                    value={countedLabel}
+                    valueClassName={`text-sm font-semibold tabular-nums ${shift.status === 'OPEN' ? 'text-amber-600' : ''}`}
+                  />
+                  <DataCardField label="Difference" value={varianceNode} valueClassName="text-sm font-semibold tabular-nums" />
+                  <DataCardField
+                    label="Reason"
+                    value={shift.varianceReasonCode ? reasonCodeLabel(shift.varianceReasonCode) : '-'}
+                    valueClassName="text-sm"
+                  />
+                  <DataCardField
+                    label="Notes"
+                    value={notesText(shift.varianceReason, shift.notes)}
+                    className="col-span-2"
+                    valueClassName="text-sm break-words [overflow-wrap:anywhere]"
+                  />
+                  <DataCardField
+                    label="Manager approval"
+                    value={shift.closeManagerApprovedBy?.name ?? (shift.status === 'OPEN' ? 'Shift open' : '—')}
+                    className="col-span-2"
+                    valueClassName="text-sm"
+                  />
+                </div>
+                {movementChips.length > 0 ? (
+                  <div className="mt-3 space-y-1.5 border-t border-black/5 pt-3">
+                    <div className="text-xs uppercase tracking-[0.16em] text-black/40">Drawer movements</div>
+                    {movementChips.map((row) => (
+                      <div key={row.label} className="flex items-start justify-between gap-3 text-sm">
+                        <span className="min-w-0 flex-1 break-words text-slate-600">{row.label}</span>
+                        <span
+                          className={`shrink-0 tabular-nums font-medium ${
+                            row.amount < 0 ? 'text-rose-700' : 'text-slate-950'
+                          }`}
+                        >
+                          {formatMoney(row.amount, business.currency)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </DataCard>
             );
-          })}
-          {shifts.length === 0 ? (
-            <ReportTableEmptyRow colSpan={17} message="No shifts found in this date range." paddingClassName="px-3 py-8" />
-          ) : null}
-        </tbody>
-      </ReportTableCard>
+          })
+        )}
+      </div>
+
+      <div className="hidden lg:block">
+        <ReportTableCard tableClassName="table w-full min-w-[56rem] border-separate border-spacing-y-2 xl:min-w-[104rem]">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Branch</th>
+              <th>Till</th>
+              <th>Cashier</th>
+              <th className="hidden xl:table-cell">Opening float</th>
+              <th className="hidden xl:table-cell">Cash sales</th>
+              <th className="hidden xl:table-cell">Customer payments</th>
+              <th className="hidden xl:table-cell">Supplier cash paid out</th>
+              <th className="hidden xl:table-cell">Expenses paid out</th>
+              <th className="hidden xl:table-cell">Refunds</th>
+              <th className="hidden xl:table-cell">Cash added</th>
+              <th>Cash expected</th>
+              <th>Cash counted</th>
+              <th>Difference</th>
+              <th>Reason</th>
+              <th>Notes</th>
+              <th>Manager approval</th>
+            </tr>
+          </thead>
+          <tbody>
+            {shifts.map((shift) => {
+              const byType = summarizeCashDrawerEntries(shift.cashDrawerEntries).byType;
+              return (
+                <tr key={shift.id} className="rounded-xl bg-white">
+                  <td className="px-3 py-3 text-xs">{formatDateTime(shift.openedAt)}</td>
+                  <td className="px-3 py-3 text-sm">{shift.till.store.name}</td>
+                  <td className="px-3 py-3 text-sm">{shift.till.name}</td>
+                  <td className="px-3 py-3 text-sm">{shift.user.name}</td>
+                  <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.OPEN_FLOAT ?? 0, business.currency)}</td>
+                  <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.CASH_SALE ?? 0, business.currency)}</td>
+                  <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.CASH_DEBTOR_PAYMENT ?? 0, business.currency)}</td>
+                  <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.PAID_OUT_SUPPLIER ?? 0, business.currency)}</td>
+                  <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.PAID_OUT_EXPENSE ?? 0, business.currency)}</td>
+                  <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.CASH_REFUND ?? 0, business.currency)}</td>
+                  <td className="hidden px-3 py-3 text-sm xl:table-cell">{formatMoney(byType.CASH_ADJUSTMENT ?? 0, business.currency)}</td>
+                  <td className="px-3 py-3 text-sm font-semibold">
+                    {formatMoney(shift.expectedCashPence, business.currency)}
+                  </td>
+                  <td className="px-3 py-3 text-sm font-semibold">
+                    {shift.status === 'OPEN' ? (
+                      <span className="text-amber-600">Not counted yet</span>
+                    ) : shift.actualCashPence !== null ? (
+                      formatMoney(shift.actualCashPence, business.currency)
+                    ) : (
+                      '-'
+                    )}
+                  </td>
+                  <td className="px-3 py-3 text-sm">
+                    {shift.status === 'OPEN' ? (
+                      <span className="text-amber-600">Pending close</span>
+                    ) : shift.variance !== null ? (
+                      <span
+                        className={
+                          shift.variance === 0
+                            ? 'text-emerald-700'
+                            : shift.variance > 0
+                              ? 'text-accent'
+                              : 'text-rose'
+                        }
+                      >
+                        {formatMoney(shift.variance, business.currency)}
+                      </span>
+                    ) : (
+                      <span className="text-black/40">-</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-3 text-sm">
+                    {shift.varianceReasonCode ? (
+                      <span className="inline-flex items-center rounded-full bg-black/5 px-2 py-0.5 text-xs font-medium text-black/50">
+                        {reasonCodeLabel(shift.varianceReasonCode)}
+                      </span>
+                    ) : (
+                      <span className="text-black/40">-</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-3 align-top text-sm">
+                    <NotesCell text={notesText(shift.varianceReason, shift.notes)} />
+                  </td>
+                  <td className="px-3 py-3 text-xs">
+                    {shift.closeManagerApprovedBy?.name ?? (shift.status === 'OPEN' ? 'Shift open' : '—')}
+                  </td>
+                </tr>
+              );
+            })}
+            {shifts.length === 0 ? (
+              <ReportTableEmptyRow colSpan={17} message="No shifts found in this date range." paddingClassName="px-3 py-8" />
+            ) : null}
+          </tbody>
+        </ReportTableCard>
+      </div>
 
       {totalRows > 0 ? (
         <Pagination

--- a/lib/navigation/mobile-menu-config.ts
+++ b/lib/navigation/mobile-menu-config.ts
@@ -110,6 +110,19 @@ export const OWNER_BROWSE_AREAS: MobileBrowseArea[] = [
         roles: ['OWNER'],
         minimumPlan: 'GROWTH',
       },
+      {
+        href: '/reports/stock-movements',
+        label: 'Stock Movements',
+        iconKey: 'stockMovements',
+        roles: ['OWNER'],
+      },
+      {
+        href: '/products/labels',
+        label: 'Product Labels',
+        iconKey: 'labels',
+        roles: ['OWNER'],
+        minimumPlan: 'GROWTH',
+      },
       { href: '/purchases', label: 'Purchases', iconKey: 'purchases', roles: ['OWNER'] },
       { href: '/suppliers', label: 'Suppliers', iconKey: 'suppliers', roles: ['OWNER'] },
       { href: '/transfers', label: 'Transfers', iconKey: 'transfers', roles: ['OWNER'] },
@@ -182,6 +195,13 @@ export const MANAGER_MENU_SECTIONS: MobileBrowseArea[] = [
       { href: '/pos', label: 'POS', iconKey: 'pos', roles: ['MANAGER'] },
       { href: '/sales', label: 'Sales', iconKey: 'sales', roles: ['MANAGER'] },
       { href: '/products', label: 'Products', iconKey: 'products', roles: ['MANAGER'] },
+      {
+        href: '/online-orders',
+        label: 'Online Orders',
+        iconKey: 'orders',
+        roles: ['MANAGER'],
+        requiresFeature: 'onlineStorefront',
+      },
       { href: '/shifts', label: 'Shifts', iconKey: 'shifts', roles: ['MANAGER'] },
     ],
   },
@@ -196,6 +216,19 @@ export const MANAGER_MENU_SECTIONS: MobileBrowseArea[] = [
         href: '/inventory/stocktake',
         label: 'Stocktake',
         iconKey: 'inventory',
+        roles: ['MANAGER'],
+        minimumPlan: 'GROWTH',
+      },
+      {
+        href: '/reports/stock-movements',
+        label: 'Stock Movements',
+        iconKey: 'stockMovements',
+        roles: ['MANAGER'],
+      },
+      {
+        href: '/products/labels',
+        label: 'Product Labels',
+        iconKey: 'labels',
         roles: ['MANAGER'],
         minimumPlan: 'GROWTH',
       },
@@ -253,6 +286,8 @@ export const CRITICAL_MOBILE_OPERATIONAL_HREFS = [
   '/payments/reconciliation/card-transfer',
   '/inventory/adjustments',
   '/inventory/stocktake',
+  '/reports/stock-movements',
+  '/products/labels',
   '/expenses',
   '/payments/expense-payments',
   '/payments/customer-receipts',
@@ -293,6 +328,9 @@ export function itemIsVisible(item: Pick<MobileNavLink, 'roles' | 'href' | 'requ
   if (!item.roles.includes(context.role)) return false;
   if (!context.features.multiStore && item.href === '/transfers') return false;
   if (context.momoEnabled === false && item.href === '/payments/reconciliation') return false;
+  // Hide feature-gated destinations when the entitlement is off (no false discoverability).
+  // Plan-gated items remain visible with an upgrade lock badge via NavMobileMenu.
+  if (item.requiresFeature && !context.features[item.requiresFeature]) return false;
   return true;
 }
 

--- a/lib/navigation/mobile-parity-p1.test.ts
+++ b/lib/navigation/mobile-parity-p1.test.ts
@@ -73,6 +73,8 @@ describe('P1 mobile navigation parity', () => {
       expect.arrayContaining([
         '/inventory/adjustments',
         '/inventory/stocktake',
+        '/reports/stock-movements',
+        '/products/labels',
         '/transfers',
       ]),
     );
@@ -104,7 +106,13 @@ describe('P1 mobile navigation parity', () => {
       ]),
     );
     expect(stock?.items.map((item) => item.href)).toEqual(
-      expect.arrayContaining(['/inventory/adjustments', '/inventory/stocktake', '/transfers']),
+      expect.arrayContaining([
+        '/inventory/adjustments',
+        '/inventory/stocktake',
+        '/reports/stock-movements',
+        '/products/labels',
+        '/transfers',
+      ]),
     );
 
     for (const href of CRITICAL_MOBILE_OPERATIONAL_HREFS) {

--- a/lib/navigation/mobile-parity-p2.test.ts
+++ b/lib/navigation/mobile-parity-p2.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  getCashierMenu,
+  getManagerMenu,
+  getOwnerLauncherMenu,
+  MANAGER_MENU_SECTIONS,
+  OWNER_BROWSE_AREAS,
+} from '@/lib/navigation/mobile-menu-config';
+import { NAV_GROUPS } from '@/lib/navigation-config';
+import { getFeatures } from '@/lib/features';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+
+const ownerWithStorefront = {
+  role: 'OWNER' as const,
+  features: getFeatures('PRO', 'MULTI_STORE', { onlineStorefront: true }),
+  momoEnabled: true,
+};
+
+const ownerWithoutStorefront = {
+  role: 'OWNER' as const,
+  // Growth without storefront add-on — Pro always includes storefront.
+  features: getFeatures('GROWTH', 'SINGLE_STORE', { onlineStorefront: false }),
+  momoEnabled: true,
+};
+
+const managerWithStorefront = {
+  role: 'MANAGER' as const,
+  features: getFeatures('GROWTH', 'SINGLE_STORE', { onlineStorefront: true }),
+  momoEnabled: true,
+};
+
+const managerWithoutStorefront = {
+  role: 'MANAGER' as const,
+  features: getFeatures('GROWTH', 'SINGLE_STORE', { onlineStorefront: false }),
+  momoEnabled: true,
+};
+
+const cashierContext = {
+  role: 'CASHIER' as const,
+  features: getFeatures('PRO', 'MULTI_STORE', { onlineStorefront: true }),
+  momoEnabled: true,
+};
+
+function desktopItem(href: string) {
+  for (const group of NAV_GROUPS) {
+    const item = group.items.find((entry) => entry.href === href);
+    if (item) return item;
+  }
+  return null;
+}
+
+function ownerHrefs(ctx = ownerWithStorefront) {
+  return getOwnerLauncherMenu(ctx).browseAreas.flatMap((area) => area.items.map((item) => item.href));
+}
+
+function managerHrefs(ctx = managerWithStorefront) {
+  return getManagerMenu(ctx).flatMap((section) => section.items.map((item) => item.href));
+}
+
+describe('P2 mobile navigation parity', () => {
+  it('exposes Product Labels to Owner and Manager mobile menus, not Cashier', () => {
+    expect(ownerHrefs()).toContain('/products/labels');
+    expect(managerHrefs()).toContain('/products/labels');
+    expect(getCashierMenu(cashierContext).map((item) => item.href)).not.toContain('/products/labels');
+
+    const ownerLabels = OWNER_BROWSE_AREAS.flatMap((a) => a.items).find((i) => i.href === '/products/labels');
+    const managerLabels = MANAGER_MENU_SECTIONS.flatMap((a) => a.items).find((i) => i.href === '/products/labels');
+    expect(ownerLabels?.roles).toEqual(['OWNER']);
+    expect(managerLabels?.roles).toEqual(['MANAGER']);
+    expect(ownerLabels?.minimumPlan).toBe('GROWTH');
+    expect(managerLabels?.minimumPlan).toBe('GROWTH');
+    expect(ownerLabels?.roles).not.toContain('CASHIER');
+    expect(managerLabels?.roles).not.toContain('CASHIER');
+  });
+
+  it('places Product Labels in Stock sections for Owner and Manager', () => {
+    const ownerStock = OWNER_BROWSE_AREAS.find((area) => area.id === 'stock-suppliers');
+    const managerStock = MANAGER_MENU_SECTIONS.find((area) => area.id === 'stock');
+    expect(ownerStock?.items.some((item) => item.href === '/products/labels')).toBe(true);
+    expect(managerStock?.items.some((item) => item.href === '/products/labels')).toBe(true);
+  });
+
+  it('exposes Manager Online Orders only when Storefront is enabled', () => {
+    expect(managerHrefs(managerWithStorefront)).toContain('/online-orders');
+    expect(managerHrefs(managerWithoutStorefront)).not.toContain('/online-orders');
+
+    const managerOrders = MANAGER_MENU_SECTIONS.flatMap((a) => a.items).find((i) => i.href === '/online-orders');
+    expect(managerOrders?.requiresFeature).toBe('onlineStorefront');
+    expect(managerOrders?.roles).toEqual(['MANAGER']);
+  });
+
+  it('preserves Owner Online Orders entitlement gating without regressing enabled discovery', () => {
+    expect(ownerHrefs(ownerWithStorefront)).toContain('/online-orders');
+    expect(ownerHrefs(ownerWithoutStorefront)).not.toContain('/online-orders');
+
+    const ownerOrders = OWNER_BROWSE_AREAS.flatMap((a) => a.items).find((i) => i.href === '/online-orders');
+    expect(ownerOrders?.requiresFeature).toBe('onlineStorefront');
+    expect(ownerOrders?.roles).toEqual(['OWNER']);
+  });
+
+  it('exposes Stock Movements to Owner and Manager only', () => {
+    expect(ownerHrefs()).toContain('/reports/stock-movements');
+    expect(managerHrefs()).toContain('/reports/stock-movements');
+    expect(getCashierMenu(cashierContext).map((item) => item.href)).not.toContain('/reports/stock-movements');
+
+    const stockPage = read('app/(protected)/reports/stock-movements/page.tsx');
+    expect(stockPage).toContain("requireBusiness(['MANAGER', 'OWNER'])");
+  });
+
+  it('keeps Supplier Ageing discoverable for Owner and Manager (P1 regression)', () => {
+    expect(ownerHrefs()).toContain('/payments/supplier-aging');
+    expect(managerHrefs()).toContain('/payments/supplier-aging');
+    expect(getCashierMenu(cashierContext).map((item) => item.href)).not.toContain('/payments/supplier-aging');
+  });
+
+  it('does not expose Owner-only admin destinations to Manager or Cashier mobile menus', () => {
+    expect(managerHrefs()).not.toContain('/users');
+    expect(managerHrefs()).not.toContain('/settings/billing');
+    expect(managerHrefs()).not.toContain('/settings/backup');
+    expect(managerHrefs()).not.toContain('/settings/data-repair');
+    expect(getCashierMenu(cashierContext).map((item) => item.href)).not.toContain('/users');
+    expect(getCashierMenu(cashierContext).map((item) => item.href)).not.toContain('/settings');
+    expect(getCashierMenu(cashierContext).map((item) => item.href)).not.toContain('/settings/billing');
+  });
+
+  it('keeps mobile P2 destinations within desktop-authorised roles (nav is not auth)', () => {
+    const watched = ['/products/labels', '/online-orders', '/reports/stock-movements', '/payments/supplier-aging'];
+    const mobileItems = [
+      ...OWNER_BROWSE_AREAS.flatMap((area) => area.items),
+      ...MANAGER_MENU_SECTIONS.flatMap((area) => area.items),
+    ].filter((item) => watched.includes(item.href));
+
+    for (const item of mobileItems) {
+      const desktop = desktopItem(item.href);
+      expect(desktop, `missing desktop NAV_GROUPS entry for ${item.href}`).not.toBeNull();
+      for (const role of item.roles) {
+        expect(desktop!.roles).toContain(role);
+      }
+    }
+  });
+
+  it('does not regress desktop Stock / Sell entries for labels, online orders, and stock movements', () => {
+    expect(desktopItem('/products/labels')?.roles).toEqual(expect.arrayContaining(['MANAGER', 'OWNER']));
+    expect(desktopItem('/online-orders')?.roles).toEqual(expect.arrayContaining(['MANAGER', 'OWNER']));
+    expect(desktopItem('/online-orders')?.requiresFeature).toBe('onlineStorefront');
+    expect(desktopItem('/reports/stock-movements')?.roles).toEqual(expect.arrayContaining(['MANAGER', 'OWNER']));
+
+    // Desktop still lists Cashier for labels; P2 must not add Cashier mobile nav.
+    expect(desktopItem('/products/labels')?.roles).toContain('CASHIER');
+    expect(MANAGER_MENU_SECTIONS.flatMap((a) => a.items).some((i) => i.href === '/products/labels' && i.roles.includes('CASHIER'))).toBe(
+      false,
+    );
+  });
+
+  it('keeps route guards as the authority for Online Orders and Product Labels', () => {
+    expect(read('app/(protected)/online-orders/page.tsx')).toContain("requireBusiness(['MANAGER', 'OWNER'])");
+    expect(read('app/(protected)/products/labels/page.tsx')).toContain("requireBusiness(['CASHIER', 'MANAGER', 'OWNER'])");
+  });
+});


### PR DESCRIPTION
## Summary

Mobile Parity P2 closes confirmed discoverability and presentation gaps for authorised Owner/Manager phone workflows without redesigning TillFlow or changing financial posting.

### Approved manifest

1. **P2-01** — Product Labels mobile navigation (Owner/Manager; not Cashier)
2. **P2-02** — Manager Online Orders when Storefront is enabled
3. **P2-07** — Stock Movements mobile Stock navigation (Owner/Manager)
4. **P2-06** — Navigation-parity regression tests (incl. Supplier Ageing P1 regression)
5. **P2-03** — Cash Drawer shift ledger mobile cards (presentation-only)
6. **P2-04** — Purchase-detail lines and payment-history mobile cards (presentation-only; PR #78 form untouched)
7. **P2-05** — Product Labels queue cards and sticky Preview/Print actions

### Implementation commits

1. `e0bdf4a` — navigation parity
2. `49f4004` — Cash Drawer mobile ledger
3. `16d4eec` — purchase-detail mobile presentation
4. `e65c1f9` — Product Labels mobile workflow

### Preview deployment

| Item | Evidence |
|------|----------|
| Preview URL | https://supermarket-6yhonijuo-joshua-owusus-projects.vercel.app |
| Alias | https://supermarket-pos-git-feat-mobile-p-c7fff4-joshua-owusus-projects.vercel.app |
| Deployment ID | `dpl_2zrd8LTJmTWkZzrTmH9B6373aJuf` |
| Commit | `e65c1f903b412f3cd7a5798bc2d9341ed7c4370f` |
| Branch | `feat/mobile-parity-p2` |
| Build | Ready; CI lint/unit/typecheck/build/pos-safety green |
| Data source | Neon `tillflow_preview` (not Production) |
| Auth | Preview Deployment Protection bypass + Preview QA roles (`prev-ui-invdec-1785709013891`) |

### Authenticated Preview validation (completed)

- **Owner:** Product Labels + Stock Movements discoverable; Supplier Ageing present in Money when expanded; Labels/Cash Drawer usable across 360–430 phone widths; 0 page-level overflow on tested routes.
- **Manager:** Labels + Stock Movements discoverable; Online Orders **hidden** on GROWTH without storefront; Online Orders **visible** after temporary Preview-only PRO+addon entitlement (then restored); Cashier-style restrictions for users/billing held.
- **Cashier:** Labels/Stock Movements/financial Money links absent from mobile nav; direct `/payments/supplier-payments` denied/redirected.
- **Viewports exercised:** 360×800, 375×667, 390×844, 393×873, 430×932, 768×1024, 1440×900 on Cash Drawer, Labels, Stock Movements (Owner + Manager).
- **Purchase-detail:** Preview QA tenant has **0 purchase invoices** — interactive purchase-detail matrix **not safely testable** without creating Preview data. Presentation covered by unit/source tests + prior implementation evidence.
- **Desktop:** Cash Drawer desktop table preserved at 1440.

### Explicit exclusions (unchanged)

Cashier Labels nav; customer/supplier statement cards; Debtor Ageing; new reports; schema/migrations; supplier-payment business logic; Production mutations.

### Automated gates

- GitHub CI on PR #79: pass (lint, unit, typecheck, build, pos-safety)
- Local re-run after Preview validation: navigation P1/P2, cash-drawer/purchase/labels P2 tests, payments service+action — **68/68 pass**
- No validation fix commits required (no in-scope product P1/P2 defects confirmed)
- Production remains `d8a4fb4` / `dpl_D8ashfuFXs8KtmNfhSDLRG4TxrM7`

### Remaining limitations

1. Purchase-detail interactive Preview matrix blocked by empty purchases on Preview QA tenant (non-mutating gate).
2. Storefront-on interactive proof used a temporary Preview-only plan/addon flip that was restored immediately after the check.
3. MoMo reconciliation link correctly gated when MoMo disabled for the Preview tenant.

### Merge recommendation

**Ready for merge approval** after human review of this PR. **Do not merge from this agent.** Separate Production deployment authorisation remains required after merge.

## Test plan

- [x] Navigation unit parity (Owner/Manager/Cashier, Storefront on/off)
- [x] Cash Drawer / purchase-detail / labels structural + payment regression tests
- [x] Full suite / typecheck / lint / build (CI)
- [x] Preview deployment matches branch HEAD
- [x] Owner authenticated Preview validation
- [x] Manager Storefront-off + Storefront-on (temporary Preview entitlement)
- [x] Cashier restrictions
- [x] Viewport matrix on Labels / Cash Drawer / Stock Movements
- [ ] Purchase-detail interactive Preview (blocked: no invoices; optional follow-up seed)
- [ ] Human merge approval
- [ ] Separate Production deploy authorisation
