### PR TITLE
feat(migration): add P0 package, contract and safety foundation

### DIFF
--- a/docs/migration/P0_FUTURE_MODELS.md
+++ b/docs/migration/P0_FUTURE_MODELS.md
@@ -1,0 +1,54 @@
+# Migration Framework — Future models (post-P0)
+
+These models are designed but **not** implemented in P0 because they depend on unfinished import semantics.
+
+## `MigrationEntityMap` (P1/P2)
+
+Purpose: deterministic source → target identity across retries and successor packages.
+
+Proposed uniqueness:
+
+```
+@@unique([businessId, sourceSystemKey, entityType, sourceReference])
+```
+
+Entity types: `SUPPLIER | PRODUCT | CATEGORY` (extend later).
+
+`targetId` is polymorphic (no FK). Deleted targets are detected at import/reconcile time and reported as `MAPPED_TARGET_MISSING` — mappings must not silently retarget.
+
+Deferral reason: without import writes, maps would be empty scaffolding and risk incorrect cascade/attempt semantics.
+
+## `MigrationImportAttempt` + `MigrationChunkReceipt` (P2)
+
+Purpose: resumable chunked import with concurrency control.
+
+Proposed receipt uniqueness:
+
+```
+@@unique([businessId, packageId, attemptId, phase, chunkIndex])
+```
+
+Successful chunk receipts remain valid if a later chunk fails; package is not `IMPORTED` until all chunks and finalisation succeed.
+
+## `MigrationOpeningStockPosting` (P2)
+
+Purpose: idempotent claim for opening-stock quantity + equity posting.
+
+Proposed uniqueness:
+
+```
+@@unique([businessId, packageId, storeId, productId])
+@@unique([businessId, referenceId])
+```
+
+Must participate in the same DB transaction as inventory and journal writes.
+
+## `MigrationException` (P1+)
+
+Purpose: structured, export-safe exception rows (batch/package, entity, source row, code, severity, resolution).
+
+Prefer a dedicated table over unbounded JSON once validation UI lands.
+
+## Reconciliation results (P3)
+
+Persist expected vs actual control totals separately from package lifecycle. `MATCHED` is earned, never manually selected as an import status.

--- a/docs/migration/P0_IMPLEMENTATION.md
+++ b/docs/migration/P0_IMPLEMENTATION.md
@@ -1,0 +1,57 @@
+# Migration Framework P0 — Implementation notes
+
+## Baseline
+
+- Branch: `feat/migration-framework-p0`
+- Created from: `origin/master` @ `baadf1052a06dc8da3603a22b766c79c4b53406c`
+- Historic branch tip excluded (including unrelated POS commit on `migration-framework-phase1`)
+
+## Historic provenance (selective adaptation)
+
+| Source | Reused concept | Adaptation |
+|---|---|---|
+| `0f6a917` `checksum.ts` | SHA-256 hex | Unchanged idea; package manifest added |
+| `0f6a917` `lifecycle.ts` | Fail-closed transitions | New status vocabulary; recon separated |
+| `0f6a917` `limits.ts` | Size limits + CSV sanitize | Added 14-day expiry helpers |
+| `0f6a917` `source-system-key.ts` | Namespace normalisation | Uses `MigrationContractError` (no Next/prisma) |
+| `0f6a917` `contract.ts` | Field specs / headers | PRODUCTS (not CATALOGUE); decimal money; prohibited fields |
+| `0f6a917` schema patterns | Tenant composite unique + FKs | Package/File/BranchMapping (not Batch) |
+
+**Not reused:** `batch-service.ts`, `commit.ts`, upload UI, import actions, historic `MigrationBatch` model, Preview rehearsal scripts.
+
+## What P0 does **not** include
+
+- Upload / validation / approval UI
+- Import execution or accounting posting
+- Preview/Production `prisma migrate deploy`
+- Prospect data handling
+- Dual-control workflow
+
+## Role policy lock
+
+| Role | Access |
+|---|---|
+| Cashier | Denied |
+| Manager | Upload/inspect/validate (future wiring) |
+| Owner | Final approval |
+
+## Checksums
+
+- File identity = SHA-256 of exact uploaded bytes
+- Parsing normalisation ≠ file identity
+- Package manifest checksum = SHA-256 of canonical JSON (fixed key order; sorted files and mappings)
+
+## Expiry / retention
+
+- Unapproved packages: expire 14 days after creation (`expiresAt` immutable on file replace)
+- Approved / importing / imported: not expired by 14-day rule
+- File retention recommendation: 90 days after terminal status; retain checksums/audit forever (subject to business erasure)
+
+## Cleanup (future)
+
+A scheduled job may:
+
+1. Transition expiry-eligible packages with `now >= expiresAt` → `EXPIRED`
+2. After retention window, delete blob/storage objects while retaining DB checksum/audit rows
+
+Not implemented in P0.

--- a/docs/migration/P0_SCHEMA.md
+++ b/docs/migration/P0_SCHEMA.md
@@ -1,0 +1,67 @@
+# Migration Framework P0 — Schema
+
+## Models implemented
+
+### `MigrationPackage`
+
+Atomic package. Holds contract metadata, lifecycle status, reconciliation status, manifest checksums, expiry, and actor audit fields (`createdBy`, `validatedBy`, `approvedBy`, `executedBy`, `cancelledBy`).
+
+Critical constraints:
+
+- `@@unique([businessId, id])` — tenant composite parent
+- `@@unique([businessId, clientPackageKey])` — optional idempotent create
+- indexes on `(businessId, status, createdAt)` and `(businessId, status, expiresAt)`
+
+### `MigrationFile`
+
+Exactly one file per `(packageId, entityType)` where entityType ∈ `SUPPLIERS | PRODUCTS | OPENING_STOCK`.
+
+Checksum fields: `uploadChecksum`, `validationChecksum`, `approvedChecksum`.
+
+Tenant safety: composite FK `(businessId, packageId) → MigrationPackage(businessId, id)`.
+
+### `MigrationBranchMapping`
+
+Maps `sourceBranchKey` → `targetStoreId`.
+
+Tenant safety: composite FK `(businessId, targetStoreId) → Store(businessId, id)` with `ON DELETE RESTRICT`.
+
+Uniqueness: one source branch key per package; one target store per package.
+
+### `Store` additive constraint
+
+`@@unique([businessId, id])` enables the composite FK above. Globally unique `id` already implied this; the compound unique makes tenant membership expressible in SQL.
+
+## Deferred models (not in P0)
+
+See `P0_FUTURE_MODELS.md` for:
+
+- `MigrationEntityMap`
+- `MigrationImportAttempt` / chunk receipts
+- `MigrationOpeningStockPosting`
+- `MigrationException`
+- reconciliation result persistence
+
+## Cascade / retention behaviour
+
+| Relation | onDelete |
+|---|---|
+| Package → Business | Cascade (business erasure policy) |
+| File / mapping → Package | Cascade |
+| Mapping → Store | Restrict |
+| Actor User FKs | SetNull (retain audit ids cleared only if user removed; checksums/manifest remain) |
+
+## Protections not expressible in Prisma alone
+
+| Protection | Enforcement |
+|---|---|
+| Actor belongs to same business as package | Service transaction (`assertSameBusinessActor`) |
+| Required source branches from opening-stock file are all mapped | Service validation before VALIDATED/APPROVED |
+| Manifest matches approved checksums before import | Service (`assertApprovalEvidenceIntact`) — P2 |
+| Expiry transition DRAFT→EXPIRED | Server job / request gate (P1+) using `expiresAt` |
+
+## Migration SQL
+
+`prisma/migrations/20260806130000_migration_framework_p0/migration.sql`
+
+**Not applied** to Preview or Production under P0 authorisation.

--- a/docs/migration/P0_SCHEMA.md
+++ b/docs/migration/P0_SCHEMA.md
@@ -14,7 +14,19 @@ Critical constraints:
 
 ### `MigrationFile`
 
-Exactly one file per `(packageId, entityType)` where entityType ∈ `SUPPLIERS | PRODUCTS | OPENING_STOCK`.
+One logical file belonging to a package. Entity type ∈ `SUPPLIERS | PRODUCTS | OPENING_STOCK`
+(CHECK-constrained in SQL).
+
+`@@unique([packageId, entityType])` guarantees **at most one** file of each entity type
+within a package. It does **not** guarantee that all three Phase 1 types exist.
+
+P1 validation and approval must **transactionally** require exactly:
+
+- one `SUPPLIERS` file;
+- one `PRODUCTS` file;
+- one `OPENING_STOCK` file;
+
+before a package may become `VALIDATED` or `APPROVED`. Passing uniqueness alone is not package completeness.
 
 Checksum fields: `uploadChecksum`, `validationChecksum`, `approvedChecksum`.
 

--- a/docs/migration/PHASE1_CONTRACT_V1.md
+++ b/docs/migration/PHASE1_CONTRACT_V1.md
@@ -20,6 +20,24 @@ A package must carry:
 | Three file checksums | `SUPPLIERS`, `PRODUCTS`, `OPENING_STOCK` |
 | Branch mappings | Every `sourceBranchKey` → same-business `Store` |
 
+### Source branch key canonicalisation
+
+Approval-material `sourceBranchKey` identity (manifest + duplicate policy) uses one shared rule:
+
+1. require a string;
+2. trim surrounding whitespace;
+3. Unicode NFC;
+4. locale-independent lowercase;
+5. reject empty;
+6. max length 128 (on the NFC-trimmed form).
+
+`HQ`, `hq`, and ` HQ ` share one identity. Target `storeId` values are not case-folded.
+
+### Package file completeness
+
+The database guarantees **at most one** file per `(packageId, entityType)`.  
+P1 validation/approval must still require **exactly** the three Phase 1 entity files transactionally.
+
 ## Suppliers file
 
 Required: `sourceSupplierKey`, `supplierName`  

--- a/docs/migration/PHASE1_CONTRACT_V1.md
+++ b/docs/migration/PHASE1_CONTRACT_V1.md
@@ -1,0 +1,60 @@
+# TillFlow Migration Framework — Phase 1 Contract (v1)
+
+**Status:** Locked for P0 foundation  
+**Contract version:** `1`  
+**Scope:** One atomic package = suppliers + products + opening stock
+
+## Package identity
+
+Package identity is **not** derived from filenames.
+
+A package must carry:
+
+| Field | Rule |
+|---|---|
+| `contractVersion` | `"1"` |
+| `sourceSystemKey` | Normalised stable namespace (`[a-z0-9][a-z0-9_-]{1,62}`) |
+| `sourceBusinessKey` | Source-system business identity (NFC, ≤128) |
+| `reportingCurrency` | ISO 4217 (3 letters) |
+| `packageAsOfDate` | `YYYY-MM-DD` |
+| Three file checksums | `SUPPLIERS`, `PRODUCTS`, `OPENING_STOCK` |
+| Branch mappings | Every `sourceBranchKey` → same-business `Store` |
+
+## Suppliers file
+
+Required: `sourceSupplierKey`, `supplierName`  
+Optional: `phone`, `email`, `address`, `taxRegistrationId`, `active`  
+**Prohibited:** supplier balances and all Phase 1 excluded entities
+
+## Products file
+
+Required: `sourceProductKey`, `productName`, `costPrice`, `sellingPrice`, `active`  
+Optional: `sku`, `barcode`, `category`, `unit`, `taxTreatment`, `defaultSupplierSourceKey`
+
+Money fields use ordinary decimal major units (e.g. `12.50`). TillFlow converts to integer minor units.
+
+## Opening stock file
+
+Required: `sourceProductKey`, `sourceBranchKey`, `quantity`, `unitCost`, `asOfDate`  
+Optional: `sourceStockValue` (reconciliation control only)
+
+Rules:
+
+- Zero quantity allowed
+- Negative quantity prohibited
+- Negative unit cost prohibited
+- Authoritative value = `quantity × unitCost` (integer minor units)
+- If `sourceStockValue` is supplied, it must exactly match the calculated value after conversion
+
+## Excluded from Phase 1
+
+Customers, debtor balances, supplier balances, sales/purchase history, cash, MoMo, shifts, loyalty, historic journals, and other operational transactions.
+
+## Existing-record safety
+
+- No fuzzy matching
+- SKU/barcode conflicts are blocking
+- Ambiguous matches are blocking
+- Deleted mapped targets → `MAPPED_TARGET_MISSING`
+- No silent retargeting
+- Existing inventory or trading activity blocks opening-stock import (no Owner override in Phase 1)

--- a/lib/migration/approval.ts
+++ b/lib/migration/approval.ts
@@ -1,0 +1,116 @@
+/**
+ * Approval integrity and invalidation rules (pure).
+ *
+ * Any material file, metadata, or mapping change after approval invalidates
+ * approval. P0 defines the rules; upload/import endpoints are not implemented.
+ */
+
+import { MigrationPolicyError } from '@/lib/migration/errors';
+import {
+  assertCanInvalidateApproval,
+  assertPackageTransition,
+  isExpiryEligibleStatus,
+} from '@/lib/migration/lifecycle';
+import { manifestChecksum } from '@/lib/migration/manifest';
+import type { CanonicalPackageManifest, MigrationPackageStatus } from '@/lib/migration/types';
+
+export type ApprovalEvidence = {
+  status: MigrationPackageStatus;
+  approvedManifestChecksum: string | null;
+  approvedAt: Date | null;
+  files: Array<{
+    entityType: string;
+    uploadChecksum: string;
+    approvedChecksum: string | null;
+  }>;
+};
+
+export function assertApprovalEvidenceIntact(input: {
+  evidence: ApprovalEvidence;
+  currentManifestChecksum: string;
+}): void {
+  const { evidence } = input;
+  if (evidence.status !== 'APPROVED' && evidence.status !== 'IMPORTING') {
+    throw new MigrationPolicyError(
+      `Package status ${evidence.status} is not approved for import.`,
+      'NOT_APPROVED',
+    );
+  }
+  if (!evidence.approvedManifestChecksum) {
+    throw new MigrationPolicyError('Approved manifest checksum is missing.', 'MISSING_APPROVED_MANIFEST');
+  }
+  if (evidence.approvedManifestChecksum !== input.currentManifestChecksum) {
+    throw new MigrationPolicyError(
+      'Package content no longer matches the approved manifest checksum.',
+      'APPROVED_MANIFEST_MISMATCH',
+    );
+  }
+  for (const f of evidence.files) {
+    if (!f.approvedChecksum) {
+      throw new MigrationPolicyError(
+        `Approved checksum missing for ${f.entityType}.`,
+        'MISSING_APPROVED_FILE_CHECKSUM',
+      );
+    }
+    if (f.approvedChecksum !== f.uploadChecksum) {
+      throw new MigrationPolicyError(
+        `File ${f.entityType} changed after approval.`,
+        'APPROVED_FILE_TAMPERED',
+      );
+    }
+  }
+}
+
+/**
+ * Decide whether a candidate change requires approval invalidation.
+ * Returns the next status when invalidation is required.
+ */
+export function nextStatusAfterMaterialChange(input: {
+  status: MigrationPackageStatus;
+  previousManifestChecksum: string | null;
+  nextManifestChecksum: string;
+}): MigrationPackageStatus | null {
+  if (input.status !== 'APPROVED') return null;
+  if (
+    input.previousManifestChecksum &&
+    input.previousManifestChecksum === input.nextManifestChecksum
+  ) {
+    return null;
+  }
+  assertCanInvalidateApproval(input.status);
+  return 'APPROVAL_INVALIDATED';
+}
+
+export function buildApprovalSnapshot(manifestInput: Parameters<typeof manifestChecksum>[0]): {
+  manifestChecksum: string;
+  fileApprovedChecksums: Array<{ entityType: string; checksum: string }>;
+} {
+  return {
+    manifestChecksum: manifestChecksum(manifestInput),
+    fileApprovedChecksums: [...manifestInput.files]
+      .sort((a, b) => a.entityType.localeCompare(b.entityType))
+      .map((f) => ({ entityType: f.entityType, checksum: f.checksum })),
+  };
+}
+
+export function assertCanApprovePackage(input: {
+  status: MigrationPackageStatus;
+  manifest: CanonicalPackageManifest;
+  expiresAt: Date;
+  now?: Date;
+}): void {
+  assertPackageTransition(input.status, 'APPROVED');
+  const now = input.now ?? new Date();
+  if (isExpiryEligibleStatus(input.status) && now.getTime() >= input.expiresAt.getTime()) {
+    throw new MigrationPolicyError('Package has expired and cannot be approved.', 'PACKAGE_EXPIRED');
+  }
+  if (input.manifest.files.length !== 3) {
+    throw new MigrationPolicyError('Approval requires exactly three Phase 1 files.', 'INCOMPLETE_PACKAGE');
+  }
+  if (input.manifest.branchMappings.length === 0) {
+    throw new MigrationPolicyError(
+      'Approval requires at least one resolved branch mapping.',
+      'UNRESOLVED_BRANCH_MAPPING',
+    );
+  }
+}

