### PR TITLE
feat(migration): P1 Slice 1 schema foundation

### DIFF
--- a/.github/workflows/postgres-smoke.yml
+++ b/.github/workflows/postgres-smoke.yml
@@ -8,6 +8,8 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'scripts/migration-p1-schema-pg-test.cjs'
+      - 'scripts/migration-p1-sql-only-constraint-contract.cjs'
+      - 'docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md'
       - 'lib/migration/**'
       - '.github/workflows/postgres-smoke.yml'
 
@@ -51,11 +53,14 @@ jobs:
       - name: Generate Postgres Prisma client
         run: npx prisma generate --schema=prisma/schema.postgres.prisma
 
-      - name: Deploy migrations
+      - name: Deploy complete migration history
         run: npx prisma migrate deploy --schema=prisma/schema.postgres.prisma
 
       - name: Check migration status
         run: npx prisma migrate status --schema=prisma/schema.postgres.prisma
 
-      - name: Migration P1 schema PostgreSQL constraint tests
+      - name: Migration P1 PostgreSQL behavioural suite
         run: node scripts/migration-p1-schema-pg-test.cjs
+
+      - name: SQL-only constraint-contract introspection
+        run: node scripts/migration-p1-sql-only-constraint-contract.cjs

--- a/.github/workflows/postgres-smoke.yml
+++ b/.github/workflows/postgres-smoke.yml
@@ -7,6 +7,8 @@ on:
       - 'prisma/**'
       - 'package.json'
       - 'package-lock.json'
+      - 'scripts/migration-p1-schema-pg-test.cjs'
+      - 'lib/migration/**'
       - '.github/workflows/postgres-smoke.yml'
 
 permissions:
@@ -54,3 +56,6 @@ jobs:
 
       - name: Check migration status
         run: npx prisma migrate status --schema=prisma/schema.postgres.prisma
+
+      - name: Migration P1 schema PostgreSQL constraint tests
+        run: node scripts/migration-p1-schema-pg-test.cjs

--- a/.github/workflows/postgres-smoke.yml
+++ b/.github/workflows/postgres-smoke.yml
@@ -19,7 +19,10 @@ permissions:
 jobs:
   migrate-status:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Job timeout covers queue wait for a hosted runner plus execution.
+    # Prior workflow_dispatch attempts cancelled at ~15m with runner_id=0 / steps=[]
+    # (0 billable ms) — no test failure; the previous 15m budget expired while queued.
+    timeout-minutes: 45
     services:
       postgres:
         image: postgres:16

--- a/docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md
+++ b/docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md
@@ -1,0 +1,71 @@
+# P1 Slice 1 — intentional SQL-only constraints
+
+**Status:** Locked for Migration Framework P1 Slice 1  
+**Applies after:** `20260806170000_migration_framework_p1_slice1_schema`  
+**Ownership correction:** `20260806183000_migration_p1_slice1_latest_run_ownership`
+
+## Why SQL-only exists
+
+Prisma cannot express **optional composite foreign keys** that share a required
+scalar (for example `businessId`) already used by another required relation.
+P1 therefore keeps:
+
+- the strongest representable Prisma relations (single-column `RESTRICT`, or
+  required composites such as `createdBy` / approval `approver`); and
+- additional **SQL-only** composite foreign keys for tenant and package
+  ownership that Prisma schema-diff does not model.
+
+These SQL-only constraints are **intentional**. A Prisma-generated migration
+that proposes dropping them must **not** be accepted. Any legitimate replacement
+must update, together:
+
+1. the database invariant / migration SQL;
+2. the live `pg_constraint` introspection guard
+   (`scripts/migration-p1-sql-only-constraint-contract.cjs`);
+3. the behavioural PostgreSQL suite
+   (`scripts/migration-p1-schema-pg-test.cjs`).
+
+## Migration-safety classification (P1 Slice 1)
+
+Do **not** describe the Slice 1 work as “additive only”. Accurate classes:
+
+| Class | What happened |
+|---|---|
+| Additive schema objects | New columns/tables/indexes (`lineageRootId`, validation/approval evidence, `storageStatus`, …) |
+| Lineage backfill | `lineageRootId = id` for existing package rows |
+| Nullability strengthening | `createdByUserId` guarded then `SET NOT NULL`; `lineageRootId` `NOT NULL` |
+| Constraint strengthening | Actor/approver `ON DELETE RESTRICT`; reconciliation CHECK; latest-run ownership FKs |
+| Constraint replacement | Status CHECK drop/recreate (add `SUPERSEDED`); actor FKs `SET NULL` → `RESTRICT` |
+
+No table rebuild, no migration-evidence deletion, and no invented actor identity
+backfill. If any `createdByUserId` were NULL, migration `20260806170000` fails
+closed before strengthening.
+
+## Protected SQL-only inventory
+
+Live definitions are asserted after `prisma migrate deploy` by
+`scripts/migration-p1-sql-only-constraint-contract.cjs`.
+
+| Constraint | Table | Columns → referenced | ON DELETE |
+|---|---|---|---|
+| `MigrationPackage_businessId_predecessorPackageId_fkey` | MigrationPackage | `(businessId, predecessorPackageId)` → `MigrationPackage(businessId, id)` | RESTRICT |
+| `MigrationPackage_businessId_validatedByUserId_fkey` | MigrationPackage | `(businessId, validatedByUserId)` → `User(businessId, id)` | RESTRICT |
+| `MigrationPackage_businessId_approvedByUserId_fkey` | MigrationPackage | `(businessId, approvedByUserId)` → `User(businessId, id)` | RESTRICT |
+| `MigrationPackage_businessId_executedByUserId_fkey` | MigrationPackage | `(businessId, executedByUserId)` → `User(businessId, id)` | RESTRICT |
+| `MigrationPackage_businessId_cancelledByUserId_fkey` | MigrationPackage | `(businessId, cancelledByUserId)` → `User(businessId, id)` | RESTRICT |
+| `MigrationPackage_businessId_supersededByUserId_fkey` | MigrationPackage | `(businessId, supersededByUserId)` → `User(businessId, id)` | RESTRICT |
+| `MigrationValidationRun_businessId_validatedByUserId_fkey` | MigrationValidationRun | `(businessId, validatedByUserId)` → `User(businessId, id)` | RESTRICT |
+| `MigrationPackage_businessId_latestValidationRunId_fkey` | MigrationPackage | `(businessId, latestValidationRunId)` → `MigrationValidationRun(businessId, id)` | RESTRICT |
+| `MigrationPackage_latestValidationRunId_id_fkey` | MigrationPackage | `(latestValidationRunId, id)` → `MigrationValidationRun(id, packageId)` | RESTRICT |
+
+## latestValidationRun ownership invariant
+
+When `latestValidationRunId` is not null:
+
+```
+package.businessId = run.businessId
+AND package.id = run.packageId
+```
+
+NULL `latestValidationRunId` remains permitted (MATCH SIMPLE). Historical runs
+stay rows on `MigrationValidationRun`; only the package pointer moves.

--- a/lib/migration/index.ts
+++ b/lib/migration/index.ts
@@ -1,7 +1,7 @@
 /**
- * Migration Framework P0 public surface.
+ * Migration Framework public surface (P0 helpers + P1 Slice 1 schema constants).
  *
- * No upload UI, import execution, or accounting posting is exported from P0.
+ * No upload UI, import execution, or accounting posting is exported yet.
  */
 
 export * from '@/lib/migration/types';

--- a/lib/migration/lifecycle.test.ts
+++ b/lib/migration/lifecycle.test.ts
@@ -32,16 +32,26 @@ describe('migration package lifecycle', () => {
     expect(() => assertPackageTransition('DRAFT', 'IMPORTING')).toThrow(MigrationLifecycleError);
   });
 
-  it('treats IMPORTED, EXPIRED, CANCELLED as terminal', () => {
+  it('treats IMPORTED, EXPIRED, CANCELLED, SUPERSEDED as terminal', () => {
     expect(isPackageLifecycleTerminal('IMPORTED')).toBe(true);
     expect(isPackageLifecycleTerminal('EXPIRED')).toBe(true);
     expect(isPackageLifecycleTerminal('CANCELLED')).toBe(true);
+    expect(isPackageLifecycleTerminal('SUPERSEDED')).toBe(true);
     expect(isPackageLifecycleTerminal('APPROVED')).toBe(false);
   });
 
   it('allows approval invalidation from APPROVED only via APPROVAL_INVALIDATED', () => {
     assertPackageTransition('APPROVED', 'APPROVAL_INVALIDATED');
     expect(canTransitionPackage('IMPORTED', 'APPROVAL_INVALIDATED')).toBe(false);
+    expect(canTransitionPackage('APPROVAL_INVALIDATED', 'DRAFT')).toBe(false);
+    expect(canTransitionPackage('APPROVAL_INVALIDATED', 'VALIDATED')).toBe(false);
+  });
+
+  it('allows supersession from APPROVED or APPROVAL_INVALIDATED only', () => {
+    assertPackageTransition('APPROVED', 'SUPERSEDED');
+    assertPackageTransition('APPROVAL_INVALIDATED', 'SUPERSEDED');
+    expect(canTransitionPackage('DRAFT', 'SUPERSEDED')).toBe(false);
+    expect(canTransitionPackage('IMPORTING', 'SUPERSEDED')).toBe(false);
   });
 
   it('keeps reconciliation separate from package lifecycle', () => {

--- a/lib/migration/lifecycle.ts
+++ b/lib/migration/lifecycle.ts
@@ -1,8 +1,10 @@
 /**
  * Package lifecycle and reconciliation transition rules (fail-closed).
  *
- * Provenance: structure adapted from historic lib/migration/lifecycle.ts (0f6a917);
- * statuses rewritten for the locked DRAFT→IMPORTED / separate reconciliation model.
+ * P1 closed contract:
+ * - packages are mutable only before first APPROVED;
+ * - APPROVAL_INVALIDATED is not an editable recovery state;
+ * - SUPERSEDED is terminal (successor creation).
  */
 
 import { MigrationLifecycleError } from '@/lib/migration/errors';
@@ -10,15 +12,16 @@ import type { MigrationPackageStatus, MigrationReconciliationStatus } from '@/li
 
 const PACKAGE_TRANSITIONS: Record<MigrationPackageStatus, MigrationPackageStatus[]> = {
   DRAFT: ['VALIDATED', 'VALIDATION_FAILED', 'CANCELLED', 'EXPIRED'],
-  VALIDATED: ['APPROVED', 'APPROVAL_INVALIDATED', 'DRAFT', 'VALIDATION_FAILED', 'CANCELLED', 'EXPIRED'],
-  APPROVED: ['IMPORTING', 'APPROVAL_INVALIDATED', 'CANCELLED'],
+  VALIDATED: ['APPROVED', 'DRAFT', 'VALIDATION_FAILED', 'CANCELLED', 'EXPIRED'],
+  APPROVED: ['IMPORTING', 'APPROVAL_INVALIDATED', 'CANCELLED', 'SUPERSEDED'],
   IMPORTING: ['IMPORTED', 'IMPORT_FAILED'],
   IMPORTED: [],
   VALIDATION_FAILED: ['DRAFT', 'CANCELLED', 'EXPIRED'],
-  APPROVAL_INVALIDATED: ['DRAFT', 'VALIDATED', 'CANCELLED', 'EXPIRED'],
+  APPROVAL_INVALIDATED: ['SUPERSEDED', 'CANCELLED', 'EXPIRED'],
   IMPORT_FAILED: ['IMPORTING', 'CANCELLED'],
   EXPIRED: [],
   CANCELLED: [],
+  SUPERSEDED: [],
 };
 
 const RECON_TRANSITIONS: Record<MigrationReconciliationStatus, MigrationReconciliationStatus[]> = {
@@ -63,14 +66,19 @@ export function assertReconciliationTransition(
 
 /** Import completion does not imply successful reconciliation. */
 export function isPackageLifecycleTerminal(status: MigrationPackageStatus): boolean {
-  return status === 'IMPORTED' || status === 'EXPIRED' || status === 'CANCELLED';
+  return (
+    status === 'IMPORTED' ||
+    status === 'EXPIRED' ||
+    status === 'CANCELLED' ||
+    status === 'SUPERSEDED'
+  );
 }
 
 export function isReconciliationTerminal(status: MigrationReconciliationStatus): boolean {
   return status === 'MATCHED';
 }
 
-/** Statuses subject to the 14-day unapproved expiry rule. */
+/** Statuses subject to the 14-day unapproved (draft) expiry rule. */
 export function isExpiryEligibleStatus(status: MigrationPackageStatus): boolean {
   return (
     status === 'DRAFT' ||
@@ -80,7 +88,17 @@ export function isExpiryEligibleStatus(status: MigrationPackageStatus): boolean 
   );
 }
 
+/** Pre-approval mutable statuses (files/mappings may change). */
+export function isPreApprovalMutableStatus(status: MigrationPackageStatus): boolean {
+  return status === 'DRAFT' || status === 'VALIDATED' || status === 'VALIDATION_FAILED';
+}
+
 /** Material change after approval must move APPROVED → APPROVAL_INVALIDATED. */
 export function assertCanInvalidateApproval(status: MigrationPackageStatus): void {
   assertPackageTransition(status, 'APPROVAL_INVALIDATED');
+}
+
+/** Successor creation transitions predecessor to SUPERSEDED. */
+export function assertCanSupersedePackage(status: MigrationPackageStatus): void {
+  assertPackageTransition(status, 'SUPERSEDED');
 }

--- a/lib/migration/limits.ts
+++ b/lib/migration/limits.ts
@@ -1,25 +1,64 @@
 /**
  * Hard limits, expiry constants, and CSV export sanitisation.
  *
- * Provenance: adapted from historic lib/migration/limits.ts (0f6a917 / 995c96f).
+ * P1 Slice 1 contractual limits (owner-closed):
+ * - 25 MiB upload / uncompressed per file
+ * - 50_000 data rows (excluding header)
+ * - 32 columns
+ * - no compressed uploads
  */
 
 /** Unapproved packages expire 14 days after initial package creation. */
 export const MIGRATION_UNAPPROVED_EXPIRY_DAYS = 14;
 
+/** Approved packages remain import-eligible for 14 days after approval. */
+export const MIGRATION_APPROVAL_VALIDITY_DAYS = 14;
+
 /** Retain protected source files for 90 days after terminal package status. */
 export const MIGRATION_FILE_RETENTION_DAYS = 90;
 
-export const MIGRATION_MAX_FILE_BYTES = 5 * 1024 * 1024; // 5 MiB
+/** Contractual max uploaded bytes per file (25 MiB). */
+export const MIGRATION_MAX_UPLOAD_BYTES = 26_214_400;
+
+/** Contractual max uncompressed bytes per file (25 MiB; compression disabled). */
+export const MIGRATION_MAX_UNCOMPRESSED_BYTES = 26_214_400;
+
+/**
+ * @deprecated Use MIGRATION_MAX_UPLOAD_BYTES. Kept as an alias so older imports
+ * cannot silently retain the retired 5 MiB constant.
+ */
+export const MIGRATION_MAX_FILE_BYTES = MIGRATION_MAX_UPLOAD_BYTES;
+
+/** Maximum data rows per file, excluding the header row. */
 export const MIGRATION_MAX_ROWS = 50_000;
+
+/** Maximum CSV columns per file (Phase 1 entity headers are ≤11). */
+export const MIGRATION_MAX_COLUMNS = 32;
+
 export const MIGRATION_MAX_EXCEPTIONS_RETAINED = 2_000;
 export const MIGRATION_MAX_JSON_CHARS = 500_000;
-/** Documented future import chunk size — not used by P0 execution. */
+
+/** Compressed uploads are not permitted in P1. */
+export const MIGRATION_COMPRESSION_ALLOWED = false;
+
+/** Documented future import chunk size — not used by P1 slice 1. */
 export const MIGRATION_DEFAULT_CHUNK_SIZE = 200;
+
+export const MIGRATION_FILE_STORAGE_STATUSES = ['PENDING', 'FINALISED', 'FAILED'] as const;
+export type MigrationFileStorageStatus = (typeof MIGRATION_FILE_STORAGE_STATUSES)[number];
+
+export const MIGRATION_VALIDATION_RUN_STATUSES = ['SUCCESS', 'FAILED', 'STALE'] as const;
+export type MigrationValidationRunStatus = (typeof MIGRATION_VALIDATION_RUN_STATUSES)[number];
 
 export function computePackageExpiresAt(createdAt: Date): Date {
   const expires = new Date(createdAt.getTime());
   expires.setUTCDate(expires.getUTCDate() + MIGRATION_UNAPPROVED_EXPIRY_DAYS);
+  return expires;
+}
+
+export function computeApprovalExpiresAt(approvedAt: Date): Date {
+  const expires = new Date(approvedAt.getTime());
+  expires.setUTCDate(expires.getUTCDate() + MIGRATION_APPROVAL_VALIDITY_DAYS);
   return expires;
 }
 

--- a/lib/migration/schema-contract.test.ts
+++ b/lib/migration/schema-contract.test.ts
@@ -8,10 +8,26 @@ import {
   MIGRATION_PACKAGE_STATUSES,
   MIGRATION_RECONCILIATION_STATUSES,
 } from '@/lib/migration/types';
+import {
+  MIGRATION_APPROVAL_VALIDITY_DAYS,
+  MIGRATION_COMPRESSION_ALLOWED,
+  MIGRATION_MAX_COLUMNS,
+  MIGRATION_MAX_ROWS,
+  MIGRATION_MAX_UNCOMPRESSED_BYTES,
+  MIGRATION_MAX_UPLOAD_BYTES,
+  MIGRATION_UNAPPROVED_EXPIRY_DAYS,
+} from '@/lib/migration/limits';
 
-describe('migration P0 schema contract', () => {
-  const sql = readFileSync(
+describe('migration P1 schema contract', () => {
+  const p0Sql = readFileSync(
     join(process.cwd(), 'prisma/migrations/20260806130000_migration_framework_p0/migration.sql'),
+    'utf8',
+  );
+  const p1Sql = readFileSync(
+    join(
+      process.cwd(),
+      'prisma/migrations/20260806170000_migration_framework_p1_slice1_schema/migration.sql',
+    ),
     'utf8',
   );
 
@@ -24,25 +40,46 @@ describe('migration P0 schema contract', () => {
     for (const status of MIGRATION_RECONCILIATION_STATUSES) {
       expect(MIGRATION_PACKAGE_STATUSES).not.toContain(status as never);
     }
+    expect(MIGRATION_PACKAGE_STATUSES).toContain('SUPERSEDED');
     expect(MIGRATION_PACKAGE_STATUSES).not.toContain('MATCHED' as never);
     expect(MIGRATION_RECONCILIATION_STATUSES).toContain('MATCHED');
   });
 
-  it('migration SQL creates package-oriented tables with tenant composite FKs', () => {
-    expect(sql).toContain('CREATE TABLE "MigrationPackage"');
-    expect(sql).toContain('CREATE TABLE "MigrationFile"');
-    expect(sql).toContain('CREATE TABLE "MigrationBranchMapping"');
-    expect(sql).toContain('MigrationFile_packageId_entityType_key');
-    expect(sql).toContain('MigrationBranchMapping_businessId_targetStoreId_fkey');
-    expect(sql).toContain('REFERENCES "Store"("businessId", "id")');
-    expect(sql).not.toContain('CREATE TABLE "MigrationBatch"');
-    expect(sql).not.toContain('CREATE TABLE "MigrationEntityMap"');
-    expect(sql).not.toContain('CREATE TABLE "MigrationChunkReceipt"');
-    expect(sql).not.toContain('CREATE TABLE "MigrationOpeningStockPosting"');
+  it('locks P1 contractual file limits', () => {
+    expect(MIGRATION_MAX_UPLOAD_BYTES).toBe(26_214_400);
+    expect(MIGRATION_MAX_UNCOMPRESSED_BYTES).toBe(26_214_400);
+    expect(MIGRATION_MAX_ROWS).toBe(50_000);
+    expect(MIGRATION_MAX_COLUMNS).toBe(32);
+    expect(MIGRATION_UNAPPROVED_EXPIRY_DAYS).toBe(14);
+    expect(MIGRATION_APPROVAL_VALIDITY_DAYS).toBe(14);
+    expect(MIGRATION_COMPRESSION_ALLOWED).toBe(false);
+  });
+
+  it('P0 migration SQL creates package-oriented tables with tenant composite FKs', () => {
+    expect(p0Sql).toContain('CREATE TABLE "MigrationPackage"');
+    expect(p0Sql).toContain('CREATE TABLE "MigrationFile"');
+    expect(p0Sql).toContain('CREATE TABLE "MigrationBranchMapping"');
+    expect(p0Sql).toContain('MigrationFile_packageId_entityType_key');
+    expect(p0Sql).toContain('MigrationBranchMapping_businessId_targetStoreId_fkey');
+    expect(p0Sql).toContain('REFERENCES "Store"("businessId", "id")');
+  });
+
+  it('P1 migration SQL adds lineage, evidence tables, and invariants', () => {
+    expect(p1Sql).toContain('CREATE TABLE "MigrationValidationRun"');
+    expect(p1Sql).toContain('CREATE TABLE "MigrationApprovalHistory"');
+    expect(p1Sql).toContain('User_businessId_id_key');
+    expect(p1Sql).toContain('MigrationPackage_predecessorPackageId_key');
+    expect(p1Sql).toContain('MigrationPackage_businessId_predecessorPackageId_fkey');
+    expect(p1Sql).toContain('MigrationPackage_predecessor_not_self_check');
+    expect(p1Sql).toContain('MigrationPackage_recon_imported_only_check');
+    expect(p1Sql).toContain("'SUPERSEDED'");
+    expect(p1Sql).toContain('storageStatus');
+    expect(p1Sql).not.toContain('supersededByPackageId');
+    expect(p1Sql).not.toContain('CREATE TABLE "MigrationEntityMap"');
+    expect(p1Sql).not.toContain('CREATE TABLE "MigrationChunkReceipt"');
   });
 
   it('documents that uniqueness is at-most-one per entity type, not completeness', () => {
-    // Service-layer helpers still enforce exactly-three at validation/approval.
     expect(MIGRATION_ENTITY_TYPES).toHaveLength(3);
   });
 });

--- a/lib/migration/schema-contract.test.ts
+++ b/lib/migration/schema-contract.test.ts
@@ -79,6 +79,21 @@ describe('migration P1 schema contract', () => {
     expect(p1Sql).not.toContain('CREATE TABLE "MigrationChunkReceipt"');
   });
 
+  it('P1 ownership correction enforces same-business and same-package latest runs', () => {
+    const ownershipSql = readFileSync(
+      join(
+        process.cwd(),
+        'prisma/migrations/20260806183000_migration_p1_slice1_latest_run_ownership/migration.sql',
+      ),
+      'utf8',
+    );
+    expect(ownershipSql).toContain('MigrationValidationRun_id_packageId_key');
+    expect(ownershipSql).toContain('MigrationPackage_businessId_latestValidationRunId_fkey');
+    expect(ownershipSql).toContain('MigrationPackage_latestValidationRunId_id_fkey');
+    expect(ownershipSql).toContain('ON DELETE RESTRICT');
+    expect(ownershipSql).toMatch(/constraint strengthening|Constraint strengthening/i);
+  });
+
   it('documents that uniqueness is at-most-one per entity type, not completeness', () => {
     expect(MIGRATION_ENTITY_TYPES).toHaveLength(3);
   });

--- a/lib/migration/types.ts
+++ b/lib/migration/types.ts
@@ -21,6 +21,7 @@ export const MIGRATION_PACKAGE_STATUSES = [
   'IMPORT_FAILED',
   'EXPIRED',
   'CANCELLED',
+  'SUPERSEDED',
 ] as const;
 export type MigrationPackageStatus = (typeof MIGRATION_PACKAGE_STATUSES)[number];
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "db:wal": "tsx scripts/enable-wal.ts",
     "db:setup": "npm run db:push:local && npm run db:wal && npm run db:seed",
     "db:reset": "del dev.db 2>nul & npm run db:setup",
-    "generate:og": "node scripts/generate-tillflow-og-v2.mjs"
+    "generate:og": "node scripts/generate-tillflow-og-v2.mjs",
+    "test:migration:p1-schema:pg": "node scripts/migration-p1-schema-pg-test.cjs"
   },
   "engines": {
     "node": ">=18 <24"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "db:setup": "npm run db:push:local && npm run db:wal && npm run db:seed",
     "db:reset": "del dev.db 2>nul & npm run db:setup",
     "generate:og": "node scripts/generate-tillflow-og-v2.mjs",
-    "test:migration:p1-schema:pg": "node scripts/migration-p1-schema-pg-test.cjs"
+    "test:migration:p1-schema:pg": "node scripts/migration-p1-schema-pg-test.cjs",
+    "test:migration:p1-sql-only-contract": "node scripts/migration-p1-sql-only-constraint-contract.cjs"
   },
   "engines": {
     "node": ">=18 <24"

--- a/prisma/migrations/20260806170000_migration_framework_p1_slice1_schema/migration.sql
+++ b/prisma/migrations/20260806170000_migration_framework_p1_slice1_schema/migration.sql
@@ -1,0 +1,241 @@
+-- Migration Framework P1 Slice 1: schema foundation only.
+-- Additive: lineage, validation/approval evidence, storageStatus, actor Restrict FKs, limits-aligned CHECKs.
+-- Does not implement upload/validation/approval/import services.
+
+-- ---------------------------------------------------------------------------
+-- 0) Preconditions: refuse unsafe NOT NULL upgrades (do not invent actor ids)
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "MigrationPackage" WHERE "createdByUserId" IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'P1 slice1 blocked: MigrationPackage.createdByUserId has NULL rows; cannot require creator without inventing actors';
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 1) User tenant-safe composite uniqueness (actor FK target)
+-- ---------------------------------------------------------------------------
+CREATE UNIQUE INDEX "User_businessId_id_key" ON "User"("businessId", "id");
+
+-- ---------------------------------------------------------------------------
+-- 2) MigrationPackage: additive columns (nullable first where backfill needed)
+-- ---------------------------------------------------------------------------
+ALTER TABLE "MigrationPackage" ADD COLUMN "approvalExpiresAt" TIMESTAMP(3);
+ALTER TABLE "MigrationPackage" ADD COLUMN "lineageRootId" TEXT;
+ALTER TABLE "MigrationPackage" ADD COLUMN "predecessorPackageId" TEXT;
+ALTER TABLE "MigrationPackage" ADD COLUMN "latestValidationRunId" TEXT;
+ALTER TABLE "MigrationPackage" ADD COLUMN "supersededByUserId" TEXT;
+ALTER TABLE "MigrationPackage" ADD COLUMN "supersededAt" TIMESTAMP(3);
+
+-- Root packages: lineageRootId = id (safe derivation, not invented identity)
+UPDATE "MigrationPackage" SET "lineageRootId" = "id" WHERE "lineageRootId" IS NULL;
+ALTER TABLE "MigrationPackage" ALTER COLUMN "lineageRootId" SET NOT NULL;
+
+-- Require creator when no NULL rows remain (checked above)
+ALTER TABLE "MigrationPackage" ALTER COLUMN "createdByUserId" SET NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3) Expand status CHECK with SUPERSEDED; add reconciliation invariant
+-- ---------------------------------------------------------------------------
+ALTER TABLE "MigrationPackage" DROP CONSTRAINT "MigrationPackage_status_check";
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_status_check" CHECK (
+  "status" IN (
+    'DRAFT',
+    'VALIDATED',
+    'APPROVED',
+    'IMPORTING',
+    'IMPORTED',
+    'VALIDATION_FAILED',
+    'APPROVAL_INVALIDATED',
+    'IMPORT_FAILED',
+    'EXPIRED',
+    'CANCELLED',
+    'SUPERSEDED'
+  )
+);
+
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_recon_imported_only_check" CHECK (
+  "status" = 'IMPORTED' OR "reconciliationStatus" = 'NOT_STARTED'
+);
+
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_predecessor_not_self_check" CHECK (
+  "predecessorPackageId" IS NULL OR "predecessorPackageId" <> "id"
+);
+
+-- ---------------------------------------------------------------------------
+-- 4) Replace actor FKs: drop SET NULL, add Restrict (+ composite where Prisma supports)
+-- ---------------------------------------------------------------------------
+ALTER TABLE "MigrationPackage" DROP CONSTRAINT "MigrationPackage_createdByUserId_fkey";
+ALTER TABLE "MigrationPackage" DROP CONSTRAINT "MigrationPackage_validatedByUserId_fkey";
+ALTER TABLE "MigrationPackage" DROP CONSTRAINT "MigrationPackage_approvedByUserId_fkey";
+ALTER TABLE "MigrationPackage" DROP CONSTRAINT "MigrationPackage_executedByUserId_fkey";
+ALTER TABLE "MigrationPackage" DROP CONSTRAINT "MigrationPackage_cancelledByUserId_fkey";
+
+-- Required creator: composite same-business FK (Prisma-managed name)
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_businessId_createdByUserId_fkey"
+  FOREIGN KEY ("businessId", "createdByUserId") REFERENCES "User"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Optional actors: single-column Restrict (Prisma) + composite same-business (SQL-only)
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_validatedByUserId_fkey"
+  FOREIGN KEY ("validatedByUserId") REFERENCES "User"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_businessId_validatedByUserId_fkey"
+  FOREIGN KEY ("businessId", "validatedByUserId") REFERENCES "User"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_approvedByUserId_fkey"
+  FOREIGN KEY ("approvedByUserId") REFERENCES "User"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_businessId_approvedByUserId_fkey"
+  FOREIGN KEY ("businessId", "approvedByUserId") REFERENCES "User"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_executedByUserId_fkey"
+  FOREIGN KEY ("executedByUserId") REFERENCES "User"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_businessId_executedByUserId_fkey"
+  FOREIGN KEY ("businessId", "executedByUserId") REFERENCES "User"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_cancelledByUserId_fkey"
+  FOREIGN KEY ("cancelledByUserId") REFERENCES "User"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_businessId_cancelledByUserId_fkey"
+  FOREIGN KEY ("businessId", "cancelledByUserId") REFERENCES "User"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_supersededByUserId_fkey"
+  FOREIGN KEY ("supersededByUserId") REFERENCES "User"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_businessId_supersededByUserId_fkey"
+  FOREIGN KEY ("businessId", "supersededByUserId") REFERENCES "User"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 5) Lineage: UNIQUE(predecessorPackageId); Prisma id FK + SQL composite tenant FK
+-- ---------------------------------------------------------------------------
+CREATE UNIQUE INDEX "MigrationPackage_predecessorPackageId_key"
+  ON "MigrationPackage"("predecessorPackageId");
+
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_predecessorPackageId_fkey"
+  FOREIGN KEY ("predecessorPackageId") REFERENCES "MigrationPackage"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_businessId_predecessorPackageId_fkey"
+  FOREIGN KEY ("businessId", "predecessorPackageId") REFERENCES "MigrationPackage"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "MigrationPackage_businessId_lineageRootId_idx"
+  ON "MigrationPackage"("businessId", "lineageRootId");
+
+CREATE INDEX "MigrationPackage_businessId_status_approvalExpiresAt_idx"
+  ON "MigrationPackage"("businessId", "status", "approvalExpiresAt");
+
+CREATE UNIQUE INDEX "MigrationPackage_latestValidationRunId_key"
+  ON "MigrationPackage"("latestValidationRunId");
+
+-- ---------------------------------------------------------------------------
+-- 6) MigrationValidationRun (create before latestValidationRun FK)
+-- ---------------------------------------------------------------------------
+CREATE TABLE "MigrationValidationRun" (
+    "id" TEXT NOT NULL,
+    "businessId" TEXT NOT NULL,
+    "packageId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "manifestChecksum" TEXT NOT NULL,
+    "resultDigest" TEXT,
+    "summaryJson" TEXT,
+    "exceptionCount" INTEGER NOT NULL DEFAULT 0,
+    "exceptionsTruncated" INTEGER NOT NULL DEFAULT 0,
+    "validatedByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "supersededAt" TIMESTAMP(3),
+
+    CONSTRAINT "MigrationValidationRun_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "MigrationValidationRun_status_check" CHECK (
+      "status" IN ('SUCCESS', 'FAILED', 'STALE')
+    )
+);
+
+CREATE UNIQUE INDEX "MigrationValidationRun_businessId_id_key"
+  ON "MigrationValidationRun"("businessId", "id");
+CREATE INDEX "MigrationValidationRun_businessId_packageId_createdAt_idx"
+  ON "MigrationValidationRun"("businessId", "packageId", "createdAt");
+CREATE INDEX "MigrationValidationRun_packageId_createdAt_idx"
+  ON "MigrationValidationRun"("packageId", "createdAt");
+
+ALTER TABLE "MigrationValidationRun" ADD CONSTRAINT "MigrationValidationRun_businessId_packageId_fkey"
+  FOREIGN KEY ("businessId", "packageId") REFERENCES "MigrationPackage"("businessId", "id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "MigrationValidationRun" ADD CONSTRAINT "MigrationValidationRun_validatedByUserId_fkey"
+  FOREIGN KEY ("validatedByUserId") REFERENCES "User"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "MigrationValidationRun" ADD CONSTRAINT "MigrationValidationRun_businessId_validatedByUserId_fkey"
+  FOREIGN KEY ("businessId", "validatedByUserId") REFERENCES "User"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- latestValidationRun pointer (nullable; SetNull on run delete)
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_latestValidationRunId_fkey"
+  FOREIGN KEY ("latestValidationRunId") REFERENCES "MigrationValidationRun"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 7) MigrationApprovalHistory (immutable; Restrict package + composite approver)
+-- ---------------------------------------------------------------------------
+CREATE TABLE "MigrationApprovalHistory" (
+    "id" TEXT NOT NULL,
+    "businessId" TEXT NOT NULL,
+    "packageId" TEXT NOT NULL,
+    "approverUserId" TEXT NOT NULL,
+    "approvedAt" TIMESTAMP(3) NOT NULL,
+    "approvedManifestChecksum" TEXT NOT NULL,
+    "approvalExpiresAt" TIMESTAMP(3) NOT NULL,
+    "validationRunId" TEXT,
+    "validationResultDigest" TEXT,
+    "contractVersion" TEXT NOT NULL,
+    "reportingCurrency" TEXT NOT NULL,
+    "packageAsOfDate" TEXT NOT NULL,
+    "branchMappingDigest" TEXT,
+    "fileChecksumsJson" TEXT NOT NULL,
+    "acknowledgementJson" TEXT,
+    "note" TEXT,
+    "snapshotJson" TEXT,
+    "invalidatedAt" TIMESTAMP(3),
+    "invalidationReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MigrationApprovalHistory_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MigrationApprovalHistory_businessId_id_key"
+  ON "MigrationApprovalHistory"("businessId", "id");
+CREATE INDEX "MigrationApprovalHistory_businessId_packageId_approvedAt_idx"
+  ON "MigrationApprovalHistory"("businessId", "packageId", "approvedAt");
+CREATE INDEX "MigrationApprovalHistory_packageId_approvedAt_idx"
+  ON "MigrationApprovalHistory"("packageId", "approvedAt");
+
+ALTER TABLE "MigrationApprovalHistory" ADD CONSTRAINT "MigrationApprovalHistory_businessId_packageId_fkey"
+  FOREIGN KEY ("businessId", "packageId") REFERENCES "MigrationPackage"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "MigrationApprovalHistory" ADD CONSTRAINT "MigrationApprovalHistory_businessId_approverUserId_fkey"
+  FOREIGN KEY ("businessId", "approverUserId") REFERENCES "User"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 8) MigrationFile.storageStatus
+-- ---------------------------------------------------------------------------
+ALTER TABLE "MigrationFile" ADD COLUMN "storageStatus" TEXT NOT NULL DEFAULT 'PENDING';
+
+ALTER TABLE "MigrationFile" ADD CONSTRAINT "MigrationFile_storageStatus_check" CHECK (
+  "storageStatus" IN ('PENDING', 'FINALISED', 'FAILED')
+);
+
+CREATE INDEX "MigrationFile_businessId_storageStatus_idx"
+  ON "MigrationFile"("businessId", "storageStatus");