--- a/lib/migration/checksum-manifest.test.ts
+++ b/lib/migration/checksum-manifest.test.ts
@@ -1,0 +1,138 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest';
+import { sha256Hex, isSha256Hex } from '@/lib/migration/checksum';
+import {
+  buildCanonicalManifest,
+  manifestChecksum,
+  serializeCanonicalManifest,
+} from '@/lib/migration/manifest';
+import {
+  assertApprovalEvidenceIntact,
+  nextStatusAfterMaterialChange,
+  buildApprovalSnapshot,
+} from '@/lib/migration/approval';
+import { MigrationPolicyError } from '@/lib/migration/errors';
+
+const baseFiles = [
+  { entityType: 'SUPPLIERS' as const, checksum: sha256Hex('suppliers-a') },
+  { entityType: 'PRODUCTS' as const, checksum: sha256Hex('products-a') },
+  { entityType: 'OPENING_STOCK' as const, checksum: sha256Hex('stock-a') },
+];
+
+const baseMappings = [
+  { sourceBranchKey: 'HQ', targetStoreId: 'store_1' },
+  { sourceBranchKey: 'BRANCH-2', targetStoreId: 'store_2' },
+];
+
+function baseManifestInput(overrides: Partial<Parameters<typeof manifestChecksum>[0]> = {}) {
+  return {
+    contractVersion: '1',
+    sourceSystemKey: 'legacy-pos',
+    sourceBusinessKey: 'biz-001',
+    reportingCurrency: 'GHS',
+    packageAsOfDate: '2026-09-01',
+    files: baseFiles,
+    branchMappings: baseMappings,
+    ...overrides,
+  };
+}
+
+describe('migration checksums', () => {
+  it('checksums exact bytes and changes when a byte changes', () => {
+    const a = sha256Hex(Buffer.from('name,price\nA,1'));
+    const b = sha256Hex(Buffer.from('name,price\nA,1'));
+    const c = sha256Hex(Buffer.from('name,price\nA,2'));
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(isSha256Hex(a)).toBe(true);
+  });
+
+  it('produces a deterministic manifest checksum independent of mapping input order', () => {
+    const ordered = manifestChecksum(baseManifestInput());
+    const shuffled = manifestChecksum(
+      baseManifestInput({
+        branchMappings: [...baseMappings].reverse(),
+        files: [...baseFiles].reverse(),
+      }),
+    );
+    expect(ordered).toBe(shuffled);
+    expect(isSha256Hex(ordered)).toBe(true);
+  });
+
+  it('changes manifest checksum when a material mapping changes', () => {
+    const a = manifestChecksum(baseManifestInput());
+    const b = manifestChecksum(
+      baseManifestInput({
+        branchMappings: [
+          { sourceBranchKey: 'HQ', targetStoreId: 'store_1' },
+          { sourceBranchKey: 'BRANCH-2', targetStoreId: 'store_OTHER' },
+        ],
+      }),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('serialises with fixed key order (not ordinary object insertion order)', () => {
+    const manifest = buildCanonicalManifest(baseManifestInput());
+    const json = serializeCanonicalManifest(manifest);
+    expect(json.startsWith('{"contractVersion":')).toBe(true);
+    expect(json.indexOf('"files"')).toBeLessThan(json.indexOf('"branchMappings"'));
+  });
+
+  it('invalidates approval evidence when a file checksum changes', () => {
+    const snap = buildApprovalSnapshot(baseManifestInput());
+    expect(() =>
+      assertApprovalEvidenceIntact({
+        evidence: {
+          status: 'APPROVED',
+          approvedManifestChecksum: snap.manifestChecksum,
+          approvedAt: new Date(),
+          files: baseFiles.map((f) => ({
+            entityType: f.entityType,
+            uploadChecksum: f.checksum,
+            approvedChecksum: f.checksum,
+          })),
+        },
+        currentManifestChecksum: snap.manifestChecksum,
+      }),
+    ).not.toThrow();
+
+    const tamperedUpload = sha256Hex('products-TAMPERED');
+    expect(() =>
+      assertApprovalEvidenceIntact({
+        evidence: {
+          status: 'APPROVED',
+          approvedManifestChecksum: snap.manifestChecksum,
+          approvedAt: new Date(),
+          files: baseFiles.map((f) =>
+            f.entityType === 'PRODUCTS'
+              ? {
+                  entityType: f.entityType,
+                  uploadChecksum: tamperedUpload,
+                  approvedChecksum: f.checksum,
+                }
+              : {
+                  entityType: f.entityType,
+                  uploadChecksum: f.checksum,
+                  approvedChecksum: f.checksum,
+                },
+          ),
+        },
+        currentManifestChecksum: snap.manifestChecksum,
+      }),
+    ).toThrow(MigrationPolicyError);
+
+    const next = nextStatusAfterMaterialChange({
+      status: 'APPROVED',
+      previousManifestChecksum: snap.manifestChecksum,
+      nextManifestChecksum: manifestChecksum(
+        baseManifestInput({
+          files: baseFiles.map((f) =>
+            f.entityType === 'PRODUCTS' ? { ...f, checksum: tamperedUpload } : f,
+          ),
+        }),
+      ),
+    });
+    expect(next).toBe('APPROVAL_INVALIDATED');
+  });
+});

--- a/lib/migration/checksum-manifest.test.ts
+++ b/lib/migration/checksum-manifest.test.ts
@@ -135,4 +135,63 @@ describe('migration checksums', () => {
     });
     expect(next).toBe('APPROVAL_INVALIDATED');
   });
+
+  it('canonicalises sourceBranchKey identically for case/whitespace and changes checksum for distinct keys', () => {
+    const a = manifestChecksum(
+      baseManifestInput({
+        branchMappings: [{ sourceBranchKey: 'HQ', targetStoreId: 'store_1' }],
+      }),
+    );
+    const b = manifestChecksum(
+      baseManifestInput({
+        branchMappings: [{ sourceBranchKey: 'hq', targetStoreId: 'store_1' }],
+      }),
+    );
+    const c = manifestChecksum(
+      baseManifestInput({
+        branchMappings: [{ sourceBranchKey: '  HQ  ', targetStoreId: 'store_1' }],
+      }),
+    );
+    expect(a).toBe(b);
+    expect(a).toBe(c);
+
+    const differentKey = manifestChecksum(
+      baseManifestInput({
+        branchMappings: [{ sourceBranchKey: 'WAREHOUSE', targetStoreId: 'store_1' }],
+      }),
+    );
+    expect(a).not.toBe(differentKey);
+
+    // target storeId identity is not case-folded
+    const storeCase = manifestChecksum(
+      baseManifestInput({
+        branchMappings: [{ sourceBranchKey: 'HQ', targetStoreId: 'STORE_1' }],
+      }),
+    );
+    expect(a).not.toBe(storeCase);
+
+    const manifest = buildCanonicalManifest(
+      baseManifestInput({
+        branchMappings: [{ sourceBranchKey: 'HQ', targetStoreId: 'store_1' }],
+      }),
+    );
+    expect(manifest.branchMappings[0]?.sourceBranchKey).toBe('hq');
+    expect(manifest.branchMappings[0]?.targetStoreId).toBe('store_1');
+  });
+
+  it('treats NFC-equivalent sourceBranchKey forms as identical', () => {
+    const composed = 'caf\u00e9';
+    const decomposed = 'cafe\u0301';
+    const a = manifestChecksum(
+      baseManifestInput({
+        branchMappings: [{ sourceBranchKey: composed, targetStoreId: 'store_1' }],
+      }),
+    );
+    const b = manifestChecksum(
+      baseManifestInput({
+        branchMappings: [{ sourceBranchKey: decomposed, targetStoreId: 'store_1' }],
+      }),
+    );
+    expect(a).toBe(b);
+  });
 });

--- a/lib/migration/checksum.ts
+++ b/lib/migration/checksum.ts
@@ -1,0 +1,18 @@
+/**
+ * Exact-byte SHA-256 helpers for migration file identity.
+ *
+ * Provenance: adapted from historic lib/migration/checksum.ts (0f6a917).
+ * Parsing normalisation is intentionally separate from file identity.
+ */
+
+import { createHash } from 'node:crypto';
+
+/** SHA-256 hex digest of the exact uploaded bytes (or UTF-8 string content). */
+export function sha256Hex(content: string | Buffer | Uint8Array): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+/** True when value looks like a lowercase hex SHA-256 digest. */
+export function isSha256Hex(value: string): boolean {
+  return /^[a-f0-9]{64}$/.test(value);
+}

--- a/lib/migration/contract.test.ts
+++ b/lib/migration/contract.test.ts
@@ -1,0 +1,116 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidCsvHeaders,
+  validateCsvHeaders,
+  parseAsOfDate,
+  parseReportingCurrency,
+  parseNonNegativeIntegerQuantity,
+  assertNoDuplicateSourceKeys,
+  normaliseHeaderCell,
+} from '@/lib/migration/contract';
+import {
+  parseDecimalCurrencyToMinorUnits,
+  parseOpeningStockUnitCostToMinorUnits,
+  assertSourceStockValueMatches,
+  calculateOpeningStockValueMinor,
+} from '@/lib/migration/money';
+import { normaliseSourceSystemKey, normaliseSourceBusinessKey } from '@/lib/migration/source-system-key';
+import { MigrationContractError } from '@/lib/migration/errors';
+import { sanitizeCsvCell } from '@/lib/migration/limits';
+
+describe('migration data contract v1', () => {
+  it('requires Phase 1 headers and rejects duplicates / unknown / prohibited fields', () => {
+    expect(
+      validateCsvHeaders('SUPPLIERS', ['sourceSupplierKey', 'supplierName', 'phone']).ok,
+    ).toBe(true);
+
+    const dup = validateCsvHeaders('PRODUCTS', [
+      'sourceProductKey',
+      'productName',
+      'costPrice',
+      'sellingPrice',
+      'active',
+      'sku',
+      'SKU',
+    ]);
+    expect(dup.ok).toBe(false);
+    expect(dup.duplicateHeaders).toContain('sku');
+
+    const prohibited = validateCsvHeaders('SUPPLIERS', [
+      'sourceSupplierKey',
+      'supplierName',
+      'supplierBalance',
+    ]);
+    expect(prohibited.prohibitedHeaders).toContain('supplierbalance');
+
+    expect(() =>
+      assertValidCsvHeaders('OPENING_STOCK', ['sourceProductKey', 'quantity']),
+    ).toThrow(MigrationContractError);
+  });
+
+  it('normalises headers with Unicode NFC and BOM stripping', () => {
+    expect(normaliseHeaderCell('\uFEFFsourceSupplierKey')).toBe('sourceSupplierKey');
+    expect(normaliseHeaderCell('  product   Name ')).toBe('product Name');
+  });
+
+  it('rejects duplicate source keys', () => {
+    expect(() => assertNoDuplicateSourceKeys(['A', 'a'], 'sourceSupplierKey')).toThrow(
+      /Duplicate/,
+    );
+  });
+
+  it('parses decimal currency into minor units and rejects unsafe forms', () => {
+    expect(parseDecimalCurrencyToMinorUnits('12.50')).toBe(1250);
+    expect(parseDecimalCurrencyToMinorUnits('12.5')).toBe(1250);
+    expect(parseDecimalCurrencyToMinorUnits('1,234.56')).toBe(123456);
+    expect(parseDecimalCurrencyToMinorUnits(0)).toBe(0);
+
+    expect(() => parseDecimalCurrencyToMinorUnits('12.505')).toThrow(/2 decimal/);
+    expect(() => parseDecimalCurrencyToMinorUnits('1e2')).toThrow(/scientific/);
+    expect(() => parseDecimalCurrencyToMinorUnits('GH₵12.50')).toThrow(/currency symbols/);
+    expect(() => parseDecimalCurrencyToMinorUnits('1,23.45')).toThrow(/grouping/);
+    expect(() => parseDecimalCurrencyToMinorUnits('')).toThrow(MigrationContractError);
+  });
+
+  it('calculates stock value and blocks sourceStockValue mismatch', () => {
+    expect(calculateOpeningStockValueMinor(10, 1250)).toBe(12500);
+    expect(
+      assertSourceStockValueMatches({
+        quantityBase: 10,
+        unitCostMinor: 1250,
+        sourceStockValueRaw: '125.00',
+      }),
+    ).toBe(12500);
+    expect(() =>
+      assertSourceStockValueMatches({
+        quantityBase: 10,
+        unitCostMinor: 1250,
+        sourceStockValueRaw: '100.00',
+      }),
+    ).toThrow(/does not match/);
+  });
+
+  it('allows zero quantity and rejects negatives', () => {
+    expect(parseNonNegativeIntegerQuantity('0')).toBe(0);
+    expect(() => parseNonNegativeIntegerQuantity('-1')).toThrow(/non-negative/);
+    expect(() => parseOpeningStockUnitCostToMinorUnits('-1.00')).toThrow(/must not be negative/);
+    expect(() => calculateOpeningStockValueMinor(1, -1)).toThrow(/must not be negative/);
+    expect(() => calculateOpeningStockValueMinor(-1, 100)).toThrow(/non-negative/);
+  });
+
+  it('validates dates, currency, and source keys', () => {
+    expect(parseAsOfDate('2026-09-01')).toBe('2026-09-01');
+    expect(() => parseAsOfDate('2026-13-01')).toThrow();
+    expect(parseReportingCurrency('ghs')).toBe('GHS');
+    expect(() => parseReportingCurrency('cedi')).toThrow();
+    expect(normaliseSourceSystemKey('Legacy-POS')).toBe('legacy-pos');
+    expect(() => normaliseSourceSystemKey('')).toThrow();
+    expect(normaliseSourceBusinessKey(' HQ-001 ')).toBe('HQ-001');
+  });
+
+  it('sanitises CSV injection on export cells only', () => {
+    expect(sanitizeCsvCell('=cmd')).toBe("'=cmd");
+    expect(sanitizeCsvCell('plain')).toBe('plain');
+  });
+});

--- a/lib/migration/contract.test.ts
+++ b/lib/migration/contract.test.ts
@@ -99,6 +99,18 @@ describe('migration data contract v1', () => {
     expect(() => calculateOpeningStockValueMinor(-1, 100)).toThrow(/non-negative/);
   });
 