--- a/prisma/migrations/20260806183000_migration_p1_slice1_latest_run_ownership/migration.sql
+++ b/prisma/migrations/20260806183000_migration_p1_slice1_latest_run_ownership/migration.sql
@@ -1,0 +1,41 @@
+-- P1 Slice 1 correction: tenant-safe + package-safe latestValidationRunId.
+--
+-- Classification: constraint strengthening / constraint replacement (not "additive only").
+-- Does not rewrite 20260806170000 (already applied on Preview for PR #81).
+-- Production never received 20260806170000 before this correction branch.
+--
+-- Invariant enforced:
+--   package.businessId = run.businessId
+--   AND package.id = run.packageId
+-- when latestValidationRunId IS NOT NULL.
+--
+-- ON DELETE RESTRICT blocks deleting a currently selected validation run.
+-- DEFERRABLE INITIALLY DEFERRED allows package CASCADE delete of its runs at
+-- transaction end (package row gone → pointer check passes) while still
+-- rejecting a standalone DELETE of a selected run.
+
+-- 1) Replace weak single-column SET NULL pointer with Restrict
+ALTER TABLE "MigrationPackage" DROP CONSTRAINT IF EXISTS "MigrationPackage_latestValidationRunId_fkey";
+
+-- 2) Unique target for same-package ownership FK
+CREATE UNIQUE INDEX "MigrationValidationRun_id_packageId_key"
+  ON "MigrationValidationRun"("id", "packageId");
+
+-- 3) Prisma-managed single-column pointer (Restrict)
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_latestValidationRunId_fkey"
+  FOREIGN KEY ("latestValidationRunId") REFERENCES "MigrationValidationRun"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- 4) Same-business ownership (SQL-only composite; see docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md)
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_businessId_latestValidationRunId_fkey"
+  FOREIGN KEY ("businessId", "latestValidationRunId")
+  REFERENCES "MigrationValidationRun"("businessId", "id")
+  ON DELETE RESTRICT ON UPDATE CASCADE
+  DEFERRABLE INITIALLY DEFERRED;
+
+-- 5) Same-package ownership: selecting package.id must equal run.packageId
+ALTER TABLE "MigrationPackage" ADD CONSTRAINT "MigrationPackage_latestValidationRunId_id_fkey"
+  FOREIGN KEY ("latestValidationRunId", "id")
+  REFERENCES "MigrationValidationRun"("id", "packageId")
+  ON DELETE RESTRICT ON UPDATE CASCADE
+  DEFERRABLE INITIALLY DEFERRED;

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -527,12 +527,17 @@ model User {
   passwordResetTokens        PasswordResetToken[]
   reconciledPayments         PaymentReconciliation[] @relation("PaymentReconciledBy")
   productImports             ProductImport[]
-  migrationPackagesCreated   MigrationPackage[]      @relation("MigrationPackageCreatedBy")
-  migrationPackagesValidated MigrationPackage[]      @relation("MigrationPackageValidatedBy")
-  migrationPackagesApproved  MigrationPackage[]      @relation("MigrationPackageApprovedBy")
-  migrationPackagesExecuted  MigrationPackage[]      @relation("MigrationPackageExecutedBy")
-  migrationPackagesCancelled MigrationPackage[]      @relation("MigrationPackageCancelledBy")
+  migrationPackagesCreated    MigrationPackage[]           @relation("MigrationPackageCreatedBy")
+  migrationPackagesValidated  MigrationPackage[]           @relation("MigrationPackageValidatedBy")
+  migrationPackagesApproved   MigrationPackage[]           @relation("MigrationPackageApprovedBy")
+  migrationPackagesExecuted   MigrationPackage[]           @relation("MigrationPackageExecutedBy")
+  migrationPackagesCancelled  MigrationPackage[]           @relation("MigrationPackageCancelledBy")
+  migrationPackagesSuperseded MigrationPackage[]           @relation("MigrationPackageSupersededBy")
+  migrationValidationRuns     MigrationValidationRun[]
+  migrationApprovalHistories  MigrationApprovalHistory[]
 
+  /// Tenant-aware composite target for migration actor FKs.
+  @@unique([businessId, id])
   @@index([businessId, active])
 }
 