+  it('rejects signed negative zero and returns ordinary zero for valid zeros', () => {
+    for (const z of ['0', '0.0', '0.00', '+0'] as const) {
+      const v = parseDecimalCurrencyToMinorUnits(z);
+      expect(v).toBe(0);
+      expect(Object.is(v, -0)).toBe(false);
+    }
+    for (const nz of ['-0', '-0.0', '-0.00'] as const) {
+      expect(() => parseDecimalCurrencyToMinorUnits(nz)).toThrow(/signed negative zero/);
+      expect(() => parseOpeningStockUnitCostToMinorUnits(nz)).toThrow();
+    }
+  });
+
   it('validates dates, currency, and source keys', () => {
     expect(parseAsOfDate('2026-09-01')).toBe('2026-09-01');
     expect(() => parseAsOfDate('2026-13-01')).toThrow();

--- a/lib/migration/contract.ts
+++ b/lib/migration/contract.ts
@@ -1,0 +1,444 @@
+/**
+ * Source-neutral Phase 1 data contract (version 1).
+ *
+ * Provenance: field ideas adapted from historic lib/migration/contract.ts (0f6a917),
+ * rewritten for package-oriented entity names (PRODUCTS not CATALOGUE), decimal
+ * money, and prohibited Phase 1 balance/history fields.
+ */
+
+import { MigrationContractError } from '@/lib/migration/errors';
+import {
+  MIGRATION_CONTRACT_VERSION,
+  PHASE1_PROHIBITED_FIELDS,
+  type MigrationEntityType,
+  type MigrationFieldSpec,
+} from '@/lib/migration/types';
+
+export { MIGRATION_CONTRACT_VERSION };
+
+export const SUPPLIER_HEADERS = [
+  'sourceSupplierKey',
+  'supplierName',
+  'phone',
+  'email',
+  'address',
+  'taxRegistrationId',
+  'active',
+] as const;
+
+export const PRODUCT_HEADERS = [
+  'sourceProductKey',
+  'productName',
+  'costPrice',
+  'sellingPrice',
+  'active',
+  'sku',
+  'barcode',
+  'category',
+  'unit',
+  'taxTreatment',
+  'defaultSupplierSourceKey',
+] as const;
+
+export const OPENING_STOCK_HEADERS = [
+  'sourceProductKey',
+  'sourceBranchKey',
+  'quantity',
+  'unitCost',
+  'asOfDate',
+  'sourceStockValue',
+] as const;
+
+export const REQUIRED_SUPPLIER_HEADERS = ['sourceSupplierKey', 'supplierName'] as const;
+export const REQUIRED_PRODUCT_HEADERS = [
+  'sourceProductKey',
+  'productName',
+  'costPrice',
+  'sellingPrice',
+  'active',
+] as const;
+export const REQUIRED_OPENING_STOCK_HEADERS = [
+  'sourceProductKey',
+  'sourceBranchKey',
+  'quantity',
+  'unitCost',
+  'asOfDate',
+] as const;
+
+export const SUPPLIER_FIELD_SPECS: MigrationFieldSpec[] = [
+  {
+    key: 'sourceSupplierKey',
+    label: 'Source supplier key',
+    requirement: 'required',
+    validation: 'Required; unique within file; Unicode NFC',
+    maxLength: 128,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'supplierName',
+    label: 'Supplier name',
+    requirement: 'required',
+    validation: 'Required; max 200 chars',
+    maxLength: 200,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'phone',
+    label: 'Phone',
+    requirement: 'optional',
+    validation: 'Optional; max 40 chars',
+    maxLength: 40,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'email',
+    label: 'Email',
+    requirement: 'optional',
+    validation: 'Optional; max 200 chars',
+    maxLength: 200,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'address',
+    label: 'Address',
+    requirement: 'optional',
+    validation: 'Optional; max 500 chars',
+    maxLength: 500,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'taxRegistrationId',
+    label: 'Tax / registration id',
+    requirement: 'optional',
+    validation: 'Optional; max 80 chars',
+    maxLength: 80,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'active',
+    label: 'Active',
+    requirement: 'optional',
+    validation: 'Optional; true/false/1/0; default true',
+    failureSeverity: 'blocking',
+  },
+];
+
+export const PRODUCT_FIELD_SPECS: MigrationFieldSpec[] = [
+  {
+    key: 'sourceProductKey',
+    label: 'Source product key',
+    requirement: 'required',
+    validation: 'Required; unique within file',
+    maxLength: 128,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'productName',
+    label: 'Product name',
+    requirement: 'required',
+    validation: 'Required; max 200 chars',
+    maxLength: 200,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'costPrice',
+    label: 'Cost price',
+    requirement: 'required',
+    validation: 'Required; decimal currency (major units); converted to minor units',
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'sellingPrice',
+    label: 'Selling price',
+    requirement: 'required',
+    validation: 'Required; decimal currency (major units); converted to minor units',
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'active',
+    label: 'Active',
+    requirement: 'required',
+    validation: 'Required; true/false/1/0',
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'sku',
+    label: 'SKU',
+    requirement: 'optional',
+    validation: 'Optional; business-unique when present; conflicts blocking',
+    maxLength: 64,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'barcode',
+    label: 'Barcode',
+    requirement: 'optional',
+    validation: 'Optional; conflicts blocking',
+    maxLength: 64,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'category',
+    label: 'Category',
+    requirement: 'optional',
+    validation: 'Optional; max 100 chars',
+    maxLength: 100,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'unit',
+    label: 'Unit',
+    requirement: 'optional',
+    validation: 'Optional; max 40 chars',
+    maxLength: 40,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'taxTreatment',
+    label: 'Tax treatment',
+    requirement: 'optional',
+    validation: 'Optional; max 40 chars',
+    maxLength: 40,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'defaultSupplierSourceKey',
+    label: 'Default supplier source key',
+    requirement: 'optional',
+    validation: 'Optional; must match a suppliers-file sourceSupplierKey when set',
+    maxLength: 128,
+    failureSeverity: 'blocking',
+  },
+];
+
+export const OPENING_STOCK_FIELD_SPECS: MigrationFieldSpec[] = [
+  {
+    key: 'sourceProductKey',
+    label: 'Source product key',
+    requirement: 'required',
+    validation: 'Required; must reference products file',
+    maxLength: 128,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'sourceBranchKey',
+    label: 'Source branch key',
+    requirement: 'required',
+    validation: 'Required; must be mapped to a TillFlow store before approval',
+    maxLength: 128,
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'quantity',
+    label: 'Quantity',
+    requirement: 'required',
+    validation: 'Required; non-negative integer; zero allowed; negatives prohibited',
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'unitCost',
+    label: 'Unit cost',
+    requirement: 'required',
+    validation: 'Required; decimal currency ≥ 0; negatives prohibited',
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'asOfDate',
+    label: 'As-of date',
+    requirement: 'required',
+    validation: 'Required; YYYY-MM-DD',
+    failureSeverity: 'blocking',
+  },
+  {
+    key: 'sourceStockValue',
+    label: 'Source stock value',
+    requirement: 'optional',
+    validation:
+      'Optional reconciliation control; must equal quantity × unitCost after minor-unit conversion',
+    failureSeverity: 'blocking',
+  },
+];
+
+const HEADER_SETS: Record<MigrationEntityType, readonly string[]> = {
+  SUPPLIERS: SUPPLIER_HEADERS,
+  PRODUCTS: PRODUCT_HEADERS,
+  OPENING_STOCK: OPENING_STOCK_HEADERS,
+};
+
+const REQUIRED_SETS: Record<MigrationEntityType, readonly string[]> = {
+  SUPPLIERS: REQUIRED_SUPPLIER_HEADERS,
+  PRODUCTS: REQUIRED_PRODUCT_HEADERS,
+  OPENING_STOCK: REQUIRED_OPENING_STOCK_HEADERS,
+};
+
+export function headersForEntity(entityType: MigrationEntityType): readonly string[] {
+  return HEADER_SETS[entityType];
+}
+
+export function requiredHeadersForEntity(entityType: MigrationEntityType): readonly string[] {
+  return REQUIRED_SETS[entityType];
+}
+
+/** Normalise a CSV header cell: trim, NFC, collapse internal whitespace to single space, lowercase compare key. */
+export function normaliseHeaderCell(raw: string): string {
+  return raw.replace(/^\uFEFF/, '').trim().normalize('NFC').replace(/\s+/g, ' ');
+}
+
+export function headerCompareKey(raw: string): string {
+  return normaliseHeaderCell(raw).toLowerCase();
+}
+
+export type HeaderValidationResult = {
+  ok: boolean;
+  normalisedHeaders: string[];
+  missingRequired: string[];
+  unknownHeaders: string[];
+  duplicateHeaders: string[];
+  prohibitedHeaders: string[];
+};
+
+export function validateCsvHeaders(
+  entityType: MigrationEntityType,
+  rawHeaders: string[],
+): HeaderValidationResult {
+  const normalisedHeaders = rawHeaders.map(normaliseHeaderCell);
+  const compareKeys = normalisedHeaders.map((h) => h.toLowerCase());
+
+  const duplicateHeaders: string[] = [];
+  const seen = new Set<string>();
+  for (const key of compareKeys) {
+    if (!key) continue;
+    if (seen.has(key)) duplicateHeaders.push(key);
+    seen.add(key);
+  }
+
+  const allowed = new Set(HEADER_SETS[entityType].map((h) => h.toLowerCase()));
+  const prohibited = new Set(PHASE1_PROHIBITED_FIELDS.map((h) => h.toLowerCase()));
+
+  const prohibitedHeaders = compareKeys.filter((h) => h && prohibited.has(h));
+  const unknownHeaders = compareKeys.filter(
+    (h) => h && !allowed.has(h) && !prohibited.has(h),
+  );
+
+  const missingRequired = REQUIRED_SETS[entityType].filter(
+    (req) => !seen.has(req.toLowerCase()),
+  );
+
+  const ok =
+    duplicateHeaders.length === 0 &&
+    prohibitedHeaders.length === 0 &&
+    unknownHeaders.length === 0 &&
+    missingRequired.length === 0;
+
+  return {
+    ok,
+    normalisedHeaders,
+    missingRequired,
+    unknownHeaders,
+    duplicateHeaders,
+    prohibitedHeaders,
+  };
+}
+
+export function assertValidCsvHeaders(
+  entityType: MigrationEntityType,
+  rawHeaders: string[],
+): HeaderValidationResult {
+  const result = validateCsvHeaders(entityType, rawHeaders);
+  if (!result.ok) {
+    const parts: string[] = [];
+    if (result.duplicateHeaders.length) {
+      parts.push(`duplicate headers: ${result.duplicateHeaders.join(', ')}`);
+    }
+    if (result.missingRequired.length) {
+      parts.push(`missing required: ${result.missingRequired.join(', ')}`);
+    }
+    if (result.prohibitedHeaders.length) {
+      parts.push(`prohibited Phase 1 fields: ${result.prohibitedHeaders.join(', ')}`);
+    }
+    if (result.unknownHeaders.length) {
+      parts.push(`unknown headers: ${result.unknownHeaders.join(', ')}`);
+    }
+    throw new MigrationContractError(
+      `${entityType} header validation failed (${parts.join('; ')}).`,
+    );
+  }
+  return result;
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function parseAsOfDate(raw: unknown): string {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new MigrationContractError('asOfDate is required (YYYY-MM-DD).');
+  }
+  const value = raw.trim();
+  if (!ISO_DATE.test(value)) {
+    throw new MigrationContractError('asOfDate must be YYYY-MM-DD.');
+  }
+  const [y, m, d] = value.split('-').map(Number);
+  const dt = new Date(Date.UTC(y!, m! - 1, d!));
+  if (
+    dt.getUTCFullYear() !== y ||
+    dt.getUTCMonth() !== m! - 1 ||
+    dt.getUTCDate() !== d
+  ) {
+    throw new MigrationContractError('asOfDate is not a real calendar date.');
+  }
+  return value;
+}
+
+export function parseReportingCurrency(raw: unknown): string {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new MigrationContractError('reportingCurrency is required (ISO 4217).');
+  }
+  const ccy = raw.trim().toUpperCase();
+  if (!/^[A-Z]{3}$/.test(ccy)) {
+    throw new MigrationContractError('reportingCurrency must be a 3-letter ISO 4217 code.');
+  }
+  return ccy;
+}
+
+export function parseActiveFlag(raw: unknown, fieldLabel = 'active'): boolean {
+  if (raw === null || raw === undefined || String(raw).trim() === '') {
+    throw new MigrationContractError(`${fieldLabel} is required.`);
+  }
+  const v = String(raw).trim().toLowerCase();
+  if (['true', '1', 'yes', 'y'].includes(v)) return true;
+  if (['false', '0', 'no', 'n'].includes(v)) return false;
+  throw new MigrationContractError(`${fieldLabel} must be true/false (or 1/0).`);
+}
+
+export function parseOptionalActiveFlag(raw: unknown): boolean {
+  if (raw === null || raw === undefined || String(raw).trim() === '') return true;
+  return parseActiveFlag(raw, 'active');
+}
+
+export function parseNonNegativeIntegerQuantity(raw: unknown): number {
+  if (raw === null || raw === undefined || String(raw).trim() === '') {
+    throw new MigrationContractError('quantity is required.');
+  }
+  const s = String(raw).trim();
+  if (!/^\d+$/.test(s)) {
+    throw new MigrationContractError('quantity must be a non-negative integer.');
+  }
+  const n = Number(s);
+  if (!Number.isSafeInteger(n)) {
+    throw new MigrationContractError('quantity exceeds safe integer range.');
+  }
+  return n;
+}
+
+export function assertNoDuplicateSourceKeys(
+  keys: string[],
+  fieldLabel: string,
+): void {
+  const seen = new Set<string>();
+  for (const raw of keys) {
+    const key = raw.trim().normalize('NFC').toLowerCase();
+    if (seen.has(key)) {
+      throw new MigrationContractError(`Duplicate ${fieldLabel}: ${raw}`);
+    }
+    seen.add(key);
+  }
+}

--- a/lib/migration/errors.ts
+++ b/lib/migration/errors.ts
@@ -1,0 +1,33 @@
+/**
+ * Lightweight migration domain errors (avoid importing Next/prisma action-utils in unit tests).
+ */
+
+export class MigrationContractError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = 'MIGRATION_CONTRACT') {
+    super(message);
+    this.name = 'MigrationContractError';
+    this.code = code;
+  }
+}
+
+export class MigrationPolicyError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = 'MIGRATION_POLICY') {
+    super(message);
+    this.name = 'MigrationPolicyError';
+    this.code = code;
+  }
+}
+
+export class MigrationLifecycleError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = 'MIGRATION_LIFECYCLE') {
+    super(message);
+    this.name = 'MigrationLifecycleError';
+    this.code = code;
+  }
+}

--- a/lib/migration/existing-record-policy.ts
+++ b/lib/migration/existing-record-policy.ts
@@ -1,0 +1,33 @@
+/**
+ * Existing-record safety policy for Phase 1 (documented + testable constants).
+ *
+ * Enforcement against live DB rows belongs in P1/P2. P0 locks the rules.
+ */
+
+export const EXISTING_RECORD_POLICY = {
+  fuzzyMatching: false,
+  skuConflict: 'blocking' as const,
+  barcodeConflict: 'blocking' as const,
+  ambiguousSupplierMatch: 'blocking' as const,
+  ambiguousProductMatch: 'blocking' as const,
+  deletedMappedTarget: 'MAPPED_TARGET_MISSING' as const,
+  silentRetarget: false,
+  /**
+   * Products/branches with existing inventory or trading activity are not
+   * eligible for opening-stock import. No Owner override in Phase 1.
+   */
+  existingInventoryOrTradingBlocksOpeningStock: true,
+  ownerOverrideForLiveStock: false,
+} as const;
+
+export function isOpeningStockBlockedByExistingActivity(input: {
+  hasInventoryBalance: boolean;
+  hasTradingActivity: boolean;
+}): boolean {
+  if (!EXISTING_RECORD_POLICY.existingInventoryOrTradingBlocksOpeningStock) return false;
+  return input.hasInventoryBalance || input.hasTradingActivity;
+}
+
+export function mappedTargetMissingCode(): typeof EXISTING_RECORD_POLICY.deletedMappedTarget {
+  return EXISTING_RECORD_POLICY.deletedMappedTarget;
+}

--- a/lib/migration/expiry.ts
+++ b/lib/migration/expiry.ts
@@ -1,0 +1,33 @@
+/**
+ * Expiry evaluation for unapproved packages.
+ *
+ * The expiry clock starts at package creation and is not restarted by file
+ * replacement. Approved / importing / imported packages are not expired by the
+ * 14-day rule.
+ */
+
+import { isExpiryEligibleStatus } from '@/lib/migration/lifecycle';
+import type { MigrationPackageStatus } from '@/lib/migration/types';
+
+export function shouldExpireUnapprovedPackage(input: {
+  status: MigrationPackageStatus;
+  expiresAt: Date;
+  now?: Date;
+}): boolean {
+  if (!isExpiryEligibleStatus(input.status)) return false;
+  const now = input.now ?? new Date();
+  return now.getTime() >= input.expiresAt.getTime();
+}
+
+/**
+ * File replacement must not mutate expiresAt. This helper documents and tests
+ * the invariant: nextExpiresAt === previousExpiresAt.
+ */
+export function assertExpiryClockImmutable(input: {
+  previousExpiresAt: Date;
+  nextExpiresAt: Date;
+}): void {
+  if (input.previousExpiresAt.getTime() !== input.nextExpiresAt.getTime()) {
+    throw new Error('Migration package expiresAt must not change when files are replaced.');
+  }
+}

--- a/lib/migration/index.ts
+++ b/lib/migration/index.ts
@@ -12,6 +12,7 @@ export * from '@/lib/migration/lifecycle';
 export * from '@/lib/migration/money';
 export * from '@/lib/migration/limits';
 export * from '@/lib/migration/source-system-key';
+export * from '@/lib/migration/source-branch-key';
 export * from '@/lib/migration/roles';
 export * from '@/lib/migration/tenant-policy';
 export * from '@/lib/migration/approval';

--- a/lib/migration/index.ts
+++ b/lib/migration/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Migration Framework P0 public surface.
+ *
+ * No upload UI, import execution, or accounting posting is exported from P0.
+ */
+
+export * from '@/lib/migration/types';
+export * from '@/lib/migration/errors';
+export * from '@/lib/migration/checksum';
+export * from '@/lib/migration/manifest';
+export * from '@/lib/migration/lifecycle';
+export * from '@/lib/migration/money';
+export * from '@/lib/migration/limits';
+export * from '@/lib/migration/source-system-key';
+export * from '@/lib/migration/roles';
+export * from '@/lib/migration/tenant-policy';
+export * from '@/lib/migration/approval';
+export * from '@/lib/migration/existing-record-policy';
+export * from '@/lib/migration/expiry';
+export * from '@/lib/migration/contract';

--- a/lib/migration/lifecycle.test.ts
+++ b/lib/migration/lifecycle.test.ts
@@ -1,0 +1,103 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest';
+import {
+  assertPackageTransition,
+  assertReconciliationTransition,
+  canTransitionPackage,
+  canTransitionReconciliation,
+  isPackageLifecycleTerminal,
+  isExpiryEligibleStatus,
+} from '@/lib/migration/lifecycle';
+import { MigrationLifecycleError } from '@/lib/migration/errors';
+import { shouldExpireUnapprovedPackage, assertExpiryClockImmutable } from '@/lib/migration/expiry';
+import { computePackageExpiresAt } from '@/lib/migration/limits';
+
+describe('migration package lifecycle', () => {
+  it('allows DRAFT → VALIDATED and DRAFT → VALIDATION_FAILED', () => {
+    expect(canTransitionPackage('DRAFT', 'VALIDATED')).toBe(true);
+    expect(canTransitionPackage('DRAFT', 'VALIDATION_FAILED')).toBe(true);
+    assertPackageTransition('DRAFT', 'VALIDATED');
+  });
+
+  it('allows VALIDATED → APPROVED and APPROVED → IMPORTING → IMPORTED', () => {
+    assertPackageTransition('VALIDATED', 'APPROVED');
+    assertPackageTransition('APPROVED', 'IMPORTING');
+    assertPackageTransition('IMPORTING', 'IMPORTED');
+  });
+
+  it('rejects forbidden transitions fail-closed', () => {
+    expect(canTransitionPackage('DRAFT', 'APPROVED')).toBe(false);
+    expect(canTransitionPackage('DRAFT', 'IMPORTED')).toBe(false);
+    expect(canTransitionPackage('IMPORTED', 'DRAFT')).toBe(false);
+    expect(() => assertPackageTransition('DRAFT', 'IMPORTING')).toThrow(MigrationLifecycleError);
+  });
+
+  it('treats IMPORTED, EXPIRED, CANCELLED as terminal', () => {
+    expect(isPackageLifecycleTerminal('IMPORTED')).toBe(true);
+    expect(isPackageLifecycleTerminal('EXPIRED')).toBe(true);
+    expect(isPackageLifecycleTerminal('CANCELLED')).toBe(true);
+    expect(isPackageLifecycleTerminal('APPROVED')).toBe(false);
+  });
+
+  it('allows approval invalidation from APPROVED only via APPROVAL_INVALIDATED', () => {
+    assertPackageTransition('APPROVED', 'APPROVAL_INVALIDATED');
+    expect(canTransitionPackage('IMPORTED', 'APPROVAL_INVALIDATED')).toBe(false);
+  });
+
+  it('keeps reconciliation separate from package lifecycle', () => {
+    expect(canTransitionReconciliation('NOT_STARTED', 'RECONCILING')).toBe(true);
+    expect(canTransitionReconciliation('RECONCILING', 'MATCHED')).toBe(true);
+    expect(canTransitionReconciliation('NOT_STARTED', 'MATCHED')).toBe(false);
+    expect(() => assertReconciliationTransition('MATCHED', 'MISMATCHED')).toThrow(
+      MigrationLifecycleError,
+    );
+    // MATCHED is not a package status transition target from DRAFT
+    expect(canTransitionPackage('DRAFT', 'IMPORTED')).toBe(false);
+  });
+});
+
+describe('migration expiry rules', () => {
+  it('expires only unapproved-eligible statuses after expiresAt', () => {
+    const created = new Date('2026-08-01T00:00:00.000Z');
+    const expiresAt = computePackageExpiresAt(created);
+    expect(expiresAt.toISOString()).toBe('2026-08-15T00:00:00.000Z');
+
+    expect(isExpiryEligibleStatus('DRAFT')).toBe(true);
+    expect(isExpiryEligibleStatus('APPROVED')).toBe(false);
+
+    expect(
+      shouldExpireUnapprovedPackage({
+        status: 'DRAFT',
+        expiresAt,
+        now: new Date('2026-08-14T23:59:59.000Z'),
+      }),
+    ).toBe(false);
+    expect(
+      shouldExpireUnapprovedPackage({
+        status: 'DRAFT',
+        expiresAt,
+        now: new Date('2026-08-15T00:00:00.000Z'),
+      }),
+    ).toBe(true);
+    expect(
+      shouldExpireUnapprovedPackage({
+        status: 'APPROVED',
+        expiresAt,
+        now: new Date('2026-09-01T00:00:00.000Z'),
+      }),
+    ).toBe(false);
+  });
+
+  it('does not restart expiry clock on file replacement', () => {
+    const expiresAt = new Date('2026-08-20T00:00:00.000Z');
+    expect(() =>
+      assertExpiryClockImmutable({ previousExpiresAt: expiresAt, nextExpiresAt: expiresAt }),
+    ).not.toThrow();
+    expect(() =>
+      assertExpiryClockImmutable({
+        previousExpiresAt: expiresAt,
+        nextExpiresAt: new Date('2026-08-25T00:00:00.000Z'),
+      }),
+    ).toThrow(/must not change/);
+  });
+});