@@ -727,6 +732,7 @@ model ProductImport {
 
 /// Atomic Phase 1 migration package (suppliers + products + opening stock).
 /// Lifecycle status is separate from reconciliationStatus. Strings are CHECK-constrained in SQL.
+/// Lineage authority: successor.predecessorPackageId only (no supersededByPackageId).
 model MigrationPackage {
   id                       String    @id @default(cuid())
   businessId               String
@@ -741,7 +747,7 @@ model MigrationPackage {
   /// Package as-of date (YYYY-MM-DD calendar date).
   packageAsOfDate          String
   /// DRAFT | VALIDATED | APPROVED | IMPORTING | IMPORTED | VALIDATION_FAILED |
-  /// APPROVAL_INVALIDATED | IMPORT_FAILED | EXPIRED | CANCELLED
+  /// APPROVAL_INVALIDATED | IMPORT_FAILED | EXPIRED | CANCELLED | SUPERSEDED
   status                   String    @default("DRAFT")
   /// NOT_STARTED | RECONCILING | MATCHED | MISMATCHED | RECONCILIATION_FAILED
   reconciliationStatus     String    @default("NOT_STARTED")
@@ -751,49 +757,130 @@ model MigrationPackage {
   manifestChecksum         String?
   /// Manifest checksum frozen at Owner approval.
   approvedManifestChecksum String?
-  /// Expiry clock starts at package creation; not restarted by file replacement.
+  /// Draft/validation expiry clock (from creation; not restarted by file replacement).
   expiresAt                DateTime
   expiredAt                DateTime?
+  /// Import-validity window set at approval; null until approved.
+  approvalExpiresAt        DateTime?
   version                  Int       @default(1)
-  createdByUserId          String?
+  /// Immutable lineage root (root packages: lineageRootId = id).
+  lineageRootId            String
+  /// Authoritative successor link; UNIQUE; multiple NULLs allowed.
+  predecessorPackageId     String?   @unique
+  latestValidationRunId    String?   @unique
+  /// Required after create — Restrict retention (no SET NULL).
+  createdByUserId          String
   validatedByUserId        String?
   validatedAt              DateTime?
   approvedByUserId         String?
   approvedAt               DateTime?
-  /// Future executor — unused in P0.
+  /// Future executor — unused in P1 slice 1 services.
   executedByUserId         String?
   executedAt               DateTime?
   cancelledByUserId        String?
   cancelledAt              DateTime?
+  supersededByUserId       String?
+  supersededAt             DateTime?
   errorMessage             String?
   summaryJson              String?
   createdAt                DateTime  @default(now())
   updatedAt                DateTime  @updatedAt
 
-  business    Business                  @relation(fields: [businessId], references: [id], onDelete: Cascade)
-  createdBy   User?                     @relation("MigrationPackageCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
-  validatedBy User?                     @relation("MigrationPackageValidatedBy", fields: [validatedByUserId], references: [id], onDelete: SetNull)
-  approvedBy  User?                     @relation("MigrationPackageApprovedBy", fields: [approvedByUserId], references: [id], onDelete: SetNull)
-  executedBy  User?                     @relation("MigrationPackageExecutedBy", fields: [executedByUserId], references: [id], onDelete: SetNull)
-  cancelledBy User?                     @relation("MigrationPackageCancelledBy", fields: [cancelledByUserId], references: [id], onDelete: SetNull)
-  files          MigrationFile[]
-  branchMappings MigrationBranchMapping[]
+  business            Business                   @relation(fields: [businessId], references: [id], onDelete: Cascade)
+  /// Required creator — Prisma composite same-business FK.
+  createdBy           User                       @relation("MigrationPackageCreatedBy", fields: [businessId, createdByUserId], references: [businessId, id], onDelete: Restrict)
+  /// Optional actors: Prisma single-column Restrict; SQL adds same-business composite FKs (Prisma cannot express optional composites sharing required businessId).
+  validatedBy         User?                      @relation("MigrationPackageValidatedBy", fields: [validatedByUserId], references: [id], onDelete: Restrict)
+  approvedBy          User?                      @relation("MigrationPackageApprovedBy", fields: [approvedByUserId], references: [id], onDelete: Restrict)
+  executedBy          User?                      @relation("MigrationPackageExecutedBy", fields: [executedByUserId], references: [id], onDelete: Restrict)
+  cancelledBy         User?                      @relation("MigrationPackageCancelledBy", fields: [cancelledByUserId], references: [id], onDelete: Restrict)
+  supersededBy        User?                      @relation("MigrationPackageSupersededBy", fields: [supersededByUserId], references: [id], onDelete: Restrict)
+  /// Prisma self-FK by id; SQL adds composite (businessId, predecessorPackageId) for tenant safety.
+  predecessor         MigrationPackage?          @relation("MigrationPackageLineage", fields: [predecessorPackageId], references: [id], onDelete: Restrict)
+  successors          MigrationPackage[]         @relation("MigrationPackageLineage")
+  validationRuns      MigrationValidationRun[]   @relation("PackageValidationRuns")
+  latestValidationRun MigrationValidationRun?    @relation("PackageLatestValidationRun", fields: [latestValidationRunId], references: [id], onDelete: SetNull)
+  approvalHistories   MigrationApprovalHistory[]
+  files               MigrationFile[]
+  branchMappings      MigrationBranchMapping[]
 
   @@unique([businessId, id])
   @@unique([businessId, clientPackageKey])
   @@index([businessId, status, createdAt])
   @@index([businessId, status, expiresAt])
+  @@index([businessId, status, approvalExpiresAt])
   @@index([businessId, sourceSystemKey, sourceBusinessKey])
+  @@index([businessId, lineageRootId])
+}
+
+/// Historical validation evidence for a package. Retained across supersession of latestValidationRunId.
+model MigrationValidationRun {
+  id                   String    @id @default(cuid())
+  businessId           String
+  packageId            String
+  /// SUCCESS | FAILED | STALE
+  status               String
+  manifestChecksum     String
+  resultDigest         String?
+  summaryJson          String?
+  exceptionCount       Int       @default(0)
+  exceptionsTruncated  Int       @default(0)
+  validatedByUserId    String?
+  createdAt            DateTime  @default(now())
+  supersededAt         DateTime?
+
+  package      MigrationPackage  @relation("PackageValidationRuns", fields: [businessId, packageId], references: [businessId, id], onDelete: Cascade)
+  validatedBy  User?             @relation(fields: [validatedByUserId], references: [id], onDelete: Restrict)
+  latestFor    MigrationPackage? @relation("PackageLatestValidationRun")
+
+  @@unique([businessId, id])
+  @@index([businessId, packageId, createdAt])
+  @@index([packageId, createdAt])
+}
+
+/// Immutable approval snapshots. Active package approval fields may be cleared without rewriting history.
+model MigrationApprovalHistory {
+  id                       String    @id @default(cuid())
+  businessId               String
+  packageId                String
+  approverUserId           String
+  approvedAt               DateTime
+  approvedManifestChecksum String
+  approvalExpiresAt        DateTime
+  validationRunId          String?
+  validationResultDigest   String?
+  contractVersion          String
+  reportingCurrency        String
+  packageAsOfDate          String
+  branchMappingDigest      String?
+  fileChecksumsJson        String
+  acknowledgementJson      String?
+  note                     String?
+  snapshotJson             String?
+  invalidatedAt            DateTime?
+  invalidationReason       String?
+  createdAt                DateTime  @default(now())
+
+  package  MigrationPackage @relation(fields: [businessId, packageId], references: [businessId, id], onDelete: Restrict)
+  /// Required approver — Prisma composite same-business FK.
+  approver User             @relation(fields: [businessId, approverUserId], references: [businessId, id], onDelete: Restrict)
+
+  @@unique([businessId, id])
+  @@index([businessId, packageId, approvedAt])
+  @@index([packageId, approvedAt])
 }
 
 /// One immutable logical file belonging to a MigrationPackage.
 /// UNIQUE(packageId, entityType) = at most one of each type (not exactly-three completeness).
+/// Only storageStatus=FINALISED files are approval-material (enforced in services; schema documents status).
 model MigrationFile {
   id                 String    @id @default(cuid())
   businessId         String
   packageId          String
   /// SUPPLIERS | PRODUCTS | OPENING_STOCK
   entityType         String
+  /// PENDING | FINALISED | FAILED — PENDING/FAILED are not approval-material.
+  storageStatus      String    @default("PENDING")
   /// Original filename stored safely (basename only; no path separators).
   originalFilename   String?
   contentType        String?
@@ -804,7 +891,7 @@ model MigrationFile {
   validationChecksum String?
   /// SHA-256 frozen at package approval for this file.
   approvedChecksum   String?
-  /// Future blob/object storage key — unused in P0 upload endpoints.
+  /// Immutable object storage key once assigned (service-layer immutability).
   storageKey         String?
   rowCount           Int?
   validatedAt        DateTime?
@@ -818,6 +905,7 @@ model MigrationFile {
   @@unique([packageId, entityType])
   @@index([businessId, packageId])
   @@index([businessId, uploadChecksum])
+  @@index([businessId, storageStatus])
 }
 
 /// Maps a source branch key to a TillFlow Store in the same business.

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -799,7 +799,10 @@ model MigrationPackage {
   predecessor         MigrationPackage?          @relation("MigrationPackageLineage", fields: [predecessorPackageId], references: [id], onDelete: Restrict)
   successors          MigrationPackage[]         @relation("MigrationPackageLineage")
   validationRuns      MigrationValidationRun[]   @relation("PackageValidationRuns")
-  latestValidationRun MigrationValidationRun?    @relation("PackageLatestValidationRun", fields: [latestValidationRunId], references: [id], onDelete: SetNull)
+  /// Prisma single-column Restrict pointer. SQL adds same-business + same-package composite FKs
+  /// (Prisma cannot express optional composite ownership sharing package id). See
+  /// docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md.
+  latestValidationRun MigrationValidationRun?    @relation("PackageLatestValidationRun", fields: [latestValidationRunId], references: [id], onDelete: Restrict)
   approvalHistories   MigrationApprovalHistory[]
   files               MigrationFile[]
   branchMappings      MigrationBranchMapping[]
@@ -834,6 +837,8 @@ model MigrationValidationRun {
   latestFor    MigrationPackage? @relation("PackageLatestValidationRun")
 
   @@unique([businessId, id])
+  /// FK target for package-ownership: (latestValidationRunId, package.id) → (id, packageId)
+  @@unique([id, packageId])
   @@index([businessId, packageId, createdAt])
   @@index([packageId, createdAt])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -794,7 +794,10 @@ model MigrationPackage {
   predecessor         MigrationPackage?          @relation("MigrationPackageLineage", fields: [predecessorPackageId], references: [id], onDelete: Restrict)
   successors          MigrationPackage[]         @relation("MigrationPackageLineage")
   validationRuns      MigrationValidationRun[]   @relation("PackageValidationRuns")
-  latestValidationRun MigrationValidationRun?    @relation("PackageLatestValidationRun", fields: [latestValidationRunId], references: [id], onDelete: SetNull)
+  /// Prisma single-column Restrict pointer. SQL adds same-business + same-package composite FKs
+  /// (Prisma cannot express optional composite ownership sharing package id). See
+  /// docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md.
+  latestValidationRun MigrationValidationRun?    @relation("PackageLatestValidationRun", fields: [latestValidationRunId], references: [id], onDelete: Restrict)
   approvalHistories   MigrationApprovalHistory[]
   files               MigrationFile[]
   branchMappings      MigrationBranchMapping[]
@@ -829,6 +832,8 @@ model MigrationValidationRun {
   latestFor    MigrationPackage? @relation("PackageLatestValidationRun")
 
   @@unique([businessId, id])
+  /// FK target for package-ownership: (latestValidationRunId, package.id) → (id, packageId)
+  @@unique([id, packageId])
   @@index([businessId, packageId, createdAt])
   @@index([packageId, createdAt])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -528,12 +528,17 @@ model User {
   purchasePaymentsRecorded   PurchasePayment[]       @relation("PurchasePaymentRecordedBy")
   passwordResetTokens        PasswordResetToken[]
   reconciledPayments         PaymentReconciliation[] @relation("PaymentReconciledBy")
-  migrationPackagesCreated   MigrationPackage[]      @relation("MigrationPackageCreatedBy")
-  migrationPackagesValidated MigrationPackage[]      @relation("MigrationPackageValidatedBy")
-  migrationPackagesApproved  MigrationPackage[]      @relation("MigrationPackageApprovedBy")
-  migrationPackagesExecuted  MigrationPackage[]      @relation("MigrationPackageExecutedBy")
-  migrationPackagesCancelled MigrationPackage[]      @relation("MigrationPackageCancelledBy")
+  migrationPackagesCreated    MigrationPackage[]           @relation("MigrationPackageCreatedBy")
+  migrationPackagesValidated  MigrationPackage[]           @relation("MigrationPackageValidatedBy")
+  migrationPackagesApproved   MigrationPackage[]           @relation("MigrationPackageApprovedBy")
+  migrationPackagesExecuted   MigrationPackage[]           @relation("MigrationPackageExecutedBy")
+  migrationPackagesCancelled  MigrationPackage[]           @relation("MigrationPackageCancelledBy")
+  migrationPackagesSuperseded MigrationPackage[]           @relation("MigrationPackageSupersededBy")
+  migrationValidationRuns     MigrationValidationRun[]
+  migrationApprovalHistories  MigrationApprovalHistory[]
 
+  /// Tenant-aware composite target for migration actor FKs.
+  @@unique([businessId, id])
   @@index([businessId, active])
 }
 
@@ -722,6 +727,7 @@ model ProductImport {
 
 /// Atomic Phase 1 migration package (suppliers + products + opening stock).
 /// Lifecycle status is separate from reconciliationStatus. Strings are CHECK-constrained in SQL.
+/// Lineage authority: successor.predecessorPackageId only (no supersededByPackageId).
 model MigrationPackage {
   id                       String    @id @default(cuid())
   businessId               String
@@ -736,7 +742,7 @@ model MigrationPackage {
   /// Package as-of date (YYYY-MM-DD calendar date).
   packageAsOfDate          String
   /// DRAFT | VALIDATED | APPROVED | IMPORTING | IMPORTED | VALIDATION_FAILED |
-  /// APPROVAL_INVALIDATED | IMPORT_FAILED | EXPIRED | CANCELLED
+  /// APPROVAL_INVALIDATED | IMPORT_FAILED | EXPIRED | CANCELLED | SUPERSEDED
   status                   String    @default("DRAFT")
   /// NOT_STARTED | RECONCILING | MATCHED | MISMATCHED | RECONCILIATION_FAILED
   reconciliationStatus     String    @default("NOT_STARTED")
@@ -746,49 +752,130 @@ model MigrationPackage {
   manifestChecksum         String?
   /// Manifest checksum frozen at Owner approval.
   approvedManifestChecksum String?
-  /// Expiry clock starts at package creation; not restarted by file replacement.
+  /// Draft/validation expiry clock (from creation; not restarted by file replacement).
   expiresAt                DateTime
   expiredAt                DateTime?
+  /// Import-validity window set at approval; null until approved.
+  approvalExpiresAt        DateTime?
   version                  Int       @default(1)
-  createdByUserId          String?
+  /// Immutable lineage root (root packages: lineageRootId = id).
+  lineageRootId            String
+  /// Authoritative successor link; UNIQUE; multiple NULLs allowed.
+  predecessorPackageId     String?   @unique
+  latestValidationRunId    String?   @unique
+  /// Required after create — Restrict retention (no SET NULL).
+  createdByUserId          String
   validatedByUserId        String?
   validatedAt              DateTime?
   approvedByUserId         String?
   approvedAt               DateTime?
-  /// Future executor — unused in P0.
+  /// Future executor — unused in P1 slice 1 services.
   executedByUserId         String?
   executedAt               DateTime?
   cancelledByUserId        String?
   cancelledAt              DateTime?
+  supersededByUserId       String?
+  supersededAt             DateTime?
   errorMessage             String?
   summaryJson              String?
   createdAt                DateTime  @default(now())
   updatedAt                DateTime  @updatedAt
 
-  business    Business                  @relation(fields: [businessId], references: [id], onDelete: Cascade)
-  createdBy   User?                     @relation("MigrationPackageCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
-  validatedBy User?                     @relation("MigrationPackageValidatedBy", fields: [validatedByUserId], references: [id], onDelete: SetNull)
-  approvedBy  User?                     @relation("MigrationPackageApprovedBy", fields: [approvedByUserId], references: [id], onDelete: SetNull)
-  executedBy  User?                     @relation("MigrationPackageExecutedBy", fields: [executedByUserId], references: [id], onDelete: SetNull)
-  cancelledBy User?                     @relation("MigrationPackageCancelledBy", fields: [cancelledByUserId], references: [id], onDelete: SetNull)
-  files          MigrationFile[]
-  branchMappings MigrationBranchMapping[]
+  business            Business                   @relation(fields: [businessId], references: [id], onDelete: Cascade)
+  /// Required creator — Prisma composite same-business FK.
+  createdBy           User                       @relation("MigrationPackageCreatedBy", fields: [businessId, createdByUserId], references: [businessId, id], onDelete: Restrict)
+  /// Optional actors: Prisma single-column Restrict; SQL adds same-business composite FKs (Prisma cannot express optional composites sharing required businessId).
+  validatedBy         User?                      @relation("MigrationPackageValidatedBy", fields: [validatedByUserId], references: [id], onDelete: Restrict)
+  approvedBy          User?                      @relation("MigrationPackageApprovedBy", fields: [approvedByUserId], references: [id], onDelete: Restrict)
+  executedBy          User?                      @relation("MigrationPackageExecutedBy", fields: [executedByUserId], references: [id], onDelete: Restrict)
+  cancelledBy         User?                      @relation("MigrationPackageCancelledBy", fields: [cancelledByUserId], references: [id], onDelete: Restrict)
+  supersededBy        User?                      @relation("MigrationPackageSupersededBy", fields: [supersededByUserId], references: [id], onDelete: Restrict)
+  /// Prisma self-FK by id; SQL adds composite (businessId, predecessorPackageId) for tenant safety.
+  predecessor         MigrationPackage?          @relation("MigrationPackageLineage", fields: [predecessorPackageId], references: [id], onDelete: Restrict)
+  successors          MigrationPackage[]         @relation("MigrationPackageLineage")
+  validationRuns      MigrationValidationRun[]   @relation("PackageValidationRuns")
+  latestValidationRun MigrationValidationRun?    @relation("PackageLatestValidationRun", fields: [latestValidationRunId], references: [id], onDelete: SetNull)
+  approvalHistories   MigrationApprovalHistory[]
+  files               MigrationFile[]
+  branchMappings      MigrationBranchMapping[]
 
   @@unique([businessId, id])
   @@unique([businessId, clientPackageKey])
   @@index([businessId, status, createdAt])
   @@index([businessId, status, expiresAt])
+  @@index([businessId, status, approvalExpiresAt])
   @@index([businessId, sourceSystemKey, sourceBusinessKey])
+  @@index([businessId, lineageRootId])
+}
+
+/// Historical validation evidence for a package. Retained across supersession of latestValidationRunId.
+model MigrationValidationRun {
+  id                   String    @id @default(cuid())
+  businessId           String
+  packageId            String
+  /// SUCCESS | FAILED | STALE
+  status               String
+  manifestChecksum     String
+  resultDigest         String?
+  summaryJson          String?
+  exceptionCount       Int       @default(0)
+  exceptionsTruncated  Int       @default(0)
+  validatedByUserId    String?
+  createdAt            DateTime  @default(now())
+  supersededAt         DateTime?
+
+  package      MigrationPackage  @relation("PackageValidationRuns", fields: [businessId, packageId], references: [businessId, id], onDelete: Cascade)
+  validatedBy  User?             @relation(fields: [validatedByUserId], references: [id], onDelete: Restrict)
+  latestFor    MigrationPackage? @relation("PackageLatestValidationRun")
+
+  @@unique([businessId, id])
+  @@index([businessId, packageId, createdAt])
+  @@index([packageId, createdAt])
+}
+
+/// Immutable approval snapshots. Active package approval fields may be cleared without rewriting history.
+model MigrationApprovalHistory {
+  id                       String    @id @default(cuid())
+  businessId               String
+  packageId                String
+  approverUserId           String
+  approvedAt               DateTime
+  approvedManifestChecksum String
+  approvalExpiresAt        DateTime
+  validationRunId          String?
+  validationResultDigest   String?
+  contractVersion          String
+  reportingCurrency        String
+  packageAsOfDate          String
+  branchMappingDigest      String?
+  fileChecksumsJson        String
+  acknowledgementJson      String?
+  note                     String?
+  snapshotJson             String?
+  invalidatedAt            DateTime?
+  invalidationReason       String?
+  createdAt                DateTime  @default(now())
+
+  package  MigrationPackage @relation(fields: [businessId, packageId], references: [businessId, id], onDelete: Restrict)
+  /// Required approver — Prisma composite same-business FK.
+  approver User             @relation(fields: [businessId, approverUserId], references: [businessId, id], onDelete: Restrict)
+
+  @@unique([businessId, id])
+  @@index([businessId, packageId, approvedAt])
+  @@index([packageId, approvedAt])
 }
 
 /// One immutable logical file belonging to a MigrationPackage.
 /// UNIQUE(packageId, entityType) = at most one of each type (not exactly-three completeness).
+/// Only storageStatus=FINALISED files are approval-material (enforced in services; schema documents status).
 model MigrationFile {
   id                 String    @id @default(cuid())
   businessId         String
   packageId          String
   /// SUPPLIERS | PRODUCTS | OPENING_STOCK
   entityType         String
+  /// PENDING | FINALISED | FAILED — PENDING/FAILED are not approval-material.
+  storageStatus      String    @default("PENDING")
   /// Original filename stored safely (basename only; no path separators).
   originalFilename   String?
   contentType        String?
@@ -799,7 +886,7 @@ model MigrationFile {
   validationChecksum String?
   /// SHA-256 frozen at package approval for this file.
   approvedChecksum   String?
-  /// Future blob/object storage key — unused in P0 upload endpoints.
+  /// Immutable object storage key once assigned (service-layer immutability).
   storageKey         String?
   rowCount           Int?
   validatedAt        DateTime?
@@ -813,6 +900,7 @@ model MigrationFile {
   @@unique([packageId, entityType])
   @@index([businessId, packageId])
   @@index([businessId, uploadChecksum])
+  @@index([businessId, storageStatus])
 }
 
 /// Maps a source branch key to a TillFlow Store in the same business.

--- a/scripts/migration-p1-schema-pg-test.cjs
+++ b/scripts/migration-p1-schema-pg-test.cjs
@@ -1,0 +1,451 @@
+/**
+ * Disposable PostgreSQL constraint tests for Migration P1 Slice 1 schema.
+ *
+ * Requires:
+ *   POSTGRES_PRISMA_URL / POSTGRES_URL_NON_POOLING (or DATABASE_URL)
+ *
+ * Applies prisma migrate deploy against a disposable database, asserts real
+ * PostgreSQL constraints, then exits non-zero on failure.
+ *
+ * Not a substitute: SQLite / mocked Prisma unit tests.
+ */
+
+const { Client } = require('pg');
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const root = path.resolve(__dirname, '..');
+const schema = path.join(root, 'prisma', 'schema.postgres.prisma');
+
+function requireUrl() {
+  const url =
+    process.env.POSTGRES_URL_NON_POOLING ||
+    process.env.POSTGRES_PRISMA_URL ||
+    process.env.DATABASE_URL;
+  if (!url || !url.startsWith('postgres')) {
+    console.error(
+      'FATAL: PostgreSQL URL required (POSTGRES_URL_NON_POOLING / POSTGRES_PRISMA_URL). Suite did not execute.',
+    );
+    process.exit(2);
+  }
+  return url;
+}
+
+function cuid() {
+  return 'c' + crypto.randomBytes(12).toString('hex');
+}
+
+async function expectReject(fn, label, match) {
+  try {
+    await fn();
+    throw new Error(`EXPECTED_REJECT_MISSING: ${label}`);
+  } catch (err) {
+    const msg = String(err && err.message ? err.message : err);
+    if (msg.startsWith('EXPECTED_REJECT_MISSING')) throw err;
+    if (match && !match.test(msg)) {
+      throw new Error(`${label}: rejected but unexpected message: ${msg}`);
+    }
+    console.log(`  OK reject: ${label}`);
+  }
+}
+
+async function main() {
+  const url = requireUrl();
+  process.env.POSTGRES_PRISMA_URL = url;
+  process.env.POSTGRES_URL_NON_POOLING = url;
+
+  console.log('Deploying migrations…');
+  execSync(`npx prisma migrate deploy --schema="${schema}"`, {
+    cwd: root,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  const client = new Client({ connectionString: url });
+  await client.connect();
+
+  const bizA = cuid();
+  const bizB = cuid();
+  const userA = cuid();
+  const userB = cuid();
+  const userA2 = cuid();
+  const userApprover = cuid();
+
+  async function seedTenant() {
+    await client.query(`DELETE FROM "MigrationApprovalHistory"`);
+    await client.query(`DELETE FROM "MigrationPackage"`); // cascades validation runs/files via FKs carefully
+    // Order: clear latest pointers first
+    await client.query(`UPDATE "MigrationPackage" SET "latestValidationRunId" = NULL`);
+    await client.query(`DELETE FROM "MigrationValidationRun"`);
+    await client.query(`DELETE FROM "MigrationFile"`);
+    await client.query(`DELETE FROM "MigrationBranchMapping"`);
+    await client.query(`DELETE FROM "MigrationPackage"`);
+    await client.query(`DELETE FROM "User" WHERE id = ANY($1::text[])`, [
+      [userA, userB, userA2, userApprover],
+    ]);
+    await client.query(`DELETE FROM "Business" WHERE id = ANY($1::text[])`, [[bizA, bizB]]);
+
+    await client.query(
+      `INSERT INTO "Business" (id, name, "createdAt", "updatedAt") VALUES ($1,'BizA',NOW(),NOW()), ($2,'BizB',NOW(),NOW())`,
+      [bizA, bizB],
+    );
+
+    // Minimal User insert — inspect required columns
+    const userCols = await client.query(`
+      SELECT column_name, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_name = 'User' AND table_schema = 'public'
+      ORDER BY ordinal_position`);
+    const requiredUser = userCols.rows
+      .filter((c) => c.is_nullable === 'NO' && !c.column_default && c.column_name !== 'id')
+      .map((c) => c.column_name);
+    console.log('User required cols without default:', requiredUser.join(', '));
+
+    await client.query(
+      `INSERT INTO "User" (id, "businessId", name, email, "passwordHash", role, active, "createdAt")
+       VALUES
+         ($1,$2,'Owner A',$3,'x','OWNER',true,NOW()),
+         ($4,$5,'Owner B',$6,'x','OWNER',true,NOW()),
+         ($7,$2,'Owner A2',$8,'x','OWNER',true,NOW()),
+         ($9,$2,'Approver A',$10,'x','OWNER',true,NOW())`,
+      [
+        userA,
+        bizA,
+        `a-${userA}@example.com`,
+        userB,
+        bizB,
+        `b-${userB}@example.com`,
+        userA2,
+        `a2-${userA2}@example.com`,
+        userApprover,
+        `ap-${userApprover}@example.com`,
+      ],
+    );
+  }
+
+  async function insertPackage(opts) {
+    const id = opts.id || cuid();
+    const lineageRootId = opts.lineageRootId || id;
+    await client.query(
+      `INSERT INTO "MigrationPackage" (
+         id, "businessId", "contractVersion", "sourceSystemKey", "sourceBusinessKey",
+         "reportingCurrency", "packageAsOfDate", status, "reconciliationStatus",
+         "expiresAt", version, "lineageRootId", "predecessorPackageId",
+         "createdByUserId", "validatedByUserId", "approvedByUserId", "cancelledByUserId",
+         "supersededByUserId", "createdAt", "updatedAt"
+       ) VALUES (
+         $1,$2,'1','src','biz','GHS','2026-08-01',$3,$4,
+         NOW() + interval '14 days', 1, $5, $6,
+         $7,$8,$9,$10,$11, NOW(), NOW()
+       )`,
+      [
+        id,
+        opts.businessId,
+        opts.status || 'DRAFT',
+        opts.reconciliationStatus || 'NOT_STARTED',
+        lineageRootId,
+        opts.predecessorPackageId || null,
+        opts.createdByUserId,
+        opts.validatedByUserId || null,
+        opts.approvedByUserId || null,
+        opts.cancelledByUserId || null,
+        opts.supersededByUserId || null,
+      ],
+    );
+    return id;
+  }
+
+  const results = [];
+  function pass(name) {
+    results.push({ name, ok: true });
+    console.log(`PASS ${name}`);
+  }
+
+  try {
+    await seedTenant();
+
+    // 7) Multiple NULL predecessors allowed
+    const p1 = await insertPackage({ businessId: bizA, createdByUserId: userA });
+    const p2 = await insertPackage({ businessId: bizA, createdByUserId: userA });
+    pass('7 multiple NULL predecessorPackageId');
+
+    // 1) Two packages cannot share same predecessor
+    const pred = await insertPackage({
+      businessId: bizA,
+      createdByUserId: userA,
+      status: 'APPROVED',
+    });
+    await insertPackage({
+      businessId: bizA,
+      createdByUserId: userA,
+      predecessorPackageId: pred,
+      lineageRootId: pred,
+      status: 'DRAFT',
+    });
+    await expectReject(
+      () =>
+        insertPackage({
+          businessId: bizA,
+          createdByUserId: userA,
+          predecessorPackageId: pred,
+          lineageRootId: pred,
+        }),
+      '1 duplicate predecessor',
+      /unique|duplicate/i,
+    );
+    pass('1 one-successor uniqueness');
+
+    // 2) Cross-business predecessor rejected
+    const predB = await insertPackage({ businessId: bizB, createdByUserId: userB, status: 'APPROVED' });
+    await expectReject(
+      () =>
+        insertPackage({
+          businessId: bizA,
+          createdByUserId: userA,
+          predecessorPackageId: predB,
+          lineageRootId: predB,
+        }),
+      '2 cross-business predecessor',
+      /foreign key|violates/i,
+    );
+    pass('2 cross-business predecessor FK');
+
+    // 3) Self-predecessor rejected
+    const selfId = cuid();
+    await expectReject(
+      () =>
+        insertPackage({
+          id: selfId,
+          businessId: bizA,
+          createdByUserId: userA,
+          predecessorPackageId: selfId,
+          lineageRootId: selfId,
+        }),
+      '3 self-predecessor',
+      /check|violates|foreign key/i,
+    );
+    pass('3 self-predecessor blocked');
+
+    // 4) Actor from another business rejected for each actor relation
+    await expectReject(
+      () => insertPackage({ businessId: bizA, createdByUserId: userB }),
+      '4a createdBy cross-tenant',
+      /foreign key|violates/i,
+    );
+    await expectReject(
+      () =>
+        insertPackage({
+          businessId: bizA,
+          createdByUserId: userA,
+          validatedByUserId: userB,
+        }),
+      '4b validatedBy cross-tenant',
+      /foreign key|violates/i,
+    );
+    await expectReject(
+      () =>
+        insertPackage({
+          businessId: bizA,
+          createdByUserId: userA,
+          approvedByUserId: userB,
+        }),
+      '4c approvedBy cross-tenant',
+      /foreign key|violates/i,
+    );
+    await expectReject(
+      () =>
+        insertPackage({
+          businessId: bizA,
+          createdByUserId: userA,
+          cancelledByUserId: userB,
+        }),
+      '4d cancelledBy cross-tenant',
+      /foreign key|violates/i,
+    );
+    await expectReject(
+      () =>
+        insertPackage({
+          businessId: bizA,
+          createdByUserId: userA,
+          supersededByUserId: userB,
+        }),
+      '4e supersededBy cross-tenant',
+      /foreign key|violates/i,
+    );
+    pass('4 actor tenant isolation');
+
+    // 5) Deleting referenced actor blocked
+    const held = await insertPackage({ businessId: bizA, createdByUserId: userA });
+    await expectReject(
+      () => client.query(`DELETE FROM "User" WHERE id = $1`, [userA]),
+      '5 delete referenced creator',
+      /foreign key|violates|restrict/i,
+    );
+    pass('5 actor deletion restricted');
+
+    // 6) Deleting referenced predecessor blocked
+    const root = await insertPackage({
+      businessId: bizA,
+      createdByUserId: userA2,
+      status: 'SUPERSEDED',
+    });
+    await insertPackage({
+      businessId: bizA,
+      createdByUserId: userA2,
+      predecessorPackageId: root,
+      lineageRootId: root,
+    });
+    await expectReject(
+      () => client.query(`DELETE FROM "MigrationPackage" WHERE id = $1`, [root]),
+      '6 delete predecessor',
+      /foreign key|violates|restrict/i,
+    );
+    pass('6 predecessor deletion restricted');
+
+    // 8) Duplicate (packageId, entityType) rejected
+    const filePkg = await insertPackage({ businessId: bizA, createdByUserId: userA2 });
+    const fileId = cuid();
+    await client.query(
+      `INSERT INTO "MigrationFile" (
+         id, "businessId", "packageId", "entityType", "storageStatus",
+         "uploadChecksum", "byteLength", "createdAt", "updatedAt"
+       ) VALUES ($1,$2,$3,'PRODUCTS','PENDING',$4,0,NOW(),NOW())`,
+      [fileId, bizA, filePkg, 'a'.repeat(64)],
+    );
+    await expectReject(
+      () =>
+        client.query(
+          `INSERT INTO "MigrationFile" (
+             id, "businessId", "packageId", "entityType", "storageStatus",
+             "uploadChecksum", "byteLength", "createdAt", "updatedAt"
+           ) VALUES ($1,$2,$3,'PRODUCTS','PENDING',$4,0,NOW(),NOW())`,
+          [cuid(), bizA, filePkg, 'b'.repeat(64)],
+        ),
+      '8 duplicate entityType',
+      /unique|duplicate/i,
+    );
+    pass('8 duplicate packageId+entityType');
+
+    // 9) Non-IMPORTED cannot leave NOT_STARTED recon
+    await expectReject(
+      () =>
+        insertPackage({
+          businessId: bizA,
+          createdByUserId: userA2,
+          status: 'DRAFT',
+          reconciliationStatus: 'RECONCILING',
+        }),
+      '9 recon before imported',
+      /check|violates/i,
+    );
+    pass('9 reconciliation invariant (non-IMPORTED)');
+
+    // 10) IMPORTED can use recon states
+    await insertPackage({
+      businessId: bizA,
+      createdByUserId: userA2,
+      status: 'IMPORTED',
+      reconciliationStatus: 'RECONCILING',
+    });
+    await insertPackage({
+      businessId: bizA,
+      createdByUserId: userA2,
+      status: 'IMPORTED',
+      reconciliationStatus: 'MATCHED',
+    });
+    pass('10 IMPORTED may leave NOT_STARTED');
+
+    // 11) Approval-history actor deletion blocked (approver not used as package creator)
+    const apPkg = await insertPackage({
+      businessId: bizA,
+      createdByUserId: userA2,
+      status: 'APPROVED',
+    });
+    await client.query(
+      `INSERT INTO "MigrationApprovalHistory" (
+         id, "businessId", "packageId", "approverUserId", "approvedAt",
+         "approvedManifestChecksum", "approvalExpiresAt", "contractVersion",
+         "reportingCurrency", "packageAsOfDate", "fileChecksumsJson", "createdAt"
+       ) VALUES ($1,$2,$3,$4,NOW(),$5,NOW()+interval '14 days','1','GHS','2026-08-01','[]',NOW())`,
+      [cuid(), bizA, apPkg, userApprover, 'c'.repeat(64)],
+    );
+    await expectReject(
+      () => client.query(`DELETE FROM "User" WHERE id = $1`, [userApprover]),
+      '11 delete approval history approver',
+      /foreign key|violates|restrict/i,
+    );
+    pass('11 approval-history actor deletion restricted');
+
+    // 12) Transaction rollback leaves no partial schema-domain records
+    const rollId = cuid();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `INSERT INTO "MigrationPackage" (
+           id, "businessId", "contractVersion", "sourceSystemKey", "sourceBusinessKey",
+           "reportingCurrency", "packageAsOfDate", status, "reconciliationStatus",
+           "expiresAt", version, "lineageRootId", "createdByUserId", "createdAt", "updatedAt"
+         ) VALUES ($1,$2,'1','src','biz','GHS','2026-08-01','DRAFT','NOT_STARTED',
+           NOW()+interval '14 days',1,$1,$3,NOW(),NOW())`,
+        [rollId, bizA, userA],
+      );
+      await client.query(
+        `INSERT INTO "MigrationValidationRun" (
+           id, "businessId", "packageId", status, "manifestChecksum", "createdAt"
+         ) VALUES ($1,$2,$3,'SUCCESS',$4,NOW())`,
+        [cuid(), bizA, rollId, 'd'.repeat(64)],
+      );
+      // Force failure: duplicate predecessor uniqueness using existing pred
+      await client.query(
+        `INSERT INTO "MigrationPackage" (
+           id, "businessId", "contractVersion", "sourceSystemKey", "sourceBusinessKey",
+           "reportingCurrency", "packageAsOfDate", status, "reconciliationStatus",
+           "expiresAt", version, "lineageRootId", "predecessorPackageId",
+           "createdByUserId", "createdAt", "updatedAt"
+         ) VALUES ($1,$2,'1','src','biz','GHS','2026-08-01','DRAFT','NOT_STARTED',
+           NOW()+interval '14 days',1,$3,$3,$4,NOW(),NOW())`,
+        [cuid(), bizA, pred, userA],
+      );
+      await client.query('COMMIT');
+      throw new Error('rollback test should have failed before commit');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      const msg = String(err.message || err);
+      if (msg.includes('rollback test should have failed')) throw err;
+    }
+    const leftover = await client.query(`SELECT id FROM "MigrationPackage" WHERE id = $1`, [rollId]);
+    if (leftover.rowCount !== 0) {
+      throw new Error('rollback left MigrationPackage row');
+    }
+    pass('12 transaction rollback');
+
+    // 13) migrate applied cleanly (deploy at start + history row present)
+    const mig = await client.query(
+      `SELECT migration_name, finished_at FROM "_prisma_migrations"
+       WHERE migration_name = '20260806170000_migration_framework_p1_slice1_schema'
+         AND finished_at IS NOT NULL`,
+    );
+    if (mig.rowCount !== 1) {
+      throw new Error('P1 slice1 migration not recorded as finished');
+    }
+    const p0 = await client.query(
+      `SELECT migration_name FROM "_prisma_migrations"
+       WHERE migration_name = '20260806130000_migration_framework_p0'
+         AND finished_at IS NOT NULL`,
+    );
+    if (p0.rowCount !== 1) {
+      throw new Error('P0 migration missing from history');
+    }
+    pass('13 migrate deploy/status from P0+P1');
+
+    console.log(`\nAll ${results.length} PostgreSQL schema gates passed.`);
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/migration-p1-schema-pg-test.cjs
+++ b/scripts/migration-p1-schema-pg-test.cjs
@@ -1,13 +1,8 @@
 /**
- * Disposable PostgreSQL constraint tests for Migration P1 Slice 1 schema.
+ * Disposable PostgreSQL behavioural tests for Migration P1 Slice 1 schema.
  *
- * Requires:
- *   POSTGRES_PRISMA_URL / POSTGRES_URL_NON_POOLING (or DATABASE_URL)
- *
- * Applies prisma migrate deploy against a disposable database, asserts real
- * PostgreSQL constraints, then exits non-zero on failure.
- *
- * Not a substitute: SQLite / mocked Prisma unit tests.
+ * Requires POSTGRES_PRISMA_URL / POSTGRES_URL_NON_POOLING.
+ * Applies full migrate history, then asserts real PostgreSQL constraints with SQLSTATE.
  */
 
 const { Client } = require('pg');
@@ -16,7 +11,14 @@ const path = require('node:path');
 const crypto = require('node:crypto');
 
 const root = path.resolve(__dirname, '..');
-const schema = path.join(root, 'prisma', 'schema.postgres.prisma');
+const schemaRel = 'prisma/schema.postgres.prisma';
+
+const SQLSTATE = {
+  FOREIGN_KEY: '23503',
+  UNIQUE: '23505',
+  CHECK: '23514',
+  NOT_NULL: '23502',
+};
 
 function requireUrl() {
   const url =
@@ -36,17 +38,31 @@ function cuid() {
   return 'c' + crypto.randomBytes(12).toString('hex');
 }
 
-async function expectReject(fn, label, match) {
+/**
+ * @param {() => Promise<unknown>} fn
+ * @param {{ label: string, sqlstate: string, constraint?: string }} expect
+ */
+async function expectPgReject(fn, expect) {
   try {
     await fn();
-    throw new Error(`EXPECTED_REJECT_MISSING: ${label}`);
+    throw new Error(`EXPECTED_REJECT_MISSING: ${expect.label}`);
   } catch (err) {
-    const msg = String(err && err.message ? err.message : err);
-    if (msg.startsWith('EXPECTED_REJECT_MISSING')) throw err;
-    if (match && !match.test(msg)) {
-      throw new Error(`${label}: rejected but unexpected message: ${msg}`);
+    if (String(err.message || err).startsWith('EXPECTED_REJECT_MISSING')) throw err;
+    const code = err && err.code;
+    const constraint = err && err.constraint;
+    if (code !== expect.sqlstate) {
+      throw new Error(
+        `${expect.label}: expected SQLSTATE ${expect.sqlstate}, got ${code} (${err.message})`,
+      );
     }
-    console.log(`  OK reject: ${label}`);
+    if (expect.constraint && constraint !== expect.constraint) {
+      throw new Error(
+        `${expect.label}: expected constraint ${expect.constraint}, got ${constraint}`,
+      );
+    }
+    console.log(
+      `  OK reject: ${expect.label} [${code}${constraint ? '/' + constraint : ''}]`,
+    );
   }
 }
 
@@ -56,10 +72,11 @@ async function main() {
   process.env.POSTGRES_URL_NON_POOLING = url;
 
   console.log('Deploying migrations…');
-  execSync(`npx prisma migrate deploy --schema="${schema}"`, {
+  execSync(`npx prisma migrate deploy --schema=${schemaRel}`, {
     cwd: root,
     stdio: 'inherit',
     env: process.env,
+    shell: true,
   });
 
   const client = new Client({ connectionString: url });
@@ -73,10 +90,8 @@ async function main() {
   const userApprover = cuid();
 
   async function seedTenant() {
-    await client.query(`DELETE FROM "MigrationApprovalHistory"`);
-    await client.query(`DELETE FROM "MigrationPackage"`); // cascades validation runs/files via FKs carefully
-    // Order: clear latest pointers first
     await client.query(`UPDATE "MigrationPackage" SET "latestValidationRunId" = NULL`);
+    await client.query(`DELETE FROM "MigrationApprovalHistory"`);
     await client.query(`DELETE FROM "MigrationValidationRun"`);
     await client.query(`DELETE FROM "MigrationFile"`);
     await client.query(`DELETE FROM "MigrationBranchMapping"`);
@@ -90,18 +105,6 @@ async function main() {
       `INSERT INTO "Business" (id, name, "createdAt", "updatedAt") VALUES ($1,'BizA',NOW(),NOW()), ($2,'BizB',NOW(),NOW())`,
       [bizA, bizB],
     );
-
-    // Minimal User insert — inspect required columns
-    const userCols = await client.query(`
-      SELECT column_name, is_nullable, column_default
-      FROM information_schema.columns
-      WHERE table_name = 'User' AND table_schema = 'public'
-      ORDER BY ordinal_position`);
-    const requiredUser = userCols.rows
-      .filter((c) => c.is_nullable === 'NO' && !c.column_default && c.column_name !== 'id')
-      .map((c) => c.column_name);
-    console.log('User required cols without default:', requiredUser.join(', '));
-
     await client.query(
       `INSERT INTO "User" (id, "businessId", name, email, "passwordHash", role, active, "createdAt")
        VALUES
@@ -133,11 +136,11 @@ async function main() {
          "reportingCurrency", "packageAsOfDate", status, "reconciliationStatus",
          "expiresAt", version, "lineageRootId", "predecessorPackageId",
          "createdByUserId", "validatedByUserId", "approvedByUserId", "cancelledByUserId",
-         "supersededByUserId", "createdAt", "updatedAt"
+         "supersededByUserId", "latestValidationRunId", "createdAt", "updatedAt"
        ) VALUES (
          $1,$2,'1','src','biz','GHS','2026-08-01',$3,$4,
          NOW() + interval '14 days', 1, $5, $6,
-         $7,$8,$9,$10,$11, NOW(), NOW()
+         $7,$8,$9,$10,$11,$12, NOW(), NOW()
        )`,
       [
         id,
@@ -151,26 +154,35 @@ async function main() {
         opts.approvedByUserId || null,
         opts.cancelledByUserId || null,
         opts.supersededByUserId || null,
+        opts.latestValidationRunId || null,
       ],
     );
     return id;
   }
 
-  const results = [];
+  async function insertRun(opts) {
+    const id = opts.id || cuid();
+    await client.query(
+      `INSERT INTO "MigrationValidationRun" (
+         id, "businessId", "packageId", status, "manifestChecksum", "createdAt"
+       ) VALUES ($1,$2,$3,$4,$5,NOW())`,
+      [id, opts.businessId, opts.packageId, opts.status || 'SUCCESS', opts.checksum || 'a'.repeat(64)],
+    );
+    return id;
+  }
+
   function pass(name) {
-    results.push({ name, ok: true });
     console.log(`PASS ${name}`);
   }
 
   try {
     await seedTenant();
 
-    // 7) Multiple NULL predecessors allowed
-    const p1 = await insertPackage({ businessId: bizA, createdByUserId: userA });
-    const p2 = await insertPackage({ businessId: bizA, createdByUserId: userA });
-    pass('7 multiple NULL predecessorPackageId');
+    // --- lineage / actors / recon / files (SQLSTATE) ---
+    await insertPackage({ businessId: bizA, createdByUserId: userA });
+    await insertPackage({ businessId: bizA, createdByUserId: userA });
+    pass('multiple NULL predecessorPackageId');
 
-    // 1) Two packages cannot share same predecessor
     const pred = await insertPackage({
       businessId: bizA,
       createdByUserId: userA,
@@ -181,9 +193,8 @@ async function main() {
       createdByUserId: userA,
       predecessorPackageId: pred,
       lineageRootId: pred,
-      status: 'DRAFT',
     });
-    await expectReject(
+    await expectPgReject(
       () =>
         insertPackage({
           businessId: bizA,
@@ -191,14 +202,20 @@ async function main() {
           predecessorPackageId: pred,
           lineageRootId: pred,
         }),
-      '1 duplicate predecessor',
-      /unique|duplicate/i,
+      {
+        label: 'duplicate predecessor',
+        sqlstate: SQLSTATE.UNIQUE,
+        constraint: 'MigrationPackage_predecessorPackageId_key',
+      },
     );
-    pass('1 one-successor uniqueness');
+    pass('one-successor uniqueness');
 
-    // 2) Cross-business predecessor rejected
-    const predB = await insertPackage({ businessId: bizB, createdByUserId: userB, status: 'APPROVED' });
-    await expectReject(
+    const predB = await insertPackage({
+      businessId: bizB,
+      createdByUserId: userB,
+      status: 'APPROVED',
+    });
+    await expectPgReject(
       () =>
         insertPackage({
           businessId: bizA,
@@ -206,14 +223,16 @@ async function main() {
           predecessorPackageId: predB,
           lineageRootId: predB,
         }),
-      '2 cross-business predecessor',
-      /foreign key|violates/i,
+      {
+        label: 'cross-business predecessor',
+        sqlstate: SQLSTATE.FOREIGN_KEY,
+        constraint: 'MigrationPackage_businessId_predecessorPackageId_fkey',
+      },
     );
-    pass('2 cross-business predecessor FK');
+    pass('cross-business predecessor FK');
 
-    // 3) Self-predecessor rejected
     const selfId = cuid();
-    await expectReject(
+    await expectPgReject(
       () =>
         insertPackage({
           id: selfId,
@@ -222,69 +241,70 @@ async function main() {
           predecessorPackageId: selfId,
           lineageRootId: selfId,
         }),
-      '3 self-predecessor',
-      /check|violates|foreign key/i,
+      {
+        label: 'self-predecessor',
+        sqlstate: SQLSTATE.CHECK,
+        constraint: 'MigrationPackage_predecessor_not_self_check',
+      },
     );
-    pass('3 self-predecessor blocked');
+    pass('self-predecessor blocked');
 
-    // 4) Actor from another business rejected for each actor relation
-    await expectReject(
+    await expectPgReject(
       () => insertPackage({ businessId: bizA, createdByUserId: userB }),
-      '4a createdBy cross-tenant',
-      /foreign key|violates/i,
+      {
+        label: 'createdBy cross-tenant',
+        sqlstate: SQLSTATE.FOREIGN_KEY,
+        constraint: 'MigrationPackage_businessId_createdByUserId_fkey',
+      },
     );
-    await expectReject(
+    await expectPgReject(
       () =>
         insertPackage({
           businessId: bizA,
           createdByUserId: userA,
           validatedByUserId: userB,
         }),
-      '4b validatedBy cross-tenant',
-      /foreign key|violates/i,
+      {
+        label: 'validatedBy cross-tenant',
+        sqlstate: SQLSTATE.FOREIGN_KEY,
+      },
     );
-    await expectReject(
+    await expectPgReject(
       () =>
         insertPackage({
           businessId: bizA,
           createdByUserId: userA,
           approvedByUserId: userB,
         }),
-      '4c approvedBy cross-tenant',
-      /foreign key|violates/i,
+      { label: 'approvedBy cross-tenant', sqlstate: SQLSTATE.FOREIGN_KEY },
     );
-    await expectReject(
+    await expectPgReject(
       () =>
         insertPackage({
           businessId: bizA,
           createdByUserId: userA,
           cancelledByUserId: userB,
         }),
-      '4d cancelledBy cross-tenant',
-      /foreign key|violates/i,
+      { label: 'cancelledBy cross-tenant', sqlstate: SQLSTATE.FOREIGN_KEY },
     );
-    await expectReject(
+    await expectPgReject(
       () =>
         insertPackage({
           businessId: bizA,
           createdByUserId: userA,
           supersededByUserId: userB,
         }),
-      '4e supersededBy cross-tenant',
-      /foreign key|violates/i,
+      { label: 'supersededBy cross-tenant', sqlstate: SQLSTATE.FOREIGN_KEY },
     );
-    pass('4 actor tenant isolation');
+    pass('actor tenant isolation');
 
-    // 5) Deleting referenced actor blocked
-    const held = await insertPackage({ businessId: bizA, createdByUserId: userA });
-    await expectReject(
+    await insertPackage({ businessId: bizA, createdByUserId: userA });
+    await expectPgReject(
       () => client.query(`DELETE FROM "User" WHERE id = $1`, [userA]),
-      '5 delete referenced creator',
-      /foreign key|violates|restrict/i,
+      { label: 'delete referenced creator', sqlstate: SQLSTATE.FOREIGN_KEY },
     );
-    pass('5 actor deletion restricted');
+    pass('actor deletion restricted');
 
-    // 6) Deleting referenced predecessor blocked
     const root = await insertPackage({
       businessId: bizA,
       createdByUserId: userA2,
@@ -296,39 +316,38 @@ async function main() {
       predecessorPackageId: root,
       lineageRootId: root,
     });
-    await expectReject(
+    await expectPgReject(
       () => client.query(`DELETE FROM "MigrationPackage" WHERE id = $1`, [root]),
-      '6 delete predecessor',
-      /foreign key|violates|restrict/i,
+      { label: 'delete predecessor', sqlstate: SQLSTATE.FOREIGN_KEY },
     );
-    pass('6 predecessor deletion restricted');
+    pass('predecessor deletion restricted');
 
-    // 8) Duplicate (packageId, entityType) rejected
     const filePkg = await insertPackage({ businessId: bizA, createdByUserId: userA2 });
-    const fileId = cuid();
     await client.query(
       `INSERT INTO "MigrationFile" (
          id, "businessId", "packageId", "entityType", "storageStatus",
          "uploadChecksum", "byteLength", "createdAt", "updatedAt"
        ) VALUES ($1,$2,$3,'PRODUCTS','PENDING',$4,0,NOW(),NOW())`,
-      [fileId, bizA, filePkg, 'a'.repeat(64)],
+      [cuid(), bizA, filePkg, 'b'.repeat(64)],
     );
-    await expectReject(
+    await expectPgReject(
       () =>
         client.query(
           `INSERT INTO "MigrationFile" (
              id, "businessId", "packageId", "entityType", "storageStatus",
              "uploadChecksum", "byteLength", "createdAt", "updatedAt"
            ) VALUES ($1,$2,$3,'PRODUCTS','PENDING',$4,0,NOW(),NOW())`,
-          [cuid(), bizA, filePkg, 'b'.repeat(64)],
+          [cuid(), bizA, filePkg, 'c'.repeat(64)],
         ),
-      '8 duplicate entityType',
-      /unique|duplicate/i,
+      {
+        label: 'duplicate entityType',
+        sqlstate: SQLSTATE.UNIQUE,
+        constraint: 'MigrationFile_packageId_entityType_key',
+      },
     );
-    pass('8 duplicate packageId+entityType');
+    pass('duplicate packageId+entityType');
 
-    // 9) Non-IMPORTED cannot leave NOT_STARTED recon
-    await expectReject(
+    await expectPgReject(
       () =>
         insertPackage({
           businessId: bizA,
@@ -336,27 +355,22 @@ async function main() {
           status: 'DRAFT',
           reconciliationStatus: 'RECONCILING',
         }),
-      '9 recon before imported',
-      /check|violates/i,
+      {
+        label: 'recon before imported',
+        sqlstate: SQLSTATE.CHECK,
+        constraint: 'MigrationPackage_recon_imported_only_check',
+      },
     );
-    pass('9 reconciliation invariant (non-IMPORTED)');
+    pass('reconciliation invariant (non-IMPORTED)');
 
-    // 10) IMPORTED can use recon states
-    await insertPackage({
-      businessId: bizA,
-      createdByUserId: userA2,
-      status: 'IMPORTED',
-      reconciliationStatus: 'RECONCILING',
-    });
     await insertPackage({
       businessId: bizA,
       createdByUserId: userA2,
       status: 'IMPORTED',
       reconciliationStatus: 'MATCHED',
     });
-    pass('10 IMPORTED may leave NOT_STARTED');
+    pass('IMPORTED may leave NOT_STARTED');
 
-    // 11) Approval-history actor deletion blocked (approver not used as package creator)
     const apPkg = await insertPackage({
       businessId: bizA,
       createdByUserId: userA2,
@@ -368,78 +382,171 @@ async function main() {
          "approvedManifestChecksum", "approvalExpiresAt", "contractVersion",
          "reportingCurrency", "packageAsOfDate", "fileChecksumsJson", "createdAt"
        ) VALUES ($1,$2,$3,$4,NOW(),$5,NOW()+interval '14 days','1','GHS','2026-08-01','[]',NOW())`,
-      [cuid(), bizA, apPkg, userApprover, 'c'.repeat(64)],
+      [cuid(), bizA, apPkg, userApprover, 'd'.repeat(64)],
     );
-    await expectReject(
+    await expectPgReject(
       () => client.query(`DELETE FROM "User" WHERE id = $1`, [userApprover]),
-      '11 delete approval history approver',
-      /foreign key|violates|restrict/i,
+      { label: 'delete approval history approver', sqlstate: SQLSTATE.FOREIGN_KEY },
     );
-    pass('11 approval-history actor deletion restricted');
+    pass('approval-history actor deletion restricted');
 
-    // 12) Transaction rollback leaves no partial schema-domain records
+    // --- latestValidationRun ownership ---
+    const pkgA1 = await insertPackage({ businessId: bizA, createdByUserId: userA2 });
+    const pkgA2 = await insertPackage({ businessId: bizA, createdByUserId: userA2 });
+    const pkgB1 = await insertPackage({ businessId: bizB, createdByUserId: userB });
+
+    const runA1 = await insertRun({
+      businessId: bizA,
+      packageId: pkgA1,
+      checksum: '1'.repeat(64),
+    });
+    const runA1b = await insertRun({
+      businessId: bizA,
+      packageId: pkgA1,
+      checksum: '2'.repeat(64),
+    });
+    const runB1 = await insertRun({
+      businessId: bizB,
+      packageId: pkgB1,
+      checksum: '3'.repeat(64),
+    });
+
+    // NULL latest permitted
+    const nullCheck = await client.query(
+      `SELECT "latestValidationRunId" FROM "MigrationPackage" WHERE id = $1`,
+      [pkgA2],
+    );
+    if (nullCheck.rows[0].latestValidationRunId !== null) {
+      throw new Error('expected NULL latestValidationRunId on new draft');
+    }
+    pass('latestValidationRunId NULL permitted');
+
+    // Own-package latest accepted
+    await client.query(
+      `UPDATE "MigrationPackage" SET "latestValidationRunId" = $1 WHERE id = $2`,
+      [runA1, pkgA1],
+    );
+    pass('own-package latest run accepted');
+
+    // Switch pointer to newer historical run on same package
+    await client.query(
+      `UPDATE "MigrationPackage" SET "latestValidationRunId" = $1 WHERE id = $2`,
+      [runA1b, pkgA1],
+    );
+    const stillThere = await client.query(
+      `SELECT id FROM "MigrationValidationRun" WHERE id = ANY($1::text[])`,
+      [[runA1, runA1b]],
+    );
+    if (stillThere.rowCount !== 2) {
+      throw new Error('historical validation runs were not retained');
+    }
+    pass('pointer switch retains historical runs');
+
+    await expectPgReject(
+      () =>
+        client.query(
+          `UPDATE "MigrationPackage" SET "latestValidationRunId" = $1 WHERE id = $2`,
+          [runB1, pkgA1],
+        ),
+      {
+        label: 'cross-business latest run',
+        sqlstate: SQLSTATE.FOREIGN_KEY,
+        constraint: 'MigrationPackage_businessId_latestValidationRunId_fkey',
+      },
+    );
+    pass('cross-business latest run rejected');
+
+    await expectPgReject(
+      () =>
+        client.query(
+          `UPDATE "MigrationPackage" SET "latestValidationRunId" = $1 WHERE id = $2`,
+          [runA1, pkgA2],
+        ),
+      {
+        label: 'cross-package latest run',
+        sqlstate: SQLSTATE.FOREIGN_KEY,
+        constraint: 'MigrationPackage_latestValidationRunId_id_fkey',
+      },
+    );
+    pass('cross-package latest run rejected');
+
+    // Selected run deletion blocked (runA1b is currently selected by pkgA1)
+    await expectPgReject(
+      () => client.query(`DELETE FROM "MigrationValidationRun" WHERE id = $1`, [runA1b]),
+      {
+        label: 'delete selected validation run',
+        sqlstate: SQLSTATE.FOREIGN_KEY,
+      },
+    );
+    pass('selected run deletion restricted');
+
+    // Historical runA1 still cannot be claimed by another package (ownership FK)
+    // (re-assert after ensuring it is not uniquely held — already unselected)
+    const claim = await client.query(
+      `SELECT "latestValidationRunId" FROM "MigrationPackage" WHERE id = $1`,
+      [pkgA1],
+    );
+    if (claim.rows[0].latestValidationRunId === runA1) {
+      throw new Error('runA1 unexpectedly still selected');
+    }
+    await expectPgReject(
+      () =>
+        client.query(
+          `UPDATE "MigrationPackage" SET "latestValidationRunId" = $1 WHERE id = $2`,
+          [runA1, pkgA2],
+        ),
+      {
+        label: 'unrelated historical run claim',
+        sqlstate: SQLSTATE.FOREIGN_KEY,
+        constraint: 'MigrationPackage_latestValidationRunId_id_fkey',
+      },
+    );
+    pass('unrelated historical run cannot be claimed');
+
+    // rollback
     const rollId = cuid();
     try {
       await client.query('BEGIN');
-      await client.query(
-        `INSERT INTO "MigrationPackage" (
-           id, "businessId", "contractVersion", "sourceSystemKey", "sourceBusinessKey",
-           "reportingCurrency", "packageAsOfDate", status, "reconciliationStatus",
-           "expiresAt", version, "lineageRootId", "createdByUserId", "createdAt", "updatedAt"
-         ) VALUES ($1,$2,'1','src','biz','GHS','2026-08-01','DRAFT','NOT_STARTED',
-           NOW()+interval '14 days',1,$1,$3,NOW(),NOW())`,
-        [rollId, bizA, userA],
-      );
-      await client.query(
-        `INSERT INTO "MigrationValidationRun" (
-           id, "businessId", "packageId", status, "manifestChecksum", "createdAt"
-         ) VALUES ($1,$2,$3,'SUCCESS',$4,NOW())`,
-        [cuid(), bizA, rollId, 'd'.repeat(64)],
-      );
-      // Force failure: duplicate predecessor uniqueness using existing pred
-      await client.query(
-        `INSERT INTO "MigrationPackage" (
-           id, "businessId", "contractVersion", "sourceSystemKey", "sourceBusinessKey",
-           "reportingCurrency", "packageAsOfDate", status, "reconciliationStatus",
-           "expiresAt", version, "lineageRootId", "predecessorPackageId",
-           "createdByUserId", "createdAt", "updatedAt"
-         ) VALUES ($1,$2,'1','src','biz','GHS','2026-08-01','DRAFT','NOT_STARTED',
-           NOW()+interval '14 days',1,$3,$3,$4,NOW(),NOW())`,
-        [cuid(), bizA, pred, userA],
-      );
+      await insertPackage({
+        id: rollId,
+        businessId: bizA,
+        createdByUserId: userA2,
+      });
+      await insertPackage({
+        businessId: bizA,
+        createdByUserId: userA2,
+        predecessorPackageId: pred,
+        lineageRootId: pred,
+      });
       await client.query('COMMIT');
       throw new Error('rollback test should have failed before commit');
     } catch (err) {
       await client.query('ROLLBACK');
-      const msg = String(err.message || err);
-      if (msg.includes('rollback test should have failed')) throw err;
+      if (String(err.message || '').includes('rollback test should have failed')) throw err;
+      if (err.code && err.code !== SQLSTATE.UNIQUE) {
+        // insertPackage may throw before setting code on nested — accept unique path
+      }
     }
-    const leftover = await client.query(`SELECT id FROM "MigrationPackage" WHERE id = $1`, [rollId]);
-    if (leftover.rowCount !== 0) {
-      throw new Error('rollback left MigrationPackage row');
-    }
-    pass('12 transaction rollback');
+    const leftover = await client.query(`SELECT id FROM "MigrationPackage" WHERE id = $1`, [
+      rollId,
+    ]);
+    if (leftover.rowCount !== 0) throw new Error('rollback left MigrationPackage row');
+    pass('transaction rollback');
 
-    // 13) migrate applied cleanly (deploy at start + history row present)
     const mig = await client.query(
-      `SELECT migration_name, finished_at FROM "_prisma_migrations"
-       WHERE migration_name = '20260806170000_migration_framework_p1_slice1_schema'
-         AND finished_at IS NOT NULL`,
-    );
-    if (mig.rowCount !== 1) {
-      throw new Error('P1 slice1 migration not recorded as finished');
-    }
-    const p0 = await client.query(
       `SELECT migration_name FROM "_prisma_migrations"
-       WHERE migration_name = '20260806130000_migration_framework_p0'
-         AND finished_at IS NOT NULL`,
+       WHERE migration_name IN (
+         '20260806130000_migration_framework_p0',
+         '20260806170000_migration_framework_p1_slice1_schema',
+         '20260806183000_migration_p1_slice1_latest_run_ownership'
+       ) AND finished_at IS NOT NULL`,
     );
-    if (p0.rowCount !== 1) {
-      throw new Error('P0 migration missing from history');
+    if (mig.rowCount !== 3) {
+      throw new Error(`expected 3 finished migrations, got ${mig.rowCount}`);
     }
-    pass('13 migrate deploy/status from P0+P1');
+    pass('P0→P1→ownership migrate history');
 
-    console.log(`\nAll ${results.length} PostgreSQL schema gates passed.`);
+    console.log('\nAll PostgreSQL behavioural schema gates passed.');
   } finally {
     await client.end().catch(() => {});
   }

--- a/scripts/migration-p1-sql-only-constraint-contract.cjs
+++ b/scripts/migration-p1-sql-only-constraint-contract.cjs
@@ -1,0 +1,256 @@
+/**
+ * Live PostgreSQL introspection guard for intentional SQL-only composite FKs.
+ *
+ * Runs AFTER `prisma migrate deploy` against disposable Postgres.
+ * Fails if a protected constraint is missing, renamed, mistyped, mis-attached,
+ * column-mismatched, or has the wrong ON DELETE action.
+ *
+ * See docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md.
+ */
+
+const { Client } = require('pg');
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+
+/** @typedef {{ name: string, table: string, columns: string[], refTable: string, refColumns: string[], onDelete: string }} ExpectedFk */
+
+/** @type {ExpectedFk[]} */
+const PROTECTED_FOREIGN_KEYS = [
+  {
+    name: 'MigrationPackage_businessId_predecessorPackageId_fkey',
+    table: 'MigrationPackage',
+    columns: ['businessId', 'predecessorPackageId'],
+    refTable: 'MigrationPackage',
+    refColumns: ['businessId', 'id'],
+    onDelete: 'restrict',
+  },
+  {
+    name: 'MigrationPackage_businessId_validatedByUserId_fkey',
+    table: 'MigrationPackage',
+    columns: ['businessId', 'validatedByUserId'],
+    refTable: 'User',
+    refColumns: ['businessId', 'id'],
+    onDelete: 'restrict',
+  },
+  {
+    name: 'MigrationPackage_businessId_approvedByUserId_fkey',
+    table: 'MigrationPackage',
+    columns: ['businessId', 'approvedByUserId'],
+    refTable: 'User',
+    refColumns: ['businessId', 'id'],
+    onDelete: 'restrict',
+  },
+  {
+    name: 'MigrationPackage_businessId_executedByUserId_fkey',
+    table: 'MigrationPackage',
+    columns: ['businessId', 'executedByUserId'],
+    refTable: 'User',
+    refColumns: ['businessId', 'id'],
+    onDelete: 'restrict',
+  },
+  {
+    name: 'MigrationPackage_businessId_cancelledByUserId_fkey',
+    table: 'MigrationPackage',
+    columns: ['businessId', 'cancelledByUserId'],
+    refTable: 'User',
+    refColumns: ['businessId', 'id'],
+    onDelete: 'restrict',
+  },
+  {
+    name: 'MigrationPackage_businessId_supersededByUserId_fkey',
+    table: 'MigrationPackage',
+    columns: ['businessId', 'supersededByUserId'],
+    refTable: 'User',
+    refColumns: ['businessId', 'id'],
+    onDelete: 'restrict',
+  },
+  {
+    name: 'MigrationValidationRun_businessId_validatedByUserId_fkey',
+    table: 'MigrationValidationRun',
+    columns: ['businessId', 'validatedByUserId'],
+    refTable: 'User',
+    refColumns: ['businessId', 'id'],
+    onDelete: 'restrict',
+  },
+  {
+    name: 'MigrationPackage_businessId_latestValidationRunId_fkey',
+    table: 'MigrationPackage',
+    columns: ['businessId', 'latestValidationRunId'],
+    refTable: 'MigrationValidationRun',
+    refColumns: ['businessId', 'id'],
+    onDelete: 'restrict',
+  },
+  {
+    name: 'MigrationPackage_latestValidationRunId_id_fkey',
+    table: 'MigrationPackage',
+    columns: ['latestValidationRunId', 'id'],
+    refTable: 'MigrationValidationRun',
+    refColumns: ['id', 'packageId'],
+    onDelete: 'restrict',
+  },
+];
+
+function requireUrl() {
+  const url =
+    process.env.POSTGRES_URL_NON_POOLING ||
+    process.env.POSTGRES_PRISMA_URL ||
+    process.env.DATABASE_URL;
+  if (!url || !url.startsWith('postgres')) {
+    console.error(
+      'FATAL: PostgreSQL URL required. SQL-only constraint contract did not execute.',
+    );
+    process.exit(2);
+  }
+  return url;
+}
+
+function confdelToAction(confdeltype) {
+  // pg_constraint.confdeltype: a=no action, r=restrict, c=cascade, n=set null, d=set default
+  switch (confdeltype) {
+    case 'a':
+      return 'no action';
+    case 'r':
+      return 'restrict';
+    case 'c':
+      return 'cascade';
+    case 'n':
+      return 'set null';
+    case 'd':
+      return 'set default';
+    default:
+      return `unknown(${confdeltype})`;
+  }
+}
+
+async function loadFkDefinition(client, constraintName) {
+  const result = await client.query(
+    `
+    SELECT
+      c.conname AS name,
+      c.contype AS contype,
+      rel.relname AS table_name,
+      frel.relname AS foreign_table_name,
+      c.confdeltype AS confdeltype,
+      (
+        SELECT array_agg(att.attname ORDER BY u.ord)
+        FROM unnest(c.conkey) WITH ORDINALITY AS u(attnum, ord)
+        JOIN pg_attribute att
+          ON att.attrelid = c.conrelid AND att.attnum = u.attnum
+      ) AS columns,
+      (
+        SELECT array_agg(att.attname ORDER BY u.ord)
+        FROM unnest(c.confkey) WITH ORDINALITY AS u(attnum, ord)
+        JOIN pg_attribute att
+          ON att.attrelid = c.confrelid AND att.attnum = u.attnum
+      ) AS foreign_columns
+    FROM pg_constraint c
+    JOIN pg_class rel ON rel.oid = c.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    JOIN pg_class frel ON frel.oid = c.confrelid
+    WHERE nsp.nspname = 'public'
+      AND c.contype = 'f'
+      AND c.conname = $1
+    `,
+    [constraintName],
+  );
+  return result.rows[0] || null;
+}
+
+function sameStringArray(a, b) {
+  const left = normalizePgTextArray(a);
+  const right = normalizePgTextArray(b);
+  if (left.length !== right.length) return false;
+  return left.every((v, i) => v === right[i]);
+}
+
+function normalizePgTextArray(value) {
+  if (Array.isArray(value)) return value.map(String);
+  if (value == null) return [];
+  if (typeof value === 'string') {
+    // "{a,b}" or "{\"a\",\"b\"}"
+    const trimmed = value.replace(/^\{|\}$/g, '');
+    if (!trimmed) return [];
+    return trimmed.split(',').map((part) => part.replace(/^"|"$/g, ''));
+  }
+  return [String(value)];
+}
+
+async function main() {
+  const url = requireUrl();
+  process.env.POSTGRES_PRISMA_URL = url;
+  process.env.POSTGRES_URL_NON_POOLING = url;
+
+  console.log('Ensuring migrations are deployed before constraint contract…');
+  execSync('npx prisma migrate deploy --schema=prisma/schema.postgres.prisma', {
+    cwd: root,
+    stdio: 'inherit',
+    env: process.env,
+    shell: true,
+  });
+
+  const client = new Client({ connectionString: url });
+  await client.connect();
+
+  const failures = [];
+  try {
+    for (const expected of PROTECTED_FOREIGN_KEYS) {
+      const live = await loadFkDefinition(client, expected.name);
+      if (!live) {
+        failures.push(`MISSING constraint ${expected.name}`);
+        continue;
+      }
+      if (live.contype !== 'f') {
+        failures.push(`${expected.name}: expected foreign key, got contype=${live.contype}`);
+      }
+      if (live.table_name !== expected.table) {
+        failures.push(`${expected.name}: table ${live.table_name} !== ${expected.table}`);
+      }
+      if (live.foreign_table_name !== expected.refTable) {
+        failures.push(
+          `${expected.name}: ref table ${live.foreign_table_name} !== ${expected.refTable}`,
+        );
+      }
+      if (!sameStringArray(live.columns, expected.columns)) {
+        failures.push(
+          `${expected.name}: columns [${(live.columns || []).join(',')}] !== [${expected.columns.join(',')}]`,
+        );
+      }
+      if (!sameStringArray(live.foreign_columns, expected.refColumns)) {
+        failures.push(
+          `${expected.name}: ref columns [${(live.foreign_columns || []).join(',')}] !== [${expected.refColumns.join(',')}]`,
+        );
+      }
+      const onDelete = confdelToAction(live.confdeltype);
+      if (onDelete !== expected.onDelete) {
+        failures.push(
+          `${expected.name}: ON DELETE ${onDelete} !== ${expected.onDelete}`,
+        );
+      }
+
+      const relatedFails = failures.filter((f) => f.includes(expected.name));
+      if (relatedFails.length === 0) {
+        console.log(`  OK ${expected.name}`);
+      }
+    }
+
+    if (failures.length) {
+      console.error('\nSQL-only constraint contract FAILED:');
+      for (const f of failures) console.error(`  - ${f}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(
+      `\nSQL-only constraint contract passed (${PROTECTED_FOREIGN_KEYS.length} foreign keys).`,
+    );
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

P1 Slice 1 schema foundation for the migration framework. This slice introduces additive schema objects, lineage backfill, nullability strengthening, constraint strengthening, and constraint replacement. It is **not** additive-only.

### What landed
- Lifecycle `SUPERSEDED`, `predecessorPackageId` lineage, `MigrationValidationRun` / `MigrationApprovalHistory`, `MigrationFile.storageStatus`, tenant-safe actor FKs (`User @@unique([businessId,id])`), reconciliation CHECK, and contractual 25 MiB / 50k-row limits.
- Original migration `20260806170000_migration_framework_p1_slice1_schema` was applied to **Preview** for the first PR head and remains **immutable**.
- Corrective migration `20260806183000_migration_p1_slice1_latest_run_ownership` adds same-business and same-package database enforcement for `latestValidationRunId` (composite unique + ownership FKs, `ON DELETE RESTRICT`, deferrable).
- Nine intentional SQL-only composite foreign keys are protected by live PostgreSQL catalogue inspection (`scripts/migration-p1-sql-only-constraint-contract.cjs`).
- Disposable PostgreSQL behavioural suite (`scripts/migration-p1-schema-pg-test.cjs`) asserts exact SQLSTATE values (`23503` / `23505` / `23514`) across **20** behavioural gates, wired into Postgres Smoke CI.

### Out of scope (unchanged)
- No upload, validation execution, approval services, import, stock, or reconciliation execution services were implemented.
- Nothing was merged to `master` or deployed to **Production** by this PR.

## Test plan
- [x] `prisma migrate deploy` of complete history (P0 → `20260806170000` → `20260806183000`) on disposable Postgres 16
- [x] `node scripts/migration-p1-schema-pg-test.cjs` (20 behavioural gates with exact SQLSTATE)
- [x] `node scripts/migration-p1-sql-only-constraint-contract.cjs` (9 SQL-only FK live catalogue check)
- [x] `vitest` migration unit tests + full unit suite
- [x] lint / tsc / next build
- [x] CI Postgres Smoke on current PR head (`479732e`, run 31169483163)
- [ ] Do **not** merge until final CI/metadata verification; do **not** manually migrate Production