--- a/lib/migration/lifecycle.ts
+++ b/lib/migration/lifecycle.ts
@@ -1,0 +1,86 @@
+/**
+ * Package lifecycle and reconciliation transition rules (fail-closed).
+ *
+ * Provenance: structure adapted from historic lib/migration/lifecycle.ts (0f6a917);
+ * statuses rewritten for the locked DRAFT→IMPORTED / separate reconciliation model.
+ */
+
+import { MigrationLifecycleError } from '@/lib/migration/errors';
+import type { MigrationPackageStatus, MigrationReconciliationStatus } from '@/lib/migration/types';
+
+const PACKAGE_TRANSITIONS: Record<MigrationPackageStatus, MigrationPackageStatus[]> = {
+  DRAFT: ['VALIDATED', 'VALIDATION_FAILED', 'CANCELLED', 'EXPIRED'],
+  VALIDATED: ['APPROVED', 'APPROVAL_INVALIDATED', 'DRAFT', 'VALIDATION_FAILED', 'CANCELLED', 'EXPIRED'],
+  APPROVED: ['IMPORTING', 'APPROVAL_INVALIDATED', 'CANCELLED'],
+  IMPORTING: ['IMPORTED', 'IMPORT_FAILED'],
+  IMPORTED: [],
+  VALIDATION_FAILED: ['DRAFT', 'CANCELLED', 'EXPIRED'],
+  APPROVAL_INVALIDATED: ['DRAFT', 'VALIDATED', 'CANCELLED', 'EXPIRED'],
+  IMPORT_FAILED: ['IMPORTING', 'CANCELLED'],
+  EXPIRED: [],
+  CANCELLED: [],
+};
+
+const RECON_TRANSITIONS: Record<MigrationReconciliationStatus, MigrationReconciliationStatus[]> = {
+  NOT_STARTED: ['RECONCILING'],
+  RECONCILING: ['MATCHED', 'MISMATCHED', 'RECONCILIATION_FAILED'],
+  MATCHED: [],
+  MISMATCHED: ['RECONCILING'],
+  RECONCILIATION_FAILED: ['RECONCILING'],
+};
+
+export function canTransitionPackage(
+  from: MigrationPackageStatus,
+  to: MigrationPackageStatus,
+): boolean {
+  return PACKAGE_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function assertPackageTransition(
+  from: MigrationPackageStatus,
+  to: MigrationPackageStatus,
+): void {
+  if (!canTransitionPackage(from, to)) {
+    throw new MigrationLifecycleError(`Invalid migration package transition: ${from} → ${to}`);
+  }
+}
+
+export function canTransitionReconciliation(
+  from: MigrationReconciliationStatus,
+  to: MigrationReconciliationStatus,
+): boolean {
+  return RECON_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function assertReconciliationTransition(
+  from: MigrationReconciliationStatus,
+  to: MigrationReconciliationStatus,
+): void {
+  if (!canTransitionReconciliation(from, to)) {
+    throw new MigrationLifecycleError(`Invalid reconciliation transition: ${from} → ${to}`);
+  }
+}
+
+/** Import completion does not imply successful reconciliation. */
+export function isPackageLifecycleTerminal(status: MigrationPackageStatus): boolean {
+  return status === 'IMPORTED' || status === 'EXPIRED' || status === 'CANCELLED';
+}
+
+export function isReconciliationTerminal(status: MigrationReconciliationStatus): boolean {
+  return status === 'MATCHED';
+}
+
+/** Statuses subject to the 14-day unapproved expiry rule. */
+export function isExpiryEligibleStatus(status: MigrationPackageStatus): boolean {
+  return (
+    status === 'DRAFT' ||
+    status === 'VALIDATED' ||
+    status === 'VALIDATION_FAILED' ||
+    status === 'APPROVAL_INVALIDATED'
+  );
+}
+
+/** Material change after approval must move APPROVED → APPROVAL_INVALIDATED. */
+export function assertCanInvalidateApproval(status: MigrationPackageStatus): void {
+  assertPackageTransition(status, 'APPROVAL_INVALIDATED');
+}

--- a/lib/migration/limits.ts
+++ b/lib/migration/limits.ts
@@ -1,0 +1,66 @@
+/**
+ * Hard limits, expiry constants, and CSV export sanitisation.
+ *
+ * Provenance: adapted from historic lib/migration/limits.ts (0f6a917 / 995c96f).
+ */
+
+/** Unapproved packages expire 14 days after initial package creation. */
+export const MIGRATION_UNAPPROVED_EXPIRY_DAYS = 14;
+
+/** Retain protected source files for 90 days after terminal package status. */
+export const MIGRATION_FILE_RETENTION_DAYS = 90;
+
+export const MIGRATION_MAX_FILE_BYTES = 5 * 1024 * 1024; // 5 MiB
+export const MIGRATION_MAX_ROWS = 50_000;
+export const MIGRATION_MAX_EXCEPTIONS_RETAINED = 2_000;
+export const MIGRATION_MAX_JSON_CHARS = 500_000;
+/** Documented future import chunk size — not used by P0 execution. */
+export const MIGRATION_DEFAULT_CHUNK_SIZE = 200;
+
+export function computePackageExpiresAt(createdAt: Date): Date {
+  const expires = new Date(createdAt.getTime());
+  expires.setUTCDate(expires.getUTCDate() + MIGRATION_UNAPPROVED_EXPIRY_DAYS);
+  return expires;
+}
+
+export function truncateExceptionsForStorage<T extends { message: string }>(
+  exceptions: T[],
+): { retained: T[]; truncated: number } {
+  if (exceptions.length <= MIGRATION_MAX_EXCEPTIONS_RETAINED) {
+    return { retained: exceptions, truncated: 0 };
+  }
+  return {
+    retained: exceptions.slice(0, MIGRATION_MAX_EXCEPTIONS_RETAINED),
+    truncated: exceptions.length - MIGRATION_MAX_EXCEPTIONS_RETAINED,
+  };
+}
+
+export function clampJsonString(value: unknown): string {
+  const raw = JSON.stringify(value);
+  if (raw.length <= MIGRATION_MAX_JSON_CHARS) return raw;
+  return JSON.stringify({
+    truncated: true,
+    originalChars: raw.length,
+    note: 'Payload exceeded MIGRATION_MAX_JSON_CHARS and was replaced with this summary.',
+  });
+}
+
+/**
+ * Neutralise formula/CSV injection in downloaded exception / export cells.
+ * Does not mutate values stored for import identity.
+ */
+export function sanitizeCsvCell(value: string): string {
+  const s = String(value ?? '');
+  if (/^[=+\-@]/.test(s)) return `'${s}`;
+  return s;
+}
+
+/** Store only a safe basename — strip path segments and NULs. */
+export function sanitizeOriginalFilename(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const trimmed = String(raw).replace(/\u0000/g, '').trim();
+  if (!trimmed) return null;
+  const base = trimmed.split(/[/\\]/).pop() ?? trimmed;
+  const cleaned = base.replace(/[<>:"|?*\u0000-\u001f]/g, '_').slice(0, 255);
+  return cleaned || null;
+}

--- a/lib/migration/manifest.ts
+++ b/lib/migration/manifest.ts
@@ -1,0 +1,124 @@
+/**
+ * Canonical package manifest serialisation and checksum.
+ *
+ * Ordinary object property order is NOT used. Files and branch mappings are
+ * sorted deterministically before serialisation.
+ */
+
+import { sha256Hex } from '@/lib/migration/checksum';
+import { MigrationContractError } from '@/lib/migration/errors';
+import {
+  MIGRATION_ENTITY_TYPES,
+  type CanonicalBranchMapping,
+  type CanonicalFileIdentity,
+  type CanonicalPackageManifest,
+  type MigrationEntityType,
+} from '@/lib/migration/types';
+
+const ENTITY_ORDER = new Map<MigrationEntityType, number>(
+  MIGRATION_ENTITY_TYPES.map((t, i) => [t, i]),
+);
+
+function assertNonEmpty(value: string, field: string): string {
+  const v = value.trim();
+  if (!v) throw new MigrationContractError(`${field} is required for the package manifest.`);
+  return v;
+}
+
+function sortFiles(files: CanonicalFileIdentity[]): CanonicalFileIdentity[] {
+  return [...files].sort((a, b) => {
+    const ao = ENTITY_ORDER.get(a.entityType) ?? 99;
+    const bo = ENTITY_ORDER.get(b.entityType) ?? 99;
+    if (ao !== bo) return ao - bo;
+    return a.checksum.localeCompare(b.checksum);
+  });
+}
+
+function sortMappings(mappings: CanonicalBranchMapping[]): CanonicalBranchMapping[] {
+  return [...mappings].sort((a, b) => {
+    const k = a.sourceBranchKey.localeCompare(b.sourceBranchKey);
+    if (k !== 0) return k;
+    return a.targetStoreId.localeCompare(b.targetStoreId);
+  });
+}
+
+/**
+ * Build a canonical manifest. Callers must supply already-normalised keys and
+ * lowercase hex checksums. Filenames are intentionally excluded.
+ */
+export function buildCanonicalManifest(input: {
+  contractVersion: string;
+  sourceSystemKey: string;
+  sourceBusinessKey: string;
+  reportingCurrency: string;
+  packageAsOfDate: string;
+  files: CanonicalFileIdentity[];
+  branchMappings: CanonicalBranchMapping[];
+}): CanonicalPackageManifest {
+  const files = sortFiles(
+    input.files.map((f) => ({
+      entityType: f.entityType,
+      checksum: assertNonEmpty(f.checksum, 'file checksum').toLowerCase(),
+    })),
+  );
+  const branchMappings = sortMappings(
+    input.branchMappings.map((m) => ({
+      sourceBranchKey: assertNonEmpty(m.sourceBranchKey, 'sourceBranchKey'),
+      targetStoreId: assertNonEmpty(m.targetStoreId, 'targetStoreId'),
+    })),
+  );
+
+  return {
+    contractVersion: assertNonEmpty(input.contractVersion, 'contractVersion'),
+    sourceSystemKey: assertNonEmpty(input.sourceSystemKey, 'sourceSystemKey'),
+    sourceBusinessKey: assertNonEmpty(input.sourceBusinessKey, 'sourceBusinessKey'),
+    reportingCurrency: assertNonEmpty(input.reportingCurrency, 'reportingCurrency').toUpperCase(),
+    packageAsOfDate: assertNonEmpty(input.packageAsOfDate, 'packageAsOfDate'),
+    files,
+    branchMappings,
+  };
+}
+
+/**
+ * Deterministic JSON serialisation:
+ * - fixed top-level key order
+ * - files ordered by entity type then checksum
+ * - branch mappings ordered by sourceBranchKey then targetStoreId
+ * - no whitespace variance
+ */
+export function serializeCanonicalManifest(manifest: CanonicalPackageManifest): string {
+  const files = sortFiles(manifest.files).map((f) => ({
+    entityType: f.entityType,
+    checksum: f.checksum.toLowerCase(),
+  }));
+  const branchMappings = sortMappings(manifest.branchMappings).map((m) => ({
+    sourceBranchKey: m.sourceBranchKey,
+    targetStoreId: m.targetStoreId,
+  }));
+
+  // Explicit array construction — never Object.keys iteration order.
+  const payload = [
+    ['contractVersion', manifest.contractVersion],
+    ['sourceSystemKey', manifest.sourceSystemKey],
+    ['sourceBusinessKey', manifest.sourceBusinessKey],
+    ['reportingCurrency', manifest.reportingCurrency.toUpperCase()],
+    ['packageAsOfDate', manifest.packageAsOfDate],
+    ['files', files],
+    ['branchMappings', branchMappings],
+  ] as const;
+
+  return JSON.stringify(Object.fromEntries(payload));
+}
+
+export function manifestChecksum(input: Parameters<typeof buildCanonicalManifest>[0]): string {
+  const manifest = buildCanonicalManifest(input);
+  return sha256Hex(serializeCanonicalManifest(manifest));
+}
+
+/** True when two manifests produce the same checksum. */
+export function manifestsEqual(
+  a: Parameters<typeof buildCanonicalManifest>[0],
+  b: Parameters<typeof buildCanonicalManifest>[0],
+): boolean {
+  return manifestChecksum(a) === manifestChecksum(b);
+}

--- a/lib/migration/manifest.ts
+++ b/lib/migration/manifest.ts
@@ -7,6 +7,7 @@
 
 import { sha256Hex } from '@/lib/migration/checksum';
 import { MigrationContractError } from '@/lib/migration/errors';
+import { canonicaliseSourceBranchKey } from '@/lib/migration/source-branch-key';
 import {
   MIGRATION_ENTITY_TYPES,
   type CanonicalBranchMapping,
@@ -63,7 +64,9 @@ export function buildCanonicalManifest(input: {
   );
   const branchMappings = sortMappings(
     input.branchMappings.map((m) => ({
-      sourceBranchKey: assertNonEmpty(m.sourceBranchKey, 'sourceBranchKey'),
+      // Approval-material identity — same rule as tenant duplicate policy.
+      sourceBranchKey: canonicaliseSourceBranchKey(m.sourceBranchKey),
+      // Store ids are TillFlow identifiers; do not case-fold.
       targetStoreId: assertNonEmpty(m.targetStoreId, 'targetStoreId'),
     })),
   );

--- a/lib/migration/money.ts
+++ b/lib/migration/money.ts
@@ -1,0 +1,168 @@
+/**
+ * Strict decimal-currency → integer minor-unit parsing for migration CSVs.
+ *
+ * Prospects supply ordinary decimal notation (e.g. "12.50"). TillFlow stores
+ * integer minor units. Parsing normalisation is separate from file checksums.
+ */
+
+import { MigrationContractError } from '@/lib/migration/errors';
+
+/** Maximum absolute minor units accepted (fits signed 32-bit inventory/money paths safely under Number.MAX_SAFE_INTEGER). */
+export const MIGRATION_MAX_MINOR_UNITS = 9_000_000_000_000; // 90 billion major units * 100
+
+/**
+ * Parse a major-unit decimal currency string into integer minor units.
+ *
+ * Accepted:
+ * - "12", "12.5", "12.50"
+ * - optional leading +
+ * - optional thousands grouping with commas only when groups are exactly three digits
+ *
+ * Rejected:
+ * - blank / non-string
+ * - currency symbols or letters
+ * - scientific notation
+ * - more than 2 decimal places
+ * - malformed grouping
+ * - non-finite / overflow
+ */
+export function parseDecimalCurrencyToMinorUnits(raw: unknown, fieldLabel = 'amount'): number {
+  if (typeof raw !== 'string' && typeof raw !== 'number') {
+    throw new MigrationContractError(`${fieldLabel} must be a decimal currency value.`);
+  }
+  const original = String(raw).trim();
+  if (!original) {
+    throw new MigrationContractError(`${fieldLabel} is required.`);
+  }
+  if (/[eE]/.test(original)) {
+    throw new MigrationContractError(`${fieldLabel} must not use scientific notation.`);
+  }
+  if (/[^\d+.\-,]/.test(original)) {
+    throw new MigrationContractError(
+      `${fieldLabel} must be plain decimal digits (no currency symbols).`,
+    );
+  }
+
+  let signed = original;
+  let negative = false;
+  if (signed.startsWith('+')) signed = signed.slice(1);
+  if (signed.startsWith('-')) {
+    negative = true;
+    signed = signed.slice(1);
+  }
+  if (!signed || signed.startsWith('-') || signed.startsWith('+')) {
+    throw new MigrationContractError(`${fieldLabel} is malformed.`);
+  }
+
+  // Reject multiple dots.
+  if ((signed.match(/\./g) ?? []).length > 1) {
+    throw new MigrationContractError(`${fieldLabel} has too many decimal points.`);
+  }
+
+  const [intPartRaw, fracPartRaw] = signed.split('.');
+  if (fracPartRaw !== undefined && fracPartRaw.length > 2) {
+    throw new MigrationContractError(
+      `${fieldLabel} must have at most 2 decimal places (got ${fracPartRaw.length}).`,
+    );
+  }
+  if (fracPartRaw !== undefined && !/^\d{1,2}$/.test(fracPartRaw)) {
+    throw new MigrationContractError(`${fieldLabel} has an invalid fractional part.`);
+  }
+
+  const intPart = stripThousandsGrouping(intPartRaw, fieldLabel);
+  if (!/^\d+$/.test(intPart)) {
+    throw new MigrationContractError(`${fieldLabel} has an invalid integer part.`);
+  }
+
+  const frac = (fracPartRaw ?? '').padEnd(2, '0').slice(0, 2);
+  // Construct minor units without floating point.
+  const major = BigInt(intPart);
+  const minor = major * 100n + BigInt(frac || '0');
+  if (minor > BigInt(MIGRATION_MAX_MINOR_UNITS)) {
+    throw new MigrationContractError(`${fieldLabel} exceeds the maximum supported amount.`);
+  }
+  const asNumber = Number(minor);
+  if (!Number.isFinite(asNumber)) {
+    throw new MigrationContractError(`${fieldLabel} is not a finite number.`);
+  }
+  return negative ? -asNumber : asNumber;
+}
+
+function stripThousandsGrouping(intPartRaw: string, fieldLabel: string): string {
+  if (!intPartRaw.includes(',')) {
+    if (intPartRaw === '') {
+      throw new MigrationContractError(`${fieldLabel} is missing an integer part.`);
+    }
+    return intPartRaw;
+  }
+  const parts = intPartRaw.split(',');
+  if (parts[0] === '' || !/^\d{1,3}$/.test(parts[0]!)) {
+    throw new MigrationContractError(`${fieldLabel} has malformed thousands grouping.`);
+  }
+  for (let i = 1; i < parts.length; i += 1) {
+    if (!/^\d{3}$/.test(parts[i]!)) {
+      throw new MigrationContractError(`${fieldLabel} has malformed thousands grouping.`);
+    }
+  }
+  return parts.join('');
+}
+
+/**
+ * Authoritative stock value in minor units: quantity (base units) × unit cost (minor units).
+ * Uses integer arithmetic only. Zero quantity yields zero value.
+ */
+
+/** Opening-stock unit costs must be ≥ 0 after minor-unit conversion. */
+export function assertNonNegativeUnitCostMinor(unitCostMinor: number): void {
+  if (!Number.isInteger(unitCostMinor) || unitCostMinor < 0) {
+    throw new MigrationContractError('unitCost must not be negative.');
+  }
+}
+
+export function parseOpeningStockUnitCostToMinorUnits(raw: unknown): number {
+  const minor = parseDecimalCurrencyToMinorUnits(raw, 'unitCost');
+  assertNonNegativeUnitCostMinor(minor);
+  return minor;
+}
+
+export function calculateOpeningStockValueMinor(
+  quantityBase: number,
+  unitCostMinor: number,
+): number {
+  if (!Number.isInteger(quantityBase) || quantityBase < 0) {
+    throw new MigrationContractError('quantity must be a non-negative integer.');
+  }
+  assertNonNegativeUnitCostMinor(unitCostMinor);
+  const product = BigInt(quantityBase) * BigInt(unitCostMinor);
+  if (product > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new MigrationContractError('stock value overflows safe integer range.');
+  }
+  return Number(product);
+}
+
+/**
+ * Compare optional sourceStockValue control against calculated value.
+ * Phase 1 permitted tolerance: exact match after both sides are parsed to minor units.
+ */
+export function assertSourceStockValueMatches(input: {
+  quantityBase: number;
+  unitCostMinor: number;
+  sourceStockValueRaw: string | null | undefined;
+  fieldLabel?: string;
+}): number {
+  const calculated = calculateOpeningStockValueMinor(input.quantityBase, input.unitCostMinor);
+  if (input.sourceStockValueRaw == null || String(input.sourceStockValueRaw).trim() === '') {
+    return calculated;
+  }
+  const provided = parseDecimalCurrencyToMinorUnits(
+    String(input.sourceStockValueRaw),
+    input.fieldLabel ?? 'sourceStockValue',
+  );
+  if (provided !== calculated) {
+    throw new MigrationContractError(
+      `sourceStockValue (${provided}) does not match quantity × unitCost (${calculated}).`,
+      'STOCK_VALUE_MISMATCH',
+    );
+  }
+  return calculated;
+}

--- a/lib/migration/money.ts
+++ b/lib/migration/money.ts
@@ -3,6 +3,12 @@
  *
  * Prospects supply ordinary decimal notation (e.g. "12.50"). TillFlow stores
  * integer minor units. Parsing normalisation is separate from file checksums.
+ *
+ * CSV / file-boundary callers must pass string cell values. The `number`
+ * overload remains for internal numeric literals in tests and helpers; do not
+ * feed float-computed numbers from a spreadsheet path (float artefacts can
+ * appear as excessive fractional digits). A string-only public boundary may be
+ * introduced when P1 upload wiring lands.
  */
 
 import { MigrationContractError } from '@/lib/migration/errors';
@@ -17,14 +23,16 @@ export const MIGRATION_MAX_MINOR_UNITS = 9_000_000_000_000; // 90 billion major 
  * - "12", "12.5", "12.50"
  * - optional leading +
  * - optional thousands grouping with commas only when groups are exactly three digits
+ * - "0", "0.0", "0.00", "+0" → ordinary `0` (never JavaScript `-0`)
  *
  * Rejected:
- * - blank / non-string
+ * - blank / non-string-or-number
  * - currency symbols or letters
  * - scientific notation
  * - more than 2 decimal places
  * - malformed grouping
  * - non-finite / overflow
+ * - signed negative zero ("-0", "-0.0", "-0.00")
  */
 export function parseDecimalCurrencyToMinorUnits(raw: unknown, fieldLabel = 'amount'): number {
   if (typeof raw !== 'string' && typeof raw !== 'number') {
@@ -81,11 +89,19 @@ export function parseDecimalCurrencyToMinorUnits(raw: unknown, fieldLabel = 'amo
   if (minor > BigInt(MIGRATION_MAX_MINOR_UNITS)) {
     throw new MigrationContractError(`${fieldLabel} exceeds the maximum supported amount.`);
   }
+  // Reject textual signed zero before producing JavaScript -0.
+  if (negative && minor === 0n) {
+    throw new MigrationContractError(`${fieldLabel} must not be signed negative zero.`);
+  }
   const asNumber = Number(minor);
   if (!Number.isFinite(asNumber)) {
     throw new MigrationContractError(`${fieldLabel} is not a finite number.`);
   }
-  return negative ? -asNumber : asNumber;
+  const result = negative ? -asNumber : asNumber;
+  if (Object.is(result, -0)) {
+    throw new MigrationContractError(`${fieldLabel} must not be signed negative zero.`);
+  }
+  return result;
 }
 
 function stripThousandsGrouping(intPartRaw: string, fieldLabel: string): string {
@@ -114,7 +130,7 @@ function stripThousandsGrouping(intPartRaw: string, fieldLabel: string): string 
 
 /** Opening-stock unit costs must be ≥ 0 after minor-unit conversion. */
 export function assertNonNegativeUnitCostMinor(unitCostMinor: number): void {
-  if (!Number.isInteger(unitCostMinor) || unitCostMinor < 0) {
+  if (!Number.isInteger(unitCostMinor) || unitCostMinor < 0 || Object.is(unitCostMinor, -0)) {
     throw new MigrationContractError('unitCost must not be negative.');
   }
 }

--- a/lib/migration/roles-tenant.test.ts
+++ b/lib/migration/roles-tenant.test.ts
@@ -1,0 +1,123 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest';
+import {
+  assertCanAccessMigration,
+  assertCanApproveMigrationPackage,
+  assertAuthenticatedMigrationActor,
+  assertSameBusinessActor,
+  canAccessMigration,
+  canApproveMigrationPackage,
+  canUploadOrValidateMigration,
+} from '@/lib/migration/roles';
+import {
+  assertBranchMappingsResolved,
+  assertPackageHasExactlyThreePhase1Files,
+  assertPackageFileTenantMatch,
+  assertStoreBelongsToPackageBusiness,
+} from '@/lib/migration/tenant-policy';
+import { MigrationPolicyError } from '@/lib/migration/errors';
+import { sha256Hex } from '@/lib/migration/checksum';
+import {
+  isOpeningStockBlockedByExistingActivity,
+  mappedTargetMissingCode,
+  EXISTING_RECORD_POLICY,
+} from '@/lib/migration/existing-record-policy';
+
+describe('migration role policy', () => {
+  it('denies Cashier and unauthenticated actors', () => {
+    expect(canAccessMigration('CASHIER')).toBe(false);
+    expect(canApproveMigrationPackage('CASHIER')).toBe(false);
+    expect(() => assertCanAccessMigration('CASHIER')).toThrow(MigrationPolicyError);
+    expect(() =>
+      assertAuthenticatedMigrationActor({ userId: null, role: null }),
+    ).toThrow(/Authentication required/);
+  });
+
+  it('allows Manager upload/validate but denies Manager approval', () => {
+    expect(canAccessMigration('MANAGER')).toBe(true);
+    expect(canUploadOrValidateMigration('MANAGER')).toBe(true);
+    expect(canApproveMigrationPackage('MANAGER')).toBe(false);
+    expect(() => assertCanApproveMigrationPackage('MANAGER')).toThrow(/Only an Owner/);
+  });
+
+  it('allows Owner approval', () => {
+    expect(canApproveMigrationPackage('OWNER')).toBe(true);
+    expect(() => assertCanApproveMigrationPackage('OWNER')).not.toThrow();
+  });
+
+  it('denies cross-tenant actors at service-policy level', () => {
+    expect(() =>
+      assertSameBusinessActor({ actorBusinessId: 'biz_a', packageBusinessId: 'biz_b' }),
+    ).toThrow(/Cross-tenant/);
+  });
+});
+
+describe('migration tenant and branch constraints', () => {
+  it('rejects cross-business store mapping', () => {
+    expect(() =>
+      assertStoreBelongsToPackageBusiness({
+        packageBusinessId: 'biz_a',
+        storeBusinessId: 'biz_b',
+        sourceBranchKey: 'HQ',
+      }),
+    ).toThrow(/outside this business/);
+  });
+
+  it('rejects duplicate source branch mappings and unresolved keys', () => {
+    expect(() =>
+      assertBranchMappingsResolved({
+        packageBusinessId: 'biz_a',
+        mappings: [
+          { sourceBranchKey: 'HQ', targetStoreId: 's1', targetStoreBusinessId: 'biz_a' },
+          { sourceBranchKey: 'hq', targetStoreId: 's2', targetStoreBusinessId: 'biz_a' },
+        ],
+        requiredSourceBranchKeys: ['HQ'],
+      }),
+    ).toThrow(/Duplicate source branch/);
+
+    expect(() =>
+      assertBranchMappingsResolved({
+        packageBusinessId: 'biz_a',
+        mappings: [
+          { sourceBranchKey: 'HQ', targetStoreId: 's1', targetStoreBusinessId: 'biz_a' },
+        ],
+        requiredSourceBranchKeys: ['HQ', 'BRANCH-2'],
+      }),
+    ).toThrow(/no target store mapping/);
+  });
+
+  it('requires exactly three Phase 1 files and matching tenants', () => {
+    expect(() =>
+      assertPackageHasExactlyThreePhase1Files([
+        { entityType: 'SUPPLIERS', uploadChecksum: sha256Hex('a') },
+        { entityType: 'PRODUCTS', uploadChecksum: sha256Hex('b') },
+      ]),
+    ).toThrow(/missing required OPENING_STOCK/);
+
+    expect(() =>
+      assertPackageHasExactlyThreePhase1Files([
+        { entityType: 'SUPPLIERS', uploadChecksum: sha256Hex('a') },
+        { entityType: 'PRODUCTS', uploadChecksum: sha256Hex('b') },
+        { entityType: 'OPENING_STOCK', uploadChecksum: sha256Hex('c') },
+      ]),
+    ).not.toThrow();
+
+    expect(() =>
+      assertPackageFileTenantMatch({ packageBusinessId: 'biz_a', fileBusinessId: 'biz_b' }),
+    ).toThrow(/does not match/);
+  });
+});
+
+describe('existing-record safety policy', () => {
+  it('blocks opening stock when inventory or trading exists and forbids fuzzy matching', () => {
+    expect(EXISTING_RECORD_POLICY.fuzzyMatching).toBe(false);
+    expect(EXISTING_RECORD_POLICY.ownerOverrideForLiveStock).toBe(false);
+    expect(
+      isOpeningStockBlockedByExistingActivity({
+        hasInventoryBalance: true,
+        hasTradingActivity: false,
+      }),
+    ).toBe(true);
+    expect(mappedTargetMissingCode()).toBe('MAPPED_TARGET_MISSING');
+  });
+});

--- a/lib/migration/roles.ts
+++ b/lib/migration/roles.ts
@@ -1,0 +1,67 @@
+/**
+ * Locked Migration Framework role policy (P0).
+ *
+ * - Cashier: no migration access
+ * - Manager: may upload / inspect / validate (when wired in P1+)
+ * - Owner: final package approval
+ * - Execution: future server-side authorised action (not implemented in P0)
+ *
+ * No migration-admin role. No mandatory dual control in Phase 1.
+ */
+
+import type { Role } from '@/lib/auth';
+import { MigrationPolicyError } from '@/lib/migration/errors';
+
+export function canAccessMigration(role: Role | null | undefined): boolean {
+  return role === 'OWNER' || role === 'MANAGER';
+}
+
+export function canUploadOrValidateMigration(role: Role | null | undefined): boolean {
+  return role === 'OWNER' || role === 'MANAGER';
+}
+
+/** Final package approval is Owner-only. */
+export function canApproveMigrationPackage(role: Role | null | undefined): boolean {
+  return role === 'OWNER';
+}
+
+/** Import execution is not exposed in P0; policy is locked for future use. */
+export function canExecuteMigrationPackage(role: Role | null | undefined): boolean {
+  return role === 'OWNER';
+}
+
+export function assertAuthenticatedMigrationActor(input: {
+  userId: string | null | undefined;
+  role: Role | null | undefined;
+}): asserts input is { userId: string; role: Role } {
+  if (!input.userId || !input.role) {
+    throw new MigrationPolicyError('Authentication required for migration access.', 'UNAUTHENTICATED');
+  }
+}
+
+export function assertCanAccessMigration(role: Role | null | undefined): void {
+  if (!canAccessMigration(role)) {
+    throw new MigrationPolicyError('Migration access denied for this role.', 'ROLE_DENIED');
+  }
+}
+
+export function assertCanApproveMigrationPackage(role: Role | null | undefined): void {
+  if (!canApproveMigrationPackage(role)) {
+    throw new MigrationPolicyError(
+      'Only an Owner may approve a migration package.',
+      'APPROVAL_ROLE_DENIED',
+    );
+  }
+}
+
+export function assertSameBusinessActor(input: {
+  actorBusinessId: string;
+  packageBusinessId: string;
+}): void {
+  if (input.actorBusinessId !== input.packageBusinessId) {
+    throw new MigrationPolicyError(
+      'Cross-tenant migration access is denied.',
+      'CROSS_TENANT_DENIED',
+    );
+  }
+}

--- a/lib/migration/schema-contract.test.ts
+++ b/lib/migration/schema-contract.test.ts
@@ -1,0 +1,43 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  MIGRATION_CONTRACT_VERSION,
+  MIGRATION_ENTITY_TYPES,
+  MIGRATION_PACKAGE_STATUSES,
+  MIGRATION_RECONCILIATION_STATUSES,
+} from '@/lib/migration/types';
+
+describe('migration P0 schema contract', () => {
+  const sql = readFileSync(
+    join(process.cwd(), 'prisma/migrations/20260806130000_migration_framework_p0/migration.sql'),
+    'utf8',
+  );
+
+  it('locks contract version and Phase 1 entity set', () => {
+    expect(MIGRATION_CONTRACT_VERSION).toBe('1');
+    expect([...MIGRATION_ENTITY_TYPES]).toEqual(['SUPPLIERS', 'PRODUCTS', 'OPENING_STOCK']);
+  });
+
+  it('keeps package lifecycle and reconciliation statuses distinct', () => {
+    for (const status of MIGRATION_RECONCILIATION_STATUSES) {
+      expect(MIGRATION_PACKAGE_STATUSES).not.toContain(status as never);
+    }
+    expect(MIGRATION_PACKAGE_STATUSES).not.toContain('MATCHED' as never);
+    expect(MIGRATION_RECONCILIATION_STATUSES).toContain('MATCHED');
+  });
+
+  it('migration SQL creates package-oriented tables with tenant composite FKs', () => {
+    expect(sql).toContain('CREATE TABLE "MigrationPackage"');
+    expect(sql).toContain('CREATE TABLE "MigrationFile"');
+    expect(sql).toContain('CREATE TABLE "MigrationBranchMapping"');
+    expect(sql).toContain('MigrationFile_packageId_entityType_key');
+    expect(sql).toContain('MigrationBranchMapping_businessId_targetStoreId_fkey');
+    expect(sql).toContain('REFERENCES "Store"("businessId", "id")');
+    expect(sql).not.toContain('CREATE TABLE "MigrationBatch"');
+    expect(sql).not.toContain('CREATE TABLE "MigrationEntityMap"');
+    expect(sql).not.toContain('CREATE TABLE "MigrationChunkReceipt"');
+    expect(sql).not.toContain('CREATE TABLE "MigrationOpeningStockPosting"');
+  });
+});

--- a/lib/migration/schema-contract.test.ts
+++ b/lib/migration/schema-contract.test.ts
@@ -40,4 +40,9 @@ describe('migration P0 schema contract', () => {
     expect(sql).not.toContain('CREATE TABLE "MigrationChunkReceipt"');
     expect(sql).not.toContain('CREATE TABLE "MigrationOpeningStockPosting"');
   });
+
+  it('documents that uniqueness is at-most-one per entity type, not completeness', () => {
+    // Service-layer helpers still enforce exactly-three at validation/approval.
+    expect(MIGRATION_ENTITY_TYPES).toHaveLength(3);
+  });
 });

--- a/lib/migration/source-branch-key.test.ts
+++ b/lib/migration/source-branch-key.test.ts
@@ -1,0 +1,36 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest';
+import {
+  canonicaliseSourceBranchKey,
+  SOURCE_BRANCH_KEY_MAX_LENGTH,
+} from '@/lib/migration/source-branch-key';
+import { assertNoDuplicateSourceBranchKeys } from '@/lib/migration/tenant-policy';
+import { MigrationContractError } from '@/lib/migration/errors';
+import { MigrationPolicyError } from '@/lib/migration/errors';
+
+describe('canonicaliseSourceBranchKey', () => {
+  it('normalises case, whitespace, and NFC identically', () => {
+    expect(canonicaliseSourceBranchKey('HQ')).toBe('hq');
+    expect(canonicaliseSourceBranchKey('hq')).toBe('hq');
+    expect(canonicaliseSourceBranchKey('  HQ  ')).toBe('hq');
+    expect(canonicaliseSourceBranchKey('caf\u00e9')).toBe(canonicaliseSourceBranchKey('cafe\u0301'));
+  });
+
+  it('rejects empty, non-string, and overlong keys', () => {
+    expect(() => canonicaliseSourceBranchKey('')).toThrow(MigrationContractError);
+    expect(() => canonicaliseSourceBranchKey('   ')).toThrow(MigrationContractError);
+    expect(() => canonicaliseSourceBranchKey(1 as unknown as string)).toThrow(MigrationContractError);
+    expect(() =>
+      canonicaliseSourceBranchKey('x'.repeat(SOURCE_BRANCH_KEY_MAX_LENGTH + 1)),
+    ).toThrow(/at most/);
+  });
+
+  it('feeds the same identity into duplicate detection', () => {
+    expect(() =>
+      assertNoDuplicateSourceBranchKeys([
+        { sourceBranchKey: 'HQ' },
+        { sourceBranchKey: ' hq ' },
+      ]),
+    ).toThrow(MigrationPolicyError);
+  });
+});

--- a/lib/migration/source-branch-key.ts
+++ b/lib/migration/source-branch-key.ts
@@ -1,0 +1,39 @@
+/**
+ * Canonical source-branch-key identity for migration packages.
+ *
+ * Used by manifest checksums, duplicate detection, and tenant mapping policy so
+ * approval identity cannot drift from mapping uniqueness.
+ *
+ * Canonical rule (locked):
+ * 1. value must be a string
+ * 2. trim surrounding whitespace
+ * 3. Unicode NFC normalisation
+ * 4. locale-independent lowercase (`String.prototype.toLowerCase`)
+ * 5. reject empty result
+ * 6. enforce max length after trim/NFC (before case fold is equivalent for ASCII;
+ *    length is checked on the NFC-trimmed form before lowercasing so combining
+ *    characters are measured in their composed form)
+ *
+ * Target TillFlow `storeId` values are NOT canonicalised by this helper.
+ */
+
+import { MigrationContractError } from '@/lib/migration/errors';
+
+/** Matches Phase 1 opening-stock `sourceBranchKey` field max length. */
+export const SOURCE_BRANCH_KEY_MAX_LENGTH = 128;
+
+export function canonicaliseSourceBranchKey(raw: unknown): string {
+  if (typeof raw !== 'string') {
+    throw new MigrationContractError('sourceBranchKey must be a string.');
+  }
+  const trimmed = raw.trim().normalize('NFC');
+  if (!trimmed) {
+    throw new MigrationContractError('sourceBranchKey is required.');
+  }
+  if (trimmed.length > SOURCE_BRANCH_KEY_MAX_LENGTH) {
+    throw new MigrationContractError(
+      `sourceBranchKey must be at most ${SOURCE_BRANCH_KEY_MAX_LENGTH} characters.`,
+    );
+  }
+  return trimmed.toLowerCase();
+}

--- a/lib/migration/source-system-key.ts
+++ b/lib/migration/source-system-key.ts
@@ -1,0 +1,67 @@
+/**
+ * Stable source namespace for migration packages and future entity maps.
+ *
+ * Provenance: adapted from historic lib/migration/source-system-key.ts (0f6a917).
+ */
+
+import { MigrationContractError } from '@/lib/migration/errors';
+
+export const SOURCE_SYSTEM_KEY_MAX_LENGTH = 63;
+export const SOURCE_SYSTEM_KEY_PATTERN = /^[a-z0-9][a-z0-9_-]{1,62}$/;
+
+export const SOURCE_BUSINESS_KEY_MAX_LENGTH = 128;
+
+/**
+ * Format: lowercase ASCII; starts with alphanumeric; then [a-z0-9_-]; length 2–63.
+ * Absent key is rejected — there is no default namespace.
+ */
+export function normaliseSourceSystemKey(raw: unknown): string {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new MigrationContractError(
+      'sourceSystemKey is required (stable source namespace, e.g. legacy-pos-cutover).',
+    );
+  }
+  const key = raw.trim().toLowerCase();
+  if (key.length > SOURCE_SYSTEM_KEY_MAX_LENGTH) {
+    throw new MigrationContractError(
+      `sourceSystemKey must be at most ${SOURCE_SYSTEM_KEY_MAX_LENGTH} characters.`,
+    );
+  }
+  if (!SOURCE_SYSTEM_KEY_PATTERN.test(key)) {
+    throw new MigrationContractError(
+      'sourceSystemKey must be 2–63 chars: start with a letter or digit, then letters, digits, _ or -.',
+    );
+  }
+  return key;
+}
+
+/** Source business identity within the source system (not a TillFlow business id). */
+export function normaliseSourceBusinessKey(raw: unknown): string {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new MigrationContractError('sourceBusinessKey is required.');
+  }
+  const key = raw.trim().normalize('NFC');
+  if (key.length > SOURCE_BUSINESS_KEY_MAX_LENGTH) {
+    throw new MigrationContractError(
+      `sourceBusinessKey must be at most ${SOURCE_BUSINESS_KEY_MAX_LENGTH} characters.`,
+    );
+  }
+  if (/[\u0000-\u001f]/.test(key)) {
+    throw new MigrationContractError('sourceBusinessKey must not contain control characters.');
+  }
+  return key;
+}
+
+export function normaliseSourceKey(raw: unknown, fieldLabel: string, maxLength = 128): string {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new MigrationContractError(`${fieldLabel} is required.`);
+  }
+  const key = raw.trim().normalize('NFC');
+  if (key.length > maxLength) {
+    throw new MigrationContractError(`${fieldLabel} must be at most ${maxLength} characters.`);
+  }
+  if (/[\u0000-\u001f]/.test(key)) {
+    throw new MigrationContractError(`${fieldLabel} must not contain control characters.`);
+  }
+  return key;
+}

--- a/lib/migration/tenant-policy.ts
+++ b/lib/migration/tenant-policy.ts
@@ -1,0 +1,149 @@
+/**
+ * Pure tenant / branch mapping policy helpers.
+ *
+ * Database composite FKs enforce store∈business. These helpers cover service-layer
+ * checks that Prisma cannot express alone (unresolved mappings, package completeness).
+ */
+
+import { MigrationPolicyError } from '@/lib/migration/errors';
+import { MIGRATION_ENTITY_TYPES, type MigrationEntityType } from '@/lib/migration/types';
+
+export type BranchMappingInput = {
+  sourceBranchKey: string;
+  targetStoreId: string;
+  /** Business id of the target store (looked up server-side). */
+  targetStoreBusinessId: string;
+};
+
+export type PackageFilePresence = {
+  entityType: MigrationEntityType;
+  uploadChecksum: string;
+};
+
+export function assertStoreBelongsToPackageBusiness(input: {
+  packageBusinessId: string;
+  storeBusinessId: string;
+  sourceBranchKey: string;
+}): void {
+  if (input.packageBusinessId !== input.storeBusinessId) {
+    throw new MigrationPolicyError(
+      `Branch mapping for "${input.sourceBranchKey}" targets a store outside this business.`,
+      'CROSS_BUSINESS_STORE',
+    );
+  }
+}
+
+export function assertNoDuplicateSourceBranchKeys(
+  mappings: Array<{ sourceBranchKey: string }>,
+): void {
+  const seen = new Set<string>();
+  for (const m of mappings) {
+    const key = m.sourceBranchKey.trim().normalize('NFC').toLowerCase();
+    if (seen.has(key)) {
+      throw new MigrationPolicyError(
+        `Duplicate source branch key "${m.sourceBranchKey}".`,
+        'DUPLICATE_SOURCE_BRANCH',
+      );
+    }
+    seen.add(key);
+  }
+}
+
+export function assertNoDuplicateTargetStores(
+  mappings: Array<{ targetStoreId: string; sourceBranchKey: string }>,
+): void {
+  const seen = new Set<string>();
+  for (const m of mappings) {
+    if (seen.has(m.targetStoreId)) {
+      throw new MigrationPolicyError(
+        `Target store ${m.targetStoreId} is mapped more than once (source "${m.sourceBranchKey}").`,
+        'DUPLICATE_TARGET_STORE',
+      );
+    }
+    seen.add(m.targetStoreId);
+  }
+}
+
+export function assertBranchMappingsResolved(input: {
+  packageBusinessId: string;
+  mappings: BranchMappingInput[];
+  requiredSourceBranchKeys: string[];
+}): void {
+  if (input.mappings.length === 0 && input.requiredSourceBranchKeys.length > 0) {
+    throw new MigrationPolicyError(
+      'Branch mappings are required before validation/approval.',
+      'UNRESOLVED_BRANCH_MAPPING',
+    );
+  }
+
+  assertNoDuplicateSourceBranchKeys(input.mappings);
+  assertNoDuplicateTargetStores(input.mappings);
+
+  for (const m of input.mappings) {
+    assertStoreBelongsToPackageBusiness({
+      packageBusinessId: input.packageBusinessId,
+      storeBusinessId: m.targetStoreBusinessId,
+      sourceBranchKey: m.sourceBranchKey,
+    });
+  }
+
+  const mapped = new Set(
+    input.mappings.map((m) => m.sourceBranchKey.trim().normalize('NFC').toLowerCase()),
+  );
+  for (const required of input.requiredSourceBranchKeys) {
+    const key = required.trim().normalize('NFC').toLowerCase();
+    if (!mapped.has(key)) {
+      throw new MigrationPolicyError(
+        `Source branch "${required}" has no target store mapping.`,
+        'UNRESOLVED_BRANCH_MAPPING',
+      );
+    }
+  }
+}
+
+export function assertPackageHasExactlyThreePhase1Files(
+  files: PackageFilePresence[],
+): void {
+  const byType = new Map<string, PackageFilePresence>();
+  for (const f of files) {
+    if (byType.has(f.entityType)) {
+      throw new MigrationPolicyError(
+        `Package already has a ${f.entityType} file.`,
+        'DUPLICATE_ENTITY_FILE',
+      );
+    }
+    if (!f.uploadChecksum) {
+      throw new MigrationPolicyError(
+        `${f.entityType} file is missing an upload checksum.`,
+        'MISSING_FILE_CHECKSUM',
+      );
+    }
+    byType.set(f.entityType, f);
+  }
+  for (const required of MIGRATION_ENTITY_TYPES) {
+    if (!byType.has(required)) {
+      throw new MigrationPolicyError(
+        `Package is missing required ${required} file.`,
+        'MISSING_ENTITY_FILE',
+      );
+    }
+  }
+  if (files.length !== MIGRATION_ENTITY_TYPES.length) {
+    throw new MigrationPolicyError(
+      'Phase 1 packages must contain exactly three files.',
+      'INVALID_PACKAGE_FILE_COUNT',
+    );
+  }
+}
+
+export function assertPackageFileTenantMatch(input: {
+  packageBusinessId: string;
+  fileBusinessId: string;
+}): void {
+  if (input.packageBusinessId !== input.fileBusinessId) {
+    throw new MigrationPolicyError(
+      'Migration file businessId does not match its package.',
+      'PACKAGE_FILE_TENANT_MISMATCH',
+    );
+  }
+}

--- a/lib/migration/tenant-policy.ts
+++ b/lib/migration/tenant-policy.ts
@@ -6,6 +6,7 @@
  */
 
 import { MigrationPolicyError } from '@/lib/migration/errors';
+import { canonicaliseSourceBranchKey } from '@/lib/migration/source-branch-key';
 import { MIGRATION_ENTITY_TYPES, type MigrationEntityType } from '@/lib/migration/types';
 
 export type BranchMappingInput = {
@@ -38,7 +39,7 @@ export function assertNoDuplicateSourceBranchKeys(
 ): void {
   const seen = new Set<string>();
   for (const m of mappings) {
-    const key = m.sourceBranchKey.trim().normalize('NFC').toLowerCase();
+    const key = canonicaliseSourceBranchKey(m.sourceBranchKey);
     if (seen.has(key)) {
       throw new MigrationPolicyError(
         `Duplicate source branch key "${m.sourceBranchKey}".`,
@@ -87,11 +88,9 @@ export function assertBranchMappingsResolved(input: {
     });
   }
 
-  const mapped = new Set(
-    input.mappings.map((m) => m.sourceBranchKey.trim().normalize('NFC').toLowerCase()),
-  );
+  const mapped = new Set(input.mappings.map((m) => canonicaliseSourceBranchKey(m.sourceBranchKey)));
   for (const required of input.requiredSourceBranchKeys) {
-    const key = required.trim().normalize('NFC').toLowerCase();
+    const key = canonicaliseSourceBranchKey(required);
     if (!mapped.has(key)) {
       throw new MigrationPolicyError(
         `Source branch "${required}" has no target store mapping.`,

--- a/lib/migration/types.ts
+++ b/lib/migration/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Migration Framework P0 — shared types and locked Phase 1 constants.
+ *
+ * Provenance: adapted from historic lib/migration/types.ts (0f6a917) for the
+ * package-oriented model; statuses and entity names follow the P0 lock.
+ */
+
+export const MIGRATION_CONTRACT_VERSION = '1' as const;
+
+export const MIGRATION_ENTITY_TYPES = ['SUPPLIERS', 'PRODUCTS', 'OPENING_STOCK'] as const;
+export type MigrationEntityType = (typeof MIGRATION_ENTITY_TYPES)[number];
+
+export const MIGRATION_PACKAGE_STATUSES = [
+  'DRAFT',
+  'VALIDATED',
+  'APPROVED',
+  'IMPORTING',
+  'IMPORTED',
+  'VALIDATION_FAILED',
+  'APPROVAL_INVALIDATED',
+  'IMPORT_FAILED',
+  'EXPIRED',
+  'CANCELLED',
+] as const;
+export type MigrationPackageStatus = (typeof MIGRATION_PACKAGE_STATUSES)[number];
+
+export const MIGRATION_RECONCILIATION_STATUSES = [
+  'NOT_STARTED',
+  'RECONCILING',
+  'MATCHED',
+  'MISMATCHED',
+  'RECONCILIATION_FAILED',
+] as const;
+export type MigrationReconciliationStatus = (typeof MIGRATION_RECONCILIATION_STATUSES)[number];
+
+/** Fields prohibited in Phase 1 source files (extension points only). */
+export const PHASE1_PROHIBITED_FIELDS = [
+  'supplierBalance',
+  'supplier_balance',
+  'openingBalance',
+  'opening_balance',
+  'customerId',
+  'customer_id',
+  'debtorBalance',
+  'debtor_balance',
+  'loyaltyPoints',
+  'loyalty_points',
+  'salesHistory',
+  'purchaseHistory',
+  'cashBalance',
+  'momoBalance',
+  'shiftId',
+] as const;
+
+export function isMigrationEntityType(value: string): value is MigrationEntityType {
+  return (MIGRATION_ENTITY_TYPES as readonly string[]).includes(value);
+}
+
+export function isMigrationPackageStatus(value: string): value is MigrationPackageStatus {
+  return (MIGRATION_PACKAGE_STATUSES as readonly string[]).includes(value);
+}
+
+export function isMigrationReconciliationStatus(
+  value: string,
+): value is MigrationReconciliationStatus {
+  return (MIGRATION_RECONCILIATION_STATUSES as readonly string[]).includes(value);
+}
+
+export type MigrationFieldRequirement = 'required' | 'optional' | 'prohibited';
+
+export type MigrationFieldSpec = {
+  key: string;
+  label: string;
+  requirement: MigrationFieldRequirement;
+  validation: string;
+  normalisation?: string;
+  maxLength?: number;
+  failureSeverity: 'blocking' | 'warning';
+};
+
+export type CanonicalBranchMapping = {
+  sourceBranchKey: string;
+  targetStoreId: string;
+};
+
+export type CanonicalFileIdentity = {
+  entityType: MigrationEntityType;
+  /** SHA-256 hex of exact file bytes. */
+  checksum: string;
+};
+
+export type CanonicalPackageManifest = {
+  contractVersion: string;
+  sourceSystemKey: string;
+  sourceBusinessKey: string;
+  reportingCurrency: string;
+  packageAsOfDate: string;
+  files: CanonicalFileIdentity[];
+  branchMappings: CanonicalBranchMapping[];
+};

--- a/prisma/migrations/20260806130000_migration_framework_p0/migration.sql
+++ b/prisma/migrations/20260806130000_migration_framework_p0/migration.sql
@@ -1,0 +1,170 @@
+-- Migration Framework P0: package-oriented foundation.
+-- NOT applied to Preview or Production by this PR authorisation.
+-- Adds MigrationPackage, MigrationFile, MigrationBranchMapping and tenant-safe Store uniqueness.
+
+-- Tenant-aware composite uniqueness for Store (enables composite FKs from branch mappings).
+CREATE UNIQUE INDEX "Store_businessId_id_key" ON "Store"("businessId", "id");
+
+-- CreateTable
+CREATE TABLE "MigrationPackage" (
+    "id" TEXT NOT NULL,
+    "businessId" TEXT NOT NULL,
+    "contractVersion" TEXT NOT NULL,
+    "sourceSystemKey" TEXT NOT NULL,
+    "sourceBusinessKey" TEXT NOT NULL,
+    "reportingCurrency" TEXT NOT NULL,
+    "packageAsOfDate" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "reconciliationStatus" TEXT NOT NULL DEFAULT 'NOT_STARTED',
+    "clientPackageKey" TEXT,
+    "manifestChecksum" TEXT,
+    "approvedManifestChecksum" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "expiredAt" TIMESTAMP(3),
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdByUserId" TEXT,
+    "validatedByUserId" TEXT,
+    "validatedAt" TIMESTAMP(3),
+    "approvedByUserId" TEXT,
+    "approvedAt" TIMESTAMP(3),
+    "executedByUserId" TEXT,
+    "executedAt" TIMESTAMP(3),
+    "cancelledByUserId" TEXT,
+    "cancelledAt" TIMESTAMP(3),
+    "errorMessage" TEXT,
+    "summaryJson" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MigrationPackage_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "MigrationPackage_status_check" CHECK (
+      "status" IN (
+        'DRAFT',
+        'VALIDATED',
+        'APPROVED',
+        'IMPORTING',
+        'IMPORTED',
+        'VALIDATION_FAILED',
+        'APPROVAL_INVALIDATED',
+        'IMPORT_FAILED',
+        'EXPIRED',
+        'CANCELLED'
+      )
+    ),
+    CONSTRAINT "MigrationPackage_reconciliationStatus_check" CHECK (
+      "reconciliationStatus" IN (
+        'NOT_STARTED',
+        'RECONCILING',
+        'MATCHED',
+        'MISMATCHED',
+        'RECONCILIATION_FAILED'
+      )
+    )
+);
+
+-- CreateTable
+CREATE TABLE "MigrationFile" (
+    "id" TEXT NOT NULL,
+    "businessId" TEXT NOT NULL,
+    "packageId" TEXT NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "originalFilename" TEXT,
+    "contentType" TEXT,
+    "byteLength" INTEGER NOT NULL DEFAULT 0,
+    "uploadChecksum" TEXT NOT NULL,
+    "validationChecksum" TEXT,
+    "approvedChecksum" TEXT,
+    "storageKey" TEXT,
+    "rowCount" INTEGER,
+    "validatedAt" TIMESTAMP(3),
+    "approvedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MigrationFile_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "MigrationFile_entityType_check" CHECK (
+      "entityType" IN ('SUPPLIERS', 'PRODUCTS', 'OPENING_STOCK')
+    )
+);
+
+-- CreateTable
+CREATE TABLE "MigrationBranchMapping" (
+    "id" TEXT NOT NULL,
+    "businessId" TEXT NOT NULL,
+    "packageId" TEXT NOT NULL,
+    "sourceBranchKey" TEXT NOT NULL,
+    "targetStoreId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MigrationBranchMapping_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MigrationPackage_businessId_id_key" ON "MigrationPackage"("businessId", "id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MigrationPackage_businessId_clientPackageKey_key" ON "MigrationPackage"("businessId", "clientPackageKey");
+
+-- CreateIndex
+CREATE INDEX "MigrationPackage_businessId_status_createdAt_idx" ON "MigrationPackage"("businessId", "status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MigrationPackage_businessId_status_expiresAt_idx" ON "MigrationPackage"("businessId", "status", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "MigrationPackage_businessId_sourceSystemKey_sourceBusinessKey_idx" ON "MigrationPackage"("businessId", "sourceSystemKey", "sourceBusinessKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MigrationFile_businessId_id_key" ON "MigrationFile"("businessId", "id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MigrationFile_packageId_entityType_key" ON "MigrationFile"("packageId", "entityType");
+
+-- CreateIndex
+CREATE INDEX "MigrationFile_businessId_packageId_idx" ON "MigrationFile"("businessId", "packageId");
+
+-- CreateIndex
+CREATE INDEX "MigrationFile_businessId_uploadChecksum_idx" ON "MigrationFile"("businessId", "uploadChecksum");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MigrationBranchMapping_businessId_id_key" ON "MigrationBranchMapping"("businessId", "id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MigrationBranchMapping_packageId_sourceBranchKey_key" ON "MigrationBranchMapping"("packageId", "sourceBranchKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MigrationBranchMapping_packageId_targetStoreId_key" ON "MigrationBranchMapping"("packageId", "targetStoreId");
+
+-- CreateIndex
+CREATE INDEX "MigrationBranchMapping_businessId_packageId_idx" ON "MigrationBranchMapping"("businessId", "packageId");
+
+-- CreateIndex
+CREATE INDEX "MigrationBranchMapping_businessId_targetStoreId_idx" ON "MigrationBranchMapping"("businessId", "targetStoreId");
+
+-- AddForeignKey
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_businessId_fkey" FOREIGN KEY ("businessId") REFERENCES "Business"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_validatedByUserId_fkey" FOREIGN KEY ("validatedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_approvedByUserId_fkey" FOREIGN KEY ("approvedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_executedByUserId_fkey" FOREIGN KEY ("executedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_cancelledByUserId_fkey" FOREIGN KEY ("cancelledByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey — tenant-scoped package membership for files
+ALTER TABLE "MigrationFile" ADD CONSTRAINT "MigrationFile_businessId_packageId_fkey" FOREIGN KEY ("businessId", "packageId") REFERENCES "MigrationPackage"("businessId", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey — tenant-scoped package membership for branch mappings
+ALTER TABLE "MigrationBranchMapping" ADD CONSTRAINT "MigrationBranchMapping_businessId_packageId_fkey" FOREIGN KEY ("businessId", "packageId") REFERENCES "MigrationPackage"("businessId", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey — store must belong to the same business (composite)
+ALTER TABLE "MigrationBranchMapping" ADD CONSTRAINT "MigrationBranchMapping_businessId_targetStoreId_fkey" FOREIGN KEY ("businessId", "targetStoreId") REFERENCES "Store"("businessId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -787,6 +787,7 @@ model MigrationPackage {
 }
 
 /// One immutable logical file belonging to a MigrationPackage.
+/// UNIQUE(packageId, entityType) = at most one of each type (not exactly-three completeness).
 model MigrationFile {
   id                 String    @id @default(cuid())
   businessId         String

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -177,6 +177,7 @@ model Business {
   categories             Category[]
   products               Product[]
   productImports         ProductImport[]
+  migrationPackages      MigrationPackage[]
   accounts               Account[]
   journalEntries         JournalEntry[]
   expenses               Expense[]
@@ -419,7 +420,10 @@ model Store {
   transfersIn            StockTransfer[]         @relation("StockTransferToStore")
   reorderActions         ReorderAction[]
   paymentReconciliations PaymentReconciliation[]
+  migrationBranchMappings MigrationBranchMapping[]
 
+  /// Tenant-aware composite target for migration branch mappings.
+  @@unique([businessId, id])
   @@index([businessId])
 }
 
@@ -523,6 +527,11 @@ model User {
   passwordResetTokens        PasswordResetToken[]
   reconciledPayments         PaymentReconciliation[] @relation("PaymentReconciledBy")
   productImports             ProductImport[]
+  migrationPackagesCreated   MigrationPackage[]      @relation("MigrationPackageCreatedBy")
+  migrationPackagesValidated MigrationPackage[]      @relation("MigrationPackageValidatedBy")
+  migrationPackagesApproved  MigrationPackage[]      @relation("MigrationPackageApprovedBy")
+  migrationPackagesExecuted  MigrationPackage[]      @relation("MigrationPackageExecutedBy")
+  migrationPackagesCancelled MigrationPackage[]      @relation("MigrationPackageCancelledBy")
 
   @@index([businessId, active])
 }
@@ -714,6 +723,121 @@ model ProductImport {
   uploadedBy User?    @relation(fields: [uploadedByUserId], references: [id])
 
   @@index([businessId, createdAt])
+}
+
+/// Atomic Phase 1 migration package (suppliers + products + opening stock).
+/// Lifecycle status is separate from reconciliationStatus. Strings are CHECK-constrained in SQL.
+model MigrationPackage {
+  id                       String    @id @default(cuid())
+  businessId               String
+  /// TillFlow migration contract version (e.g. "1").
+  contractVersion          String
+  /// Stable normalized source namespace (immutable after create).
+  sourceSystemKey          String
+  /// Source-system business identity (not a TillFlow business id).
+  sourceBusinessKey        String
+  /// ISO 4217 reporting currency for package money fields.
+  reportingCurrency        String
+  /// Package as-of date (YYYY-MM-DD calendar date).
+  packageAsOfDate          String
+  /// DRAFT | VALIDATED | APPROVED | IMPORTING | IMPORTED | VALIDATION_FAILED |
+  /// APPROVAL_INVALIDATED | IMPORT_FAILED | EXPIRED | CANCELLED
+  status                   String    @default("DRAFT")
+  /// NOT_STARTED | RECONCILING | MATCHED | MISMATCHED | RECONCILIATION_FAILED
+  reconciliationStatus     String    @default("NOT_STARTED")
+  /// Optional client key for idempotent package create within a business.
+  clientPackageKey         String?
+  /// Canonical SHA-256 of the approved/validatable package manifest.
+  manifestChecksum         String?
+  /// Manifest checksum frozen at Owner approval.
+  approvedManifestChecksum String?
+  /// Expiry clock starts at package creation; not restarted by file replacement.
+  expiresAt                DateTime
+  expiredAt                DateTime?
+  version                  Int       @default(1)
+  createdByUserId          String?
+  validatedByUserId        String?
+  validatedAt              DateTime?
+  approvedByUserId         String?
+  approvedAt               DateTime?
+  /// Future executor — unused in P0.
+  executedByUserId         String?
+  executedAt               DateTime?
+  cancelledByUserId        String?
+  cancelledAt              DateTime?
+  errorMessage             String?
+  summaryJson              String?
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt
+
+  business    Business                  @relation(fields: [businessId], references: [id], onDelete: Cascade)
+  createdBy   User?                     @relation("MigrationPackageCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
+  validatedBy User?                     @relation("MigrationPackageValidatedBy", fields: [validatedByUserId], references: [id], onDelete: SetNull)
+  approvedBy  User?                     @relation("MigrationPackageApprovedBy", fields: [approvedByUserId], references: [id], onDelete: SetNull)
+  executedBy  User?                     @relation("MigrationPackageExecutedBy", fields: [executedByUserId], references: [id], onDelete: SetNull)
+  cancelledBy User?                     @relation("MigrationPackageCancelledBy", fields: [cancelledByUserId], references: [id], onDelete: SetNull)
+  files          MigrationFile[]
+  branchMappings MigrationBranchMapping[]
+
+  @@unique([businessId, id])
+  @@unique([businessId, clientPackageKey])
+  @@index([businessId, status, createdAt])
+  @@index([businessId, status, expiresAt])
+  @@index([businessId, sourceSystemKey, sourceBusinessKey])
+}
+
+/// One immutable logical file belonging to a MigrationPackage.
+model MigrationFile {
+  id                 String    @id @default(cuid())
+  businessId         String
+  packageId          String
+  /// SUPPLIERS | PRODUCTS | OPENING_STOCK
+  entityType         String
+  /// Original filename stored safely (basename only; no path separators).
+  originalFilename   String?
+  contentType        String?
+  byteLength         Int       @default(0)
+  /// SHA-256 hex of exact uploaded bytes.
+  uploadChecksum     String
+  /// SHA-256 of bytes presented at validation (must match upload for approval).
+  validationChecksum String?
+  /// SHA-256 frozen at package approval for this file.
+  approvedChecksum   String?
+  /// Future blob/object storage key — unused in P0 upload endpoints.
+  storageKey         String?
+  rowCount           Int?
+  validatedAt        DateTime?
+  approvedAt         DateTime?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+
+  package MigrationPackage @relation(fields: [businessId, packageId], references: [businessId, id], onDelete: Cascade)
+
+  @@unique([businessId, id])
+  @@unique([packageId, entityType])
+  @@index([businessId, packageId])
+  @@index([businessId, uploadChecksum])
+}
+
+/// Maps a source branch key to a TillFlow Store in the same business.
+model MigrationBranchMapping {
+  id              String   @id @default(cuid())
+  businessId      String
+  packageId       String
+  sourceBranchKey String
+  targetStoreId   String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  package MigrationPackage @relation(fields: [businessId, packageId], references: [businessId, id], onDelete: Cascade)
+  /// Composite FK guarantees the store belongs to the same business.
+  store   Store            @relation(fields: [businessId, targetStoreId], references: [businessId, id], onDelete: Restrict)
+
+  @@unique([businessId, id])
+  @@unique([packageId, sourceBranchKey])
+  @@unique([packageId, targetStoreId])
+  @@index([businessId, packageId])
+  @@index([businessId, targetStoreId])
 }
 
 model Unit {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,6 +179,7 @@ model Business {
   categories             Category[]
   products               Product[]
   productImports         ProductImport[]
+  migrationPackages      MigrationPackage[]
   accounts               Account[]
   journalEntries         JournalEntry[]
   expenses               Expense[]
@@ -420,7 +421,10 @@ model Store {
   transfersIn            StockTransfer[]         @relation("StockTransferToStore")
   reorderActions             ReorderAction[]
   paymentReconciliations     PaymentReconciliation[]
+  migrationBranchMappings    MigrationBranchMapping[]
 
+  /// Tenant-aware composite target for migration branch mappings.
+  @@unique([businessId, id])
   @@index([businessId])
 }
 
@@ -524,6 +528,11 @@ model User {
   purchasePaymentsRecorded   PurchasePayment[]       @relation("PurchasePaymentRecordedBy")
   passwordResetTokens        PasswordResetToken[]
   reconciledPayments         PaymentReconciliation[] @relation("PaymentReconciledBy")
+  migrationPackagesCreated   MigrationPackage[]      @relation("MigrationPackageCreatedBy")
+  migrationPackagesValidated MigrationPackage[]      @relation("MigrationPackageValidatedBy")
+  migrationPackagesApproved  MigrationPackage[]      @relation("MigrationPackageApprovedBy")
+  migrationPackagesExecuted  MigrationPackage[]      @relation("MigrationPackageExecutedBy")
+  migrationPackagesCancelled MigrationPackage[]      @relation("MigrationPackageCancelledBy")
 
   @@index([businessId, active])
 }
@@ -709,6 +718,121 @@ model ProductImport {
   uploadedBy User?    @relation(fields: [uploadedByUserId], references: [id])
 
   @@index([businessId, createdAt])
+}
+
+/// Atomic Phase 1 migration package (suppliers + products + opening stock).
+/// Lifecycle status is separate from reconciliationStatus. Strings are CHECK-constrained in SQL.
+model MigrationPackage {
+  id                       String    @id @default(cuid())
+  businessId               String
+  /// TillFlow migration contract version (e.g. "1").
+  contractVersion          String
+  /// Stable normalized source namespace (immutable after create).
+  sourceSystemKey          String
+  /// Source-system business identity (not a TillFlow business id).
+  sourceBusinessKey        String
+  /// ISO 4217 reporting currency for package money fields.
+  reportingCurrency        String
+  /// Package as-of date (YYYY-MM-DD calendar date).
+  packageAsOfDate          String
+  /// DRAFT | VALIDATED | APPROVED | IMPORTING | IMPORTED | VALIDATION_FAILED |
+  /// APPROVAL_INVALIDATED | IMPORT_FAILED | EXPIRED | CANCELLED
+  status                   String    @default("DRAFT")
+  /// NOT_STARTED | RECONCILING | MATCHED | MISMATCHED | RECONCILIATION_FAILED
+  reconciliationStatus     String    @default("NOT_STARTED")
+  /// Optional client key for idempotent package create within a business.
+  clientPackageKey         String?
+  /// Canonical SHA-256 of the approved/validatable package manifest.
+  manifestChecksum         String?
+  /// Manifest checksum frozen at Owner approval.
+  approvedManifestChecksum String?
+  /// Expiry clock starts at package creation; not restarted by file replacement.
+  expiresAt                DateTime
+  expiredAt                DateTime?
+  version                  Int       @default(1)
+  createdByUserId          String?
+  validatedByUserId        String?
+  validatedAt              DateTime?
+  approvedByUserId         String?
+  approvedAt               DateTime?
+  /// Future executor — unused in P0.
+  executedByUserId         String?
+  executedAt               DateTime?
+  cancelledByUserId        String?
+  cancelledAt              DateTime?
+  errorMessage             String?
+  summaryJson              String?
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt
+
+  business    Business                  @relation(fields: [businessId], references: [id], onDelete: Cascade)
+  createdBy   User?                     @relation("MigrationPackageCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
+  validatedBy User?                     @relation("MigrationPackageValidatedBy", fields: [validatedByUserId], references: [id], onDelete: SetNull)
+  approvedBy  User?                     @relation("MigrationPackageApprovedBy", fields: [approvedByUserId], references: [id], onDelete: SetNull)
+  executedBy  User?                     @relation("MigrationPackageExecutedBy", fields: [executedByUserId], references: [id], onDelete: SetNull)
+  cancelledBy User?                     @relation("MigrationPackageCancelledBy", fields: [cancelledByUserId], references: [id], onDelete: SetNull)
+  files          MigrationFile[]
+  branchMappings MigrationBranchMapping[]
+
+  @@unique([businessId, id])
+  @@unique([businessId, clientPackageKey])
+  @@index([businessId, status, createdAt])
+  @@index([businessId, status, expiresAt])
+  @@index([businessId, sourceSystemKey, sourceBusinessKey])
+}
+
+/// One immutable logical file belonging to a MigrationPackage.
+model MigrationFile {
+  id                 String    @id @default(cuid())
+  businessId         String
+  packageId          String
+  /// SUPPLIERS | PRODUCTS | OPENING_STOCK
+  entityType         String
+  /// Original filename stored safely (basename only; no path separators).
+  originalFilename   String?
+  contentType        String?
+  byteLength         Int       @default(0)
+  /// SHA-256 hex of exact uploaded bytes.
+  uploadChecksum     String
+  /// SHA-256 of bytes presented at validation (must match upload for approval).
+  validationChecksum String?
+  /// SHA-256 frozen at package approval for this file.
+  approvedChecksum   String?
+  /// Future blob/object storage key — unused in P0 upload endpoints.
+  storageKey         String?
+  rowCount           Int?
+  validatedAt        DateTime?
+  approvedAt         DateTime?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+
+  package MigrationPackage @relation(fields: [businessId, packageId], references: [businessId, id], onDelete: Cascade)
+
+  @@unique([businessId, id])
+  @@unique([packageId, entityType])
+  @@index([businessId, packageId])
+  @@index([businessId, uploadChecksum])
+}
+
+/// Maps a source branch key to a TillFlow Store in the same business.
+model MigrationBranchMapping {
+  id              String   @id @default(cuid())
+  businessId      String
+  packageId       String
+  sourceBranchKey String
+  targetStoreId   String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  package MigrationPackage @relation(fields: [businessId, packageId], references: [businessId, id], onDelete: Cascade)
+  /// Composite FK guarantees the store belongs to the same business.
+  store   Store            @relation(fields: [businessId, targetStoreId], references: [businessId, id], onDelete: Restrict)
+
+  @@unique([businessId, id])
+  @@unique([packageId, sourceBranchKey])
+  @@unique([packageId, targetStoreId])
+  @@index([businessId, packageId])
+  @@index([businessId, targetStoreId])
 }
 
 model Unit {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -782,6 +782,7 @@ model MigrationPackage {
 }
 
 /// One immutable logical file belonging to a MigrationPackage.
+/// UNIQUE(packageId, entityType) = at most one of each type (not exactly-three completeness).
 model MigrationFile {
   id                 String    @id @default(cuid())
   businessId         String

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -9,11 +9,14 @@ vi.mock('react', async () => {
     };
 });
 
-// Mock navigator.onLine
-Object.defineProperty(navigator, 'onLine', {
-    writable: true,
-    value: true
-});
+// Mock navigator.onLine only when a browser-like global exists (jsdom).
+// Node-environment suites (e.g. lib/migration) must not crash on setup.
+if (typeof navigator !== 'undefined') {
+    Object.defineProperty(navigator, 'onLine', {
+        writable: true,
+        value: true,
+    });
+}
 
 // Mock indexedDB for tests
 const mockIDB = {


### PR DESCRIPTION
## Scope

P0 foundation for the Production-grade Migration Framework:

- package-oriented schema (`MigrationPackage`, `MigrationFile`, `MigrationBranchMapping`)
- exactly three permitted Phase 1 file entity types (`SUPPLIERS`, `PRODUCTS`, `OPENING_STOCK`)
- branch mappings with composite tenant/store foreign keys
- lifecycle and reconciliation status separation
- source-neutral contract v1
- decimal-money → integer minor-unit handling
- file SHA-256 and canonical package manifest checksums
- approval invalidation rules
- tenant/role policy helpers (Cashier denied; Owner-only approval)
- expiry and retention foundations (14-day unapproved expiry; 90-day file retention guidance)
- unit tests and technical documentation

Commit under review: `12144e0f26c1ad175a05b1e09153339f9b77194a`  
Baseline: `origin/master` @ `baadf1052a06dc8da3603a22b766c79c4b53406c`

## Explicit exclusions

This PR does **not** include:

- upload endpoints or UI
- package assembly workflow
- executable validation workflow
- approval actions or UI
- supplier/product import
- opening-stock or accounting posting
- chunk processing
- reconciliation execution
- Preview/Production Prisma migrate apply
- deployment
- shared data changes

## Verification (local)

| Gate | Result |
|---|---|
| Migration unit tests | **32/32 passed** |
| Full unit suite | **2,095 passed**, 8 skipped |
| POS safety | **131/131 passed** |
| Lint | **0 errors**, 3 pre-existing warnings |
| Typecheck | **passed** |
| Prisma validation | **passed** (local Prisma 5 + dummy env URLs) |
| Build | **Not passed locally** — blocked by dummy PostgreSQL credentials during `/shop/sitemap.xml` prerender |

The build failure is classified as an **environment limitation** pending CI confirmation. It must not be described as passed.

## Review focus

Please concentrate on:

1. Migration SQL and composite foreign keys (`MigrationFile`/`MigrationBranchMapping` → package; branch mapping → `Store(businessId, id)`)
2. Lifecycle transitions (fail-closed)
3. Reconciliation status separation from import lifecycle
4. Three-file completeness: `@@unique([packageId, entityType])` proves at-most-one-of-each, **not** exactly-three — service-layer invariant required at validation/approval
5. Manifest canonicalisation and approval materiality (filenames intentionally excluded)
6. Approval invalidation rules
7. Decimal parsing and opening-stock value arithmetic (integer-only; exact `sourceStockValue` match)
8. Actor and tenant authorisation (composite store FKs vs non-composite actor User FKs)
9. Expiry semantics (`expiresAt` immutable on file replace)
10. Cascade / SetNull behaviour
11. Parity between `schema.prisma` and `schema.postgres.prisma`

## Notes for reviewers

- `MigrationEntityMap`, chunk receipts, opening-stock posting claims, and exception tables are intentionally deferred (documented in `docs/migration/P0_FUTURE_MODELS.md`).
- No Preview/Production schema or data was changed by this work.
- Do not merge or deploy under this PR’s authorisation without a separate gate.