### PR TITLE
Migration P1 Slice 2B: source-neutral validation

### DIFF
--- a/.github/workflows/postgres-smoke.yml
+++ b/.github/workflows/postgres-smoke.yml
@@ -9,11 +9,13 @@ on:
       - 'package-lock.json'
       - 'scripts/migration-p1-schema-pg-test.cjs'
       - 'scripts/migration-p1-slice2a-pg-test.cjs'
+      - 'scripts/migration-p1-slice2b-pg-test.cjs'
       - 'scripts/migration-p1-sql-only-constraint-contract.cjs'
       - 'scripts/payment-receipt-origin-pg-test.cjs'
       - 'lib/payments/**'
       - 'docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md'
       - 'docs/migration/P1_SLICE2A_CONTRACT.md'
+      - 'docs/migration/P1_SLICE2B_CONTRACT.md'
       - 'docs/payments/**'
       - 'lib/migration/**'
       - 'lib/services/migration/**'
@@ -76,6 +78,16 @@ jobs:
 
       - name: Payment receipt-origin PostgreSQL behavioural suite
         run: npm run test:payment-receipt-origin:pg
+
+      - name: Migration P1 Slice 2B PostgreSQL behavioural suite
+        run: node scripts/migration-p1-slice2b-pg-test.cjs
+
+      - name: Migration P1 Slice 2B PostgreSQL service integration
+        run: npx vitest run --reporter=dot lib/services/migration/slice2b-pg.integration.test.ts
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public
+          POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public
+          MIGRATION_SLICE2B_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public
 
       - name: SQL-only constraint-contract introspection
         run: node scripts/migration-p1-sql-only-constraint-contract.cjs

--- a/app/api/migration/packages/[packageId]/validate/route.ts
+++ b/app/api/migration/packages/[packageId]/validate/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth';
+import { toPublicMigrationError } from '@/lib/services/migration/errors';
+import { validateMigrationPackage } from '@/lib/services/migration/validate';
+import { isRedirectError } from 'next/dist/client/components/redirect';
+
+export const runtime = 'nodejs';
+
+/**
+ * Slice 2B — validate a finalised Phase 1 migration package.
+ * Owner/Manager only. Session business is authoritative. No GET trigger.
+ */
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ packageId: string }> | { packageId: string } },
+) {
+  try {
+    const user = await requireRole(['OWNER', 'MANAGER']);
+    const params = await Promise.resolve(context.params);
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const result = await validateMigrationPackage(
+      {
+        userId: user.id,
+        userName: user.name,
+        userRole: user.role,
+        businessId: user.businessId,
+      },
+      {
+        packageId: params.packageId,
+        expectedVersion: body.expectedVersion as number,
+        // Explicitly ignore any client-supplied businessId.
+      },
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    if (isRedirectError(error)) throw error;
+    const pub = toPublicMigrationError(error);
+    return NextResponse.json(pub.body, { status: pub.status });
+  }
+}

--- a/app/api/migration/packages/[packageId]/validation-runs/[runId]/route.ts
+++ b/app/api/migration/packages/[packageId]/validation-runs/[runId]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth';
+import { toPublicMigrationError } from '@/lib/services/migration/errors';
+import { getMigrationValidationRun } from '@/lib/services/migration/validate';
+import { isRedirectError } from 'next/dist/client/components/redirect';
+
+export const runtime = 'nodejs';
+
+/**
+ * Slice 2B — read a tenant-scoped validation run (thin results surface).
+ * Does not trigger validation.
+ */
+export async function GET(
+  _request: NextRequest,
+  context: {
+    params: Promise<{ packageId: string; runId: string }> | { packageId: string; runId: string };
+  },
+) {
+  try {
+    const user = await requireRole(['OWNER', 'MANAGER']);
+    const params = await Promise.resolve(context.params);
+    const result = await getMigrationValidationRun(
+      {
+        userId: user.id,
+        userName: user.name,
+        userRole: user.role,
+        businessId: user.businessId,
+      },
+      { packageId: params.packageId, runId: params.runId },
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    if (isRedirectError(error)) throw error;
+    const pub = toPublicMigrationError(error);
+    return NextResponse.json(pub.body, { status: pub.status });
+  }
+}

--- a/docs/migration/P1_SLICE2B_CONTRACT.md
+++ b/docs/migration/P1_SLICE2B_CONTRACT.md
@@ -1,0 +1,175 @@
+# Migration P1 Slice 2B — locked contract
+
+**Status:** Locked for implementation  
+**Baseline:** `2a1e9140898877217a9ecdf2843df41faac0474a`  
+**Parent:** Phase 1 Contract v1 + Slice 2A  
+**Schema change:** None authorised (reuse `MigrationValidationRun`)
+
+## User outcome
+
+An Owner or Manager of the session business can validate a Phase 1 package whose three entity files are finalised. Validation is **read-only** and **source-neutral**: it streams private Blob bytes, verifies checksums, applies structural and semantic rules, persists a bounded `MigrationValidationRun`, and atomically transitions the package to `VALIDATED` or `VALIDATION_FAILED`.
+
+No products, suppliers, stock, tills, shifts, sales, purchases, payments, or accounting entries are created or mutated.
+
+## Entry conditions
+
+All must hold:
+
+1. Authenticated session; role is `OWNER` or `MANAGER`.
+2. Package id resolves under **session** `businessId` only (client `businessId` ignored/rejected).
+3. Caller supplies positive integer `expectedVersion` matching current package version (CAS).
+4. Package status is pre-approval mutable and validation-eligible:
+   - `DRAFT` (primary), or
+   - `VALIDATED` / `VALIDATION_FAILED` for deterministic retry / re-validation of the current finalised file set.
+5. Exactly three `MigrationFile` rows for `SUPPLIERS`, `PRODUCTS`, `OPENING_STOCK`, each `storageStatus = FINALISED`, with non-empty `storageKey` and `uploadChecksum`.
+6. Private migration storage is configured (`MIGRATION_BLOB_READ_WRITE_TOKEN` only).
+
+## Exit conditions
+
+| Outcome | Package status | Validation run `status` |
+|---|---|---|
+| Structural + semantic pass, checksums match | `VALIDATED` | `SUCCESS` |
+| Any blocking error, checksum mismatch, or incomplete set after eligibility | `VALIDATION_FAILED` | `FAILED` |
+| Auth / role / missing package / stale version / non-eligible lifecycle | No success transition; public error | No new success run |
+
+Process / storage failures that occur after eligibility may persist a `FAILED` run and `VALIDATION_FAILED` when the CAS write still applies; they never yield `VALIDATED`. Crash between compute and persist leaves the prior status (never falsely `VALIDATED`).
+
+## Eligible package and file states
+
+- Package: `DRAFT` | `VALIDATED` | `VALIDATION_FAILED` (not `APPROVED`+).
+- Files: only `FINALISED` rows participate; `PENDING` / `FAILED` are not validation material.
+- File replacement (Slice 2A) demotes package to `DRAFT`, clears `validationChecksum` / `validatedAt`, supersedes the latest run pointer — prior SUCCESS runs become `STALE` / `supersededAt` and **cannot** support later approval.
+
+## Supported Phase 1 entities
+
+Exactly: `SUPPLIERS`, `PRODUCTS`, `OPENING_STOCK` (see `PHASE1_CONTRACT_V1.md` / `lib/migration/contract.ts`).
+
+## Supported CSV format
+
+- CSV only; UTF-8; BOM stripped from first header cell only.
+- Delimiter: comma (`,`).
+- Record separators: LF or CRLF (CR alone rejected as malformed).
+- Quoting: RFC 4180-style; `""` escapes a quote inside quoted fields; malformed quoting → blocking issue.
+- No formula evaluation; cells beginning with `=`, `+`, `-`, or `@` are inert data and emit a **warning** (`FORMULA_PREFIX_DETECTED`).
+- Max upload / stream bytes: `MIGRATION_MAX_UPLOAD_BYTES` (25 MiB).
+- Max data rows (excluding header): `MIGRATION_MAX_ROWS` (50_000).
+- Max columns: `MIGRATION_MAX_COLUMNS` (32).
+- Max header cell length: 128.
+- Max field length: 500.
+- Max retained issues: `MIGRATION_MAX_EXCEPTIONS_RETAINED` (2_000).
+- Max summary JSON chars: `MIGRATION_MAX_JSON_CHARS` (500_000).
+
+## Header contract
+
+Headers validated via `validateCsvHeaders(entityType, …)`:
+
+- Required headers must be present (case-insensitive compare after NFC / trim / whitespace collapse).
+- Duplicate headers → error.
+- Unknown headers → error.
+- Phase 1 prohibited fields → error.
+- Allowed optional headers per entity as in `contract.ts`.
+
+## Structural rules
+
+File presence/eligibility/checksum; encoding/CSV syntax; headers; row-width consistency; blank file / header-only; blank rows (skipped with optional warning budget); row/column/field ceilings; malformed quoting; invalid source identifiers; duplicate source keys within a file; unparseable numerics; invalid monetary precision (>2 dp); invalid `asOfDate`; prohibited negatives; prohibited transaction-history fields; formula-prefix warnings.
+
+## Semantic rules (source-neutral; no ordinary business mutation)
+
+- Unique `sourceSupplierKey` / `sourceProductKey` within their files (NFC + casefold identity).
+- `defaultSupplierSourceKey` must reference a suppliers-file key when set.
+- Opening-stock `sourceProductKey` must reference the products file.
+- Product name required; SKU/barcode optional; missing barcode → **warning**; duplicate non-empty SKU or barcode within file → **error**.
+- Sale/cost prices: required decimals → minor units; negatives prohibited for cost; selling price may be zero but not negative.
+- Opening stock: non-negative integer quantity; non-negative unit cost; optional `sourceStockValue` must equal `quantity × unitCost` in minor units.
+- Cross-file consistency only across the finalised package file set.
+- Package branch mappings (same-tenant package metadata): every distinct opening-stock `sourceBranchKey` must have a mapping; unmapped → error. Mapping targets are not re-validated against live Store activity beyond existing FK integrity.
+- No read/write of Product, Supplier, Inventory, Sale, Purchase, Payment, Till, Shift, or Journal models for comparison unless separately authorised (not in Slice 2B).
+
+## Issue-code catalogue
+
+Stable public codes (see `lib/migration/issue-codes.ts`). Each retained issue may include only:
+
+`code`, `severity` (`error`|`warning`), `entityType`, `rowNumber`, `column`, `message`, optional bounded `sourceKey`.
+
+No SQL/provider text, stack traces, raw CSV rows, secrets, private URLs, pathnames, or cross-tenant data.
+
+**Errors** block `VALIDATED`. **Warnings** do not.
+
+## Validation-result contract
+
+Persisted on `MigrationValidationRun`:
+
+- `status`: `SUCCESS` | `FAILED` | `STALE` (superseded runs)
+- `manifestChecksum`: canonical checksum of the validated file set (+ package identity fields used by `manifestChecksum`)
+- `resultDigest`: SHA-256 of canonical sanitised summary (optional integrity aid)
+- `summaryJson`: bounded JSON (counts, durationMs, file checksums, truncation flags, retained issues)
+- `exceptionCount`, `exceptionsTruncated`
+- `validatedByUserId`, `createdAt`, `supersededAt`
+
+Package updates on success/failure: `status`, `version++`, `latestValidationRunId`, `validatedAt` / `validatedByUserId` on success; per-file `validationChecksum` + `validatedAt` + `rowCount` on success only.
+
+## State transitions (Slice 2B)
+
+```
+DRAFT → VALIDATED | VALIDATION_FAILED
+VALIDATED → VALIDATION_FAILED | DRAFT (demotion via Slice 2A material mutation)
+VALIDATION_FAILED → VALIDATED | VALIDATION_FAILED | DRAFT (demotion)
+```
+
+Retry of `VALIDATION_FAILED` → `VALIDATED` / `VALIDATION_FAILED` is an explicit Slice 2B lifecycle clarification for same-file re-validation (does not invent approval/import states).
+
+Idempotency: if package is `VALIDATED`, `expectedVersion` matches, and `latestValidationRun` is `SUCCESS` with the same `manifestChecksum` and not superseded → return that run without creating a duplicate.
+
+## Checksum and version binding
+
+- Stream bytes; recompute SHA-256; must equal stored `uploadChecksum`.
+- Mismatch → never `VALIDATED`; issue `CHECKSUM_MISMATCH` / storage classification.
+- Validation run binds `manifestChecksum` to the exact finalised checksums + package identity.
+- CAS: `expectedVersion` must match under `SELECT … FOR UPDATE`; bump `version` on commit.
+
+## Concurrency
+
+- No count-then-write substitute for CAS.
+- Concurrent Owner/Manager validates: one wins CAS; loser receives `STALE_VERSION`.
+- Holding long validation work **outside** the DB lock; re-lock and re-verify checksums/version before persist.
+
+## Permissions
+
+| Actor | Validate | Read own results |
+|---|---|---|
+| Owner (session business) | Yes | Yes |
+| Manager (session business) | Yes | Yes |
+| Cashier | Denied (403) | Denied |
+| Unauthenticated | Denied (401) | Denied |
+| Foreign business package | `NOT_FOUND` (404), equivalent to nonexistent | Same |
+
+## Data / response ceilings
+
+Issues retained ≤ 2000; summary JSON ≤ 500_000 chars; public API returns retained issues only plus truncation counts; no private Blob URL/pathname/token in responses.
+
+## Audit
+
+Durable `auditLog` actions (fail-closed):
+
+- `MIGRATION_VALIDATION_REQUESTED`
+- `MIGRATION_VALIDATION_SUCCEEDED`
+- `MIGRATION_VALIDATION_FAILED`
+- `MIGRATION_VALIDATION_STALE_VERSION`
+- `MIGRATION_VALIDATION_ROLE_DENIED` (when recorded at adapter boundary if applicable)
+- `MIGRATION_VALIDATION_CHECKSUM_MISMATCH`
+- `MIGRATION_VALIDATION_SUPERSEDED` (via demotion path)
+
+Details: actor, businessId, packageId, runId, versions, bounded checksum ids, counts, duration, sanitised failure class — never raw CSV or secrets.
+
+## Explicit exclusions
+
+Approval; import; reconciliation; product/supplier/stock/accounting mutation; sales/purchases/payments/shifts/tills; barcode generation; Omega/QuickBooks core adapters; Production deploy/migrate/upload/validate; Blob delete / orphan GC; public Blob token fallback; validation on GET/page load; background workers (unless 50k sync evidence forces a separately authorised design).
+
+## Preview and Production gates
+
+- Preview: synthetic data only; branch SHA must match; prove Owner/Manager/Cashier/unauth matrix; valid→`VALIDATED`; invalid→`VALIDATION_FAILED`; no business mutation; no Blob delete.
+- Production: **not authorised** by this slice. Live Production A↔B remains `NOT EXECUTED`. Automated PG two-business tests do not convert that into a live Production pass.
+
+## 25 MiB classification
+
+**PASS WITH LIMITATION** — policy + upload token ceiling proven; exact 25 MiB runtime validation remains unproven unless separately executed.

--- a/lib/migration/issue-codes.ts
+++ b/lib/migration/issue-codes.ts
@@ -1,0 +1,121 @@
+/**
+ * Slice 2B — stable public validation issue codes.
+ * Codes are independent of internal exception wording.
+ */
+
+export const MIGRATION_ISSUE_SEVERITIES = ['error', 'warning'] as const;
+export type MigrationIssueSeverity = (typeof MIGRATION_ISSUE_SEVERITIES)[number];
+
+export const MIGRATION_ISSUE_CODES = [
+  'FILE_MISSING',
+  'FILE_NOT_FINALISED',
+  'CHECKSUM_MISMATCH',
+  'STORAGE_OBJECT_MISSING',
+  'STORAGE_READ_FAILED',
+  'EMPTY_FILE',
+  'HEADER_ONLY_FILE',
+  'MALFORMED_CSV',
+  'MALFORMED_QUOTING',
+  'ROW_WIDTH_MISMATCH',
+  'TOO_MANY_COLUMNS',
+  'TOO_MANY_ROWS',
+  'FIELD_TOO_LONG',
+  'HEADER_TOO_LONG',
+  'MISSING_REQUIRED_HEADER',
+  'DUPLICATE_HEADER',
+  'UNKNOWN_HEADER',
+  'PROHIBITED_HEADER',
+  'BLANK_ROW',
+  'INVALID_SOURCE_KEY',
+  'DUPLICATE_SOURCE_KEY',
+  'INVALID_DECIMAL',
+  'INVALID_MONETARY_PRECISION',
+  'NEGATIVE_VALUE_PROHIBITED',
+  'INVALID_DATE',
+  'INVALID_ACTIVE_FLAG',
+  'REQUIRED_FIELD_MISSING',
+  'INVALID_QUANTITY',
+  'SUPPLIER_REFERENCE_MISSING',
+  'PRODUCT_REFERENCE_MISSING',
+  'DUPLICATE_SKU',
+  'DUPLICATE_BARCODE',
+  'MISSING_BARCODE',
+  'STOCK_VALUE_MISMATCH',
+  'BRANCH_KEY_UNMAPPED',
+  'BRANCH_MAPPINGS_REQUIRED',
+  'DUPLICATE_OPENING_STOCK_LINE',
+  'FORMULA_PREFIX_DETECTED',
+  'PACKAGE_INCOMPLETE',
+  'ENCODING_UNSUPPORTED',
+] as const;
+
+export type MigrationIssueCode = (typeof MIGRATION_ISSUE_CODES)[number];
+
+export type MigrationValidationIssue = {
+  code: MigrationIssueCode;
+  severity: MigrationIssueSeverity;
+  entityType: 'SUPPLIERS' | 'PRODUCTS' | 'OPENING_STOCK' | 'PACKAGE';
+  rowNumber: number | null;
+  column: string | null;
+  message: string;
+  sourceKey?: string | null;
+};
+
+const CODE_SET = new Set<string>(MIGRATION_ISSUE_CODES);
+
+export function isMigrationIssueCode(value: string): value is MigrationIssueCode {
+  return CODE_SET.has(value);
+}
+
+/** Deterministic issue ordering for stable persistence and API responses. */
+export function compareMigrationIssues(
+  a: MigrationValidationIssue,
+  b: MigrationValidationIssue,
+): number {
+  const entityOrder = { PACKAGE: 0, SUPPLIERS: 1, PRODUCTS: 2, OPENING_STOCK: 3 } as const;
+  const ea = entityOrder[a.entityType] ?? 9;
+  const eb = entityOrder[b.entityType] ?? 9;
+  if (ea !== eb) return ea - eb;
+  const ra = a.rowNumber ?? -1;
+  const rb = b.rowNumber ?? -1;
+  if (ra !== rb) return ra - rb;
+  const ca = a.column ?? '';
+  const cb = b.column ?? '';
+  if (ca !== cb) return ca.localeCompare(cb);
+  if (a.code !== b.code) return a.code.localeCompare(b.code);
+  return a.message.localeCompare(b.message);
+}
+
+const MAX_MESSAGE = 240;
+const MAX_SOURCE_KEY = 128;
+
+/** Bound and neutralise issue fields for persistence / public responses. */
+export function sanitiseMigrationIssue(
+  issue: MigrationValidationIssue,
+): MigrationValidationIssue {
+  const message = String(issue.message ?? '')
+    .replace(/[\u0000-\u001f\u007f]/g, ' ')
+    .replace(/[<>]/g, '')
+    .trim()
+    .slice(0, MAX_MESSAGE);
+  const sourceKey =
+    issue.sourceKey == null || issue.sourceKey === ''
+      ? null
+      : String(issue.sourceKey)
+          .replace(/[\u0000-\u001f\u007f]/g, '')
+          .trim()
+          .normalize('NFC')
+          .slice(0, MAX_SOURCE_KEY);
+  return {
+    code: isMigrationIssueCode(issue.code) ? issue.code : 'MALFORMED_CSV',
+    severity: issue.severity === 'warning' ? 'warning' : 'error',
+    entityType: issue.entityType,
+    rowNumber:
+      typeof issue.rowNumber === 'number' && Number.isInteger(issue.rowNumber)
+        ? issue.rowNumber
+        : null,
+    column: issue.column ? String(issue.column).slice(0, 64) : null,
+    message: message || 'Validation issue.',
+    sourceKey,
+  };
+}

--- a/lib/migration/lifecycle.test.ts
+++ b/lib/migration/lifecycle.test.ts
@@ -25,6 +25,13 @@ describe('migration package lifecycle', () => {
     assertPackageTransition('IMPORTING', 'IMPORTED');
   });
 
+  it('allows Slice 2B validation retry transitions', () => {
+    assertPackageTransition('VALIDATION_FAILED', 'VALIDATED');
+    assertPackageTransition('VALIDATION_FAILED', 'VALIDATION_FAILED');
+    assertPackageTransition('VALIDATED', 'VALIDATED');
+    assertPackageTransition('VALIDATED', 'VALIDATION_FAILED');
+  });
+
   it('rejects forbidden transitions fail-closed', () => {
     expect(canTransitionPackage('DRAFT', 'APPROVED')).toBe(false);
     expect(canTransitionPackage('DRAFT', 'IMPORTED')).toBe(false);

--- a/lib/migration/lifecycle.ts
+++ b/lib/migration/lifecycle.ts
@@ -12,11 +12,13 @@ import type { MigrationPackageStatus, MigrationReconciliationStatus } from '@/li
 
 const PACKAGE_TRANSITIONS: Record<MigrationPackageStatus, MigrationPackageStatus[]> = {
   DRAFT: ['VALIDATED', 'VALIDATION_FAILED', 'CANCELLED', 'EXPIRED'],
-  VALIDATED: ['APPROVED', 'DRAFT', 'VALIDATION_FAILED', 'CANCELLED', 'EXPIRED'],
+  // Slice 2B: VALIDATED → VALIDATED allows checksum-bound re-validation success.
+  VALIDATED: ['APPROVED', 'DRAFT', 'VALIDATED', 'VALIDATION_FAILED', 'CANCELLED', 'EXPIRED'],
   APPROVED: ['IMPORTING', 'APPROVAL_INVALIDATED', 'CANCELLED', 'SUPERSEDED'],
   IMPORTING: ['IMPORTED', 'IMPORT_FAILED'],
   IMPORTED: [],
-  VALIDATION_FAILED: ['DRAFT', 'CANCELLED', 'EXPIRED'],
+  // Slice 2B: allow same-file re-validation without requiring a demotion round-trip.
+  VALIDATION_FAILED: ['DRAFT', 'VALIDATED', 'VALIDATION_FAILED', 'CANCELLED', 'EXPIRED'],
   APPROVAL_INVALIDATED: ['SUPERSEDED', 'CANCELLED', 'EXPIRED'],
   IMPORT_FAILED: ['IMPORTING', 'CANCELLED'],
   EXPIRED: [],

--- a/lib/services/migration/csv-parser.ts
+++ b/lib/services/migration/csv-parser.ts
@@ -1,0 +1,292 @@
+/**
+ * Bounded streaming CSV parser for migration validation (Slice 2B).
+ * Does not load unbounded files into memory as a single string.
+ */
+
+import {
+  MIGRATION_MAX_COLUMNS,
+  MIGRATION_MAX_ROWS,
+  MIGRATION_MAX_UPLOAD_BYTES,
+} from '@/lib/migration/limits';
+
+export const MIGRATION_MAX_HEADER_LENGTH = 128;
+export const MIGRATION_MAX_FIELD_LENGTH = 500;
+
+export type CsvParseIssue = {
+  code:
+    | 'MALFORMED_CSV'
+    | 'MALFORMED_QUOTING'
+    | 'TOO_MANY_COLUMNS'
+    | 'TOO_MANY_ROWS'
+    | 'FIELD_TOO_LONG'
+    | 'HEADER_TOO_LONG'
+    | 'ROW_WIDTH_MISMATCH'
+    | 'EMPTY_FILE'
+    | 'ENCODING_UNSUPPORTED';
+  message: string;
+  rowNumber: number | null;
+};
+
+export type CsvParseResult = {
+  headers: string[];
+  rows: string[][];
+  /** 1-based data row numbers aligned with `rows`. */
+  rowNumbers: number[];
+  byteLength: number;
+  sha256Hex: string;
+  issues: CsvParseIssue[];
+  blankRowCount: number;
+};
+
+async function* iterateBytes(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<Uint8Array> {
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value && value.byteLength) yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Parse a CSV ReadableStream with SHA-256, size, row, column and field ceilings.
+ * Returns buffered row cells (bounded by contractual ceilings).
+ */
+export async function parseMigrationCsvStream(
+  stream: ReadableStream<Uint8Array>,
+  options: {
+    maxBytes?: number;
+    maxRows?: number;
+    maxColumns?: number;
+    maxFieldLength?: number;
+    maxHeaderLength?: number;
+  } = {},
+): Promise<CsvParseResult> {
+  const maxBytes = options.maxBytes ?? MIGRATION_MAX_UPLOAD_BYTES;
+  const maxRows = options.maxRows ?? MIGRATION_MAX_ROWS;
+  const maxColumns = options.maxColumns ?? MIGRATION_MAX_COLUMNS;
+  const maxFieldLength = options.maxFieldLength ?? MIGRATION_MAX_FIELD_LENGTH;
+  const maxHeaderLength = options.maxHeaderLength ?? MIGRATION_MAX_HEADER_LENGTH;
+
+  const { createHash } = await import('crypto');
+  const hash = createHash('sha256');
+  const issues: CsvParseIssue[] = [];
+  const rows: string[][] = [];
+  const rowNumbers: number[] = [];
+  let headers: string[] | null = null;
+  let blankRowCount = 0;
+  let byteLength = 0;
+
+  let field = '';
+  let row: string[] = [];
+  let inQuotes = false;
+  let lineNumber = 1;
+  let sawCr = false;
+  let physicalRowStart = 1;
+
+  const pushIssue = (issue: CsvParseIssue) => {
+    if (issues.length < 64) issues.push(issue);
+  };
+
+  const finishField = (isHeader: boolean) => {
+    if (isHeader && field.length > maxHeaderLength) {
+      pushIssue({
+        code: 'HEADER_TOO_LONG',
+        message: `Header exceeds ${maxHeaderLength} characters.`,
+        rowNumber: 1,
+      });
+      field = field.slice(0, maxHeaderLength);
+    } else if (!isHeader && field.length > maxFieldLength) {
+      pushIssue({
+        code: 'FIELD_TOO_LONG',
+        message: `Field exceeds ${maxFieldLength} characters.`,
+        rowNumber: lineNumber,
+      });
+      field = field.slice(0, maxFieldLength);
+    }
+    row.push(field);
+    field = '';
+  };
+
+  const finishRow = () => {
+    const isHeader = headers === null;
+    if (inQuotes) {
+      pushIssue({
+        code: 'MALFORMED_QUOTING',
+        message: 'Unterminated quoted field.',
+        rowNumber: physicalRowStart,
+      });
+      inQuotes = false;
+    }
+
+    // Drop UTF-8 BOM from first header cell only.
+    if (isHeader && row.length > 0 && row[0]!.charCodeAt(0) === 0xfeff) {
+      row[0] = row[0]!.slice(1);
+    }
+
+    const allBlank = row.every((c) => c.trim() === '');
+    if (allBlank) {
+      if (headers !== null) {
+        blankRowCount += 1;
+        if (blankRowCount <= 20) {
+          pushIssue({
+            code: 'MALFORMED_CSV',
+            message: 'Blank data row skipped.',
+            rowNumber: physicalRowStart,
+          });
+        }
+      }
+      row = [];
+      physicalRowStart = lineNumber;
+      return;
+    }
+
+    if (row.length > maxColumns) {
+      pushIssue({
+        code: 'TOO_MANY_COLUMNS',
+        message: `Row has more than ${maxColumns} columns.`,
+        rowNumber: physicalRowStart,
+      });
+      row = row.slice(0, maxColumns);
+    }
+
+    if (isHeader) {
+      headers = row;
+    } else {
+      if (headers && row.length !== headers.length) {
+        pushIssue({
+          code: 'ROW_WIDTH_MISMATCH',
+          message: `Expected ${headers.length} columns, got ${row.length}.`,
+          rowNumber: physicalRowStart,
+        });
+        while (row.length < headers.length) row.push('');
+        if (row.length > headers.length) row = row.slice(0, headers.length);
+      }
+      if (rows.length >= maxRows) {
+        pushIssue({
+          code: 'TOO_MANY_ROWS',
+          message: `File exceeds ${maxRows} data rows.`,
+          rowNumber: physicalRowStart,
+        });
+      } else {
+        rows.push(row);
+        rowNumbers.push(physicalRowStart);
+      }
+    }
+    row = [];
+    physicalRowStart = lineNumber;
+  };
+
+  for await (const chunk of iterateBytes(stream)) {
+    byteLength += chunk.byteLength;
+    if (byteLength > maxBytes) {
+      throw Object.assign(new Error('CSV_BYTE_CEILING'), { code: 'TOO_LARGE' });
+    }
+    hash.update(chunk);
+
+    // Reject obvious non-UTF8 control NULs early (binary).
+    for (let i = 0; i < chunk.byteLength; i += 1) {
+      const b = chunk[i]!;
+      if (b === 0) {
+        pushIssue({
+          code: 'ENCODING_UNSUPPORTED',
+          message: 'NUL byte encountered; UTF-8 text CSV required.',
+          rowNumber: lineNumber,
+        });
+      }
+    }
+
+    const text = Buffer.from(chunk).toString('utf8');
+    for (let i = 0; i < text.length; i += 1) {
+      const ch = text[i]!;
+      if (sawCr) {
+        sawCr = false;
+        if (ch === '\n') {
+          // CRLF consumed as one record separator.
+          continue;
+        }
+        // Lone CR — treat as malformed then continue with current char.
+        pushIssue({
+          code: 'MALFORMED_CSV',
+          message: 'Lone CR line ending is not supported.',
+          rowNumber: lineNumber,
+        });
+      }
+
+      if (inQuotes) {
+        if (ch === '"') {
+          const next = text[i + 1];
+          if (next === '"') {
+            field += '"';
+            i += 1;
+          } else {
+            inQuotes = false;
+          }
+        } else {
+          field += ch;
+          if (ch === '\n') lineNumber += 1;
+        }
+        continue;
+      }
+
+      if (ch === '"') {
+        inQuotes = true;
+        continue;
+      }
+      if (ch === ',') {
+        finishField(headers === null);
+        continue;
+      }
+      if (ch === '\r') {
+        finishField(headers === null);
+        finishRow();
+        lineNumber += 1;
+        sawCr = true;
+        continue;
+      }
+      if (ch === '\n') {
+        finishField(headers === null);
+        finishRow();
+        lineNumber += 1;
+        continue;
+      }
+      field += ch;
+    }
+  }
+
+  if (field.length > 0 || row.length > 0 || inQuotes) {
+    finishField(headers === null);
+    finishRow();
+  }
+
+  if (!headers) {
+    pushIssue({ code: 'EMPTY_FILE', message: 'File is empty.', rowNumber: null });
+    headers = [];
+  }
+
+  return {
+    headers,
+    rows,
+    rowNumbers,
+    byteLength,
+    sha256Hex: hash.digest('hex'),
+    issues,
+    blankRowCount,
+  };
+}
+
+/** Convenience for unit tests — parse a Buffer as a stream. */
+export async function parseMigrationCsvBuffer(bytes: Buffer): Promise<CsvParseResult> {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array(bytes));
+      controller.close();
+    },
+  });
+  return parseMigrationCsvStream(stream);
+}

--- a/lib/services/migration/index.ts
+++ b/lib/services/migration/index.ts
@@ -7,3 +7,6 @@ export * from '@/lib/services/migration/branch-mapping';
 export * from '@/lib/services/migration/file-download';
 export * from '@/lib/services/migration/preapproval';
 export * from '@/lib/services/migration/cleanup';
+export * from '@/lib/services/migration/validate';
+export * from '@/lib/services/migration/csv-parser';
+export * from '@/lib/services/migration/validate-engine';

--- a/lib/services/migration/slice2b-engine.test.ts
+++ b/lib/services/migration/slice2b-engine.test.ts
@@ -1,0 +1,197 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'crypto';
+import { parseMigrationCsvBuffer } from '@/lib/services/migration/csv-parser';
+import {
+  applyCrossFileSemantics,
+  validateEntityFile,
+} from '@/lib/services/migration/validate-engine';
+import {
+  compareMigrationIssues,
+  sanitiseMigrationIssue,
+} from '@/lib/migration/issue-codes';
+import { MIGRATION_MAX_EXCEPTIONS_RETAINED, truncateExceptionsForStorage } from '@/lib/migration/limits';
+
+function sha(buf: Buffer) {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+function streamOf(text: string) {
+  const buf = Buffer.from(text, 'utf8');
+  return {
+    buf,
+    checksum: sha(buf),
+    stream: new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(new Uint8Array(buf));
+        c.close();
+      },
+    }),
+  };
+}
+
+describe('migration csv parser', () => {
+  it('parses BOM + CRLF headers', async () => {
+    const text = '\uFEFFsourceSupplierKey,supplierName\r\ns1,Acme\r\n';
+    const parsed = await parseMigrationCsvBuffer(Buffer.from(text, 'utf8'));
+    expect(parsed.headers[0]).toBe('sourceSupplierKey');
+    expect(parsed.rows).toHaveLength(1);
+  });
+
+  it('rejects malformed quoting', async () => {
+    const text = 'a,b\n"unterminated,x\n';
+    const parsed = await parseMigrationCsvBuffer(Buffer.from(text, 'utf8'));
+    expect(parsed.issues.some((i) => i.code === 'MALFORMED_QUOTING')).toBe(true);
+  });
+
+  it('flags oversized fields and row ceiling', async () => {
+    const big = 'x'.repeat(501);
+    const parsed = await parseMigrationCsvBuffer(
+      Buffer.from(`sourceSupplierKey,supplierName\n${big},Name\n`, 'utf8'),
+    );
+    expect(parsed.issues.some((i) => i.code === 'FIELD_TOO_LONG')).toBe(true);
+  });
+
+  it('handles escaped quotes', async () => {
+    const parsed = await parseMigrationCsvBuffer(
+      Buffer.from('a,b\n"he""llo",world\n', 'utf8'),
+    );
+    expect(parsed.rows[0]![0]).toBe('he"llo');
+  });
+});
+
+describe('migration validate engine', () => {
+  it('validates a minimal suppliers file', async () => {
+    const { stream, checksum } = streamOf(
+      'sourceSupplierKey,supplierName\nsup-1,Acme Supplies\n',
+    );
+    const result = await validateEntityFile({
+      entityType: 'SUPPLIERS',
+      stream,
+      expectedChecksum: checksum,
+    });
+    expect(result.checksumMatched).toBe(true);
+    expect(result.issues.filter((i) => i.severity === 'error')).toHaveLength(0);
+    expect(result.sourceKeys.has('sup-1')).toBe(true);
+  });
+
+  it('emits CHECKSUM_MISMATCH without VALIDATED path inputs', async () => {
+    const { stream } = streamOf('sourceSupplierKey,supplierName\ns1,A\n');
+    const result = await validateEntityFile({
+      entityType: 'SUPPLIERS',
+      stream,
+      expectedChecksum: '0'.repeat(64),
+    });
+    expect(result.checksumMatched).toBe(false);
+    expect(result.issues.some((i) => i.code === 'CHECKSUM_MISMATCH')).toBe(true);
+  });
+
+  it('detects missing headers and prohibited fields', async () => {
+    const { stream, checksum } = streamOf('supplierName,supplierBalance\nx,1\n');
+    const result = await validateEntityFile({
+      entityType: 'SUPPLIERS',
+      stream,
+      expectedChecksum: checksum,
+    });
+    expect(result.issues.some((i) => i.code === 'MISSING_REQUIRED_HEADER')).toBe(true);
+    expect(result.issues.some((i) => i.code === 'PROHIBITED_HEADER')).toBe(true);
+  });
+
+  it('warns on missing barcode and formula prefix', async () => {
+    const csv =
+      'sourceProductKey,productName,costPrice,sellingPrice,active,barcode\n' +
+      'p1,Widget,1.00,2.00,true,\n' +
+      'p2,=CMD,1.00,2.00,true,bc2\n';
+    const { stream, checksum } = streamOf(csv);
+    const result = await validateEntityFile({
+      entityType: 'PRODUCTS',
+      stream,
+      expectedChecksum: checksum,
+    });
+    expect(result.issues.some((i) => i.code === 'MISSING_BARCODE')).toBe(true);
+    expect(result.issues.some((i) => i.code === 'FORMULA_PREFIX_DETECTED')).toBe(true);
+  });
+
+  it('rejects negative cost and bad monetary precision', async () => {
+    const csv =
+      'sourceProductKey,productName,costPrice,sellingPrice,active\n' +
+      'p1,A,-1.00,2.00,true\n' +
+      'p2,B,1.001,2.00,true\n';
+    const { stream, checksum } = streamOf(csv);
+    const result = await validateEntityFile({
+      entityType: 'PRODUCTS',
+      stream,
+      expectedChecksum: checksum,
+    });
+    expect(result.issues.some((i) => i.code === 'NEGATIVE_VALUE_PROHIBITED')).toBe(true);
+    expect(result.issues.some((i) => i.code === 'INVALID_MONETARY_PRECISION')).toBe(true);
+  });
+
+  it('enforces supplier and product cross-file refs + branch mappings', async () => {
+    const suppliers = await validateEntityFile({
+      entityType: 'SUPPLIERS',
+      ...(() => {
+        const s = streamOf('sourceSupplierKey,supplierName\ns1,A\n');
+        return { stream: s.stream, expectedChecksum: s.checksum };
+      })(),
+    });
+    const products = await validateEntityFile({
+      entityType: 'PRODUCTS',
+      ...(() => {
+        const s = streamOf(
+          'sourceProductKey,productName,costPrice,sellingPrice,active,defaultSupplierSourceKey\n' +
+            'p1,W,1.00,2.00,true,missing\n',
+        );
+        return { stream: s.stream, expectedChecksum: s.checksum };
+      })(),
+    });
+    const opening = await validateEntityFile({
+      entityType: 'OPENING_STOCK',
+      ...(() => {
+        const s = streamOf(
+          'sourceProductKey,sourceBranchKey,quantity,unitCost,asOfDate\n' +
+            'p1,hq,1,1.00,2026-01-01\n',
+        );
+        return { stream: s.stream, expectedChecksum: s.checksum };
+      })(),
+    });
+    // Fix products source key set for opening ref
+    products.sourceKeys.add('p1');
+    const cross = applyCrossFileSemantics({
+      suppliers,
+      products,
+      openingStock: opening,
+      branchMappings: [],
+    });
+    expect(cross.some((i) => i.code === 'SUPPLIER_REFERENCE_MISSING')).toBe(true);
+    expect(cross.some((i) => i.code === 'BRANCH_MAPPINGS_REQUIRED')).toBe(true);
+  });
+
+  it('sanitises and orders issues deterministically; truncates at ceiling', () => {
+    const a = sanitiseMigrationIssue({
+      code: 'DUPLICATE_SKU',
+      severity: 'error',
+      entityType: 'PRODUCTS',
+      rowNumber: 2,
+      column: 'sku',
+      message: '<script>alert(1)</script>',
+      sourceKey: 'p1',
+    });
+    expect(a.message.includes('<')).toBe(false);
+    const many = Array.from({ length: MIGRATION_MAX_EXCEPTIONS_RETAINED + 5 }, (_, i) =>
+      sanitiseMigrationIssue({
+        code: 'BLANK_ROW',
+        severity: 'warning',
+        entityType: 'SUPPLIERS',
+        rowNumber: i + 2,
+        column: null,
+        message: `row ${i}`,
+      }),
+    );
+    const sorted = [...many].sort(compareMigrationIssues);
+    expect(sorted[0]!.rowNumber).toBeLessThanOrEqual(sorted[1]!.rowNumber!);
+    const { retained, truncated } = truncateExceptionsForStorage(sorted);
+    expect(retained).toHaveLength(MIGRATION_MAX_EXCEPTIONS_RETAINED);
+    expect(truncated).toBe(5);
+  });
+});

--- a/lib/services/migration/slice2b-pg.integration.test.ts
+++ b/lib/services/migration/slice2b-pg.integration.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Slice 2B PostgreSQL two-business foreign-package service-boundary tests.
+ *
+ * Requires a real Postgres URL. Skipped otherwise — mocks are not labelled as a pass.
+ *
+ *   set DATABASE_URL=postgresql://...
+ *   npx vitest run lib/services/migration/slice2b-pg.integration.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'crypto';
+import { PrismaClient } from '@prisma/client';
+import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
+import { createMemoryMigrationObjectStorage } from '@/lib/services/migration/storage';
+import { MigrationServiceError } from '@/lib/services/migration/errors';
+
+const databaseUrl =
+  process.env.MIGRATION_SLICE2B_DATABASE_URL ||
+  process.env.POSTGRES_URL_NON_POOLING ||
+  process.env.DATABASE_URL;
+const canRun = !!databaseUrl && isPostgresDatabaseUrl(databaseUrl);
+
+const describePg = canRun ? describe : describe.skip;
+
+function sha(text: string) {
+  return createHash('sha256').update(Buffer.from(text, 'utf8')).digest('hex');
+}
+
+function cuid() {
+  return 'c' + createHash('sha256').update(String(Math.random()) + Date.now()).digest('hex').slice(0, 24);
+}
+
+describePg('migration slice 2B PostgreSQL two-business isolation', () => {
+  let prisma: PrismaClient;
+  let validateMigrationPackage: typeof import('@/lib/services/migration/validate').validateMigrationPackage;
+  let getMigrationValidationRun: typeof import('@/lib/services/migration/validate').getMigrationValidationRun;
+
+  const suffix = `s2b-${Date.now()}`;
+  let bizA = '';
+  let bizB = '';
+  let ownerA = '';
+  let managerA = '';
+  let cashierA = '';
+  let ownerB = '';
+  let storeB = '';
+  let pkgB = '';
+  const storage = createMemoryMigrationObjectStorage();
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = databaseUrl!;
+    const g = globalThis as unknown as { prisma?: PrismaClient };
+    if (g.prisma) {
+      await g.prisma.$disconnect().catch(() => {});
+      g.prisma = undefined;
+    }
+    vi.resetModules();
+    const mod = await import('@/lib/services/migration/validate');
+    validateMigrationPackage = mod.validateMigrationPackage;
+    getMigrationValidationRun = mod.getMigrationValidationRun;
+
+    prisma = new PrismaClient();
+    await prisma.$connect();
+
+    const a = await prisma.business.create({
+      data: { name: `Slice2B A ${suffix}`, currency: 'GHS' },
+    });
+    const b = await prisma.business.create({
+      data: { name: `Slice2B B ${suffix}`, currency: 'GHS' },
+    });
+    bizA = a.id;
+    bizB = b.id;
+
+    const users = await Promise.all([
+      prisma.user.create({
+        data: {
+          businessId: bizA,
+          email: `owner-a-${suffix}@example.com`,
+          name: 'Owner A',
+          role: 'OWNER',
+          passwordHash: 'x',
+        },
+      }),
+      prisma.user.create({
+        data: {
+          businessId: bizA,
+          email: `mgr-a-${suffix}@example.com`,
+          name: 'Manager A',
+          role: 'MANAGER',
+          passwordHash: 'x',
+        },
+      }),
+      prisma.user.create({
+        data: {
+          businessId: bizA,
+          email: `cash-a-${suffix}@example.com`,
+          name: 'Cashier A',
+          role: 'CASHIER',
+          passwordHash: 'x',
+        },
+      }),
+      prisma.user.create({
+        data: {
+          businessId: bizB,
+          email: `owner-b-${suffix}@example.com`,
+          name: 'Owner B',
+          role: 'OWNER',
+          passwordHash: 'x',
+        },
+      }),
+    ]);
+    ownerA = users[0]!.id;
+    managerA = users[1]!.id;
+    cashierA = users[2]!.id;
+    ownerB = users[3]!.id;
+
+    const store = await prisma.store.create({
+      data: { businessId: bizB, name: `Store B ${suffix}` },
+    });
+    storeB = store.id;
+
+    pkgB = cuid();
+    const expiresAt = new Date(Date.now() + 14 * 86400000);
+    await prisma.migrationPackage.create({
+      data: {
+        id: pkgB,
+        businessId: bizB,
+        contractVersion: '1',
+        sourceSystemKey: 'synthetic',
+        sourceBusinessKey: 'biz-b-src',
+        reportingCurrency: 'GHS',
+        packageAsOfDate: '2026-01-15',
+        status: 'DRAFT',
+        version: 1,
+        lineageRootId: pkgB,
+        createdByUserId: ownerB,
+        expiresAt,
+      },
+    });
+
+    await prisma.migrationBranchMapping.create({
+      data: {
+        businessId: bizB,
+        packageId: pkgB,
+        sourceBranchKey: 'hq',
+        targetStoreId: storeB,
+      },
+    });
+
+    const csv = {
+      SUPPLIERS: 'sourceSupplierKey,supplierName\ns1,Acme\n',
+      PRODUCTS:
+        'sourceProductKey,productName,costPrice,sellingPrice,active,barcode,defaultSupplierSourceKey\n' +
+        'p1,Widget,1.50,2.00,true,bc1,s1\n',
+      OPENING_STOCK:
+        'sourceProductKey,sourceBranchKey,quantity,unitCost,asOfDate\n' +
+        'p1,hq,10,1.50,2026-01-15\n',
+    } as const;
+
+    for (const entityType of Object.keys(csv) as Array<keyof typeof csv>) {
+      const body = Buffer.from(csv[entityType], 'utf8');
+      const pathname = `mig/${bizB}/${pkgB}/upl/${entityType}.csv`;
+      await storage.put({ pathname, body, contentType: 'text/csv' });
+      await prisma.migrationFile.create({
+        data: {
+          businessId: bizB,
+          packageId: pkgB,
+          entityType,
+          storageStatus: 'FINALISED',
+          storageKey: pathname,
+          uploadChecksum: sha(csv[entityType]),
+          byteLength: body.length,
+        },
+      });
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    try {
+      await prisma.migrationPackage.updateMany({
+        where: { businessId: { in: [bizA, bizB] } },
+        data: { latestValidationRunId: null },
+      });
+      await prisma.migrationValidationRun.deleteMany({
+        where: { businessId: { in: [bizA, bizB] } },
+      });
+      await prisma.migrationFile.deleteMany({ where: { businessId: { in: [bizA, bizB] } } });
+      await prisma.migrationBranchMapping.deleteMany({
+        where: { businessId: { in: [bizA, bizB] } },
+      });
+      await prisma.migrationPackage.deleteMany({ where: { businessId: { in: [bizA, bizB] } } });
+      await prisma.store.deleteMany({ where: { businessId: { in: [bizA, bizB] } } });
+      await prisma.user.deleteMany({ where: { businessId: { in: [bizA, bizB] } } });
+      await prisma.business.deleteMany({ where: { id: { in: [bizA, bizB] } } });
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  it('Owner B can validate own package', async () => {
+    const productCountBefore = await prisma.product.count({ where: { businessId: bizB } });
+    const result = await validateMigrationPackage(
+      { userId: ownerB, userRole: 'OWNER', businessId: bizB, userName: 'Owner B' },
+      { packageId: pkgB, expectedVersion: 1, businessId: bizA },
+      { db: prisma, storage },
+    );
+    expect(result.packageStatus).toBe('VALIDATED');
+    const productCountAfter = await prisma.product.count({ where: { businessId: bizB } });
+    expect(productCountAfter).toBe(productCountBefore);
+  });
+
+  it('Owner A / Manager A get NOT_FOUND for Business B package (non-enumerating)', async () => {
+    const pkg = await prisma.migrationPackage.findFirst({ where: { id: pkgB } });
+    expect(pkg?.businessId).toBe(bizB);
+
+    async function capture(actor: {
+      userId: string;
+      userRole: string;
+      businessId: string;
+      userName: string;
+    }, packageId: string) {
+      try {
+        await validateMigrationPackage(
+          actor,
+          { packageId, expectedVersion: pkg!.version },
+          { db: prisma, storage },
+        );
+        return null;
+      } catch (e) {
+        return e as MigrationServiceError;
+      }
+    }
+
+    const ownerForeign = await capture(
+      { userId: ownerA, userRole: 'OWNER', businessId: bizA, userName: 'Owner A' },
+      pkgB,
+    );
+    const ownerMissing = await capture(
+      { userId: ownerA, userRole: 'OWNER', businessId: bizA, userName: 'Owner A' },
+      'missing-package-id-zzzz',
+    );
+    const mgrForeign = await capture(
+      { userId: managerA, userRole: 'MANAGER', businessId: bizA, userName: 'Mgr A' },
+      pkgB,
+    );
+
+    expect(ownerForeign?.code).toBe('NOT_FOUND');
+    expect(ownerMissing?.code).toBe('NOT_FOUND');
+    expect(mgrForeign?.code).toBe('NOT_FOUND');
+    expect(ownerForeign?.message).toBe(ownerMissing?.message);
+    expect(JSON.stringify(ownerForeign)).not.toContain(bizB);
+    expect(JSON.stringify(ownerForeign)).not.toContain('VALIDATED');
+
+    // No mutation of foreign package
+    const again = await prisma.migrationPackage.findFirst({ where: { id: pkgB } });
+    expect(again?.version).toBe(pkg!.version);
+  });
+
+  it('Cashier A denied; unauthenticated denied', async () => {
+    await expect(
+      validateMigrationPackage(
+        { userId: cashierA, userRole: 'CASHIER', businessId: bizA, userName: 'Cash' },
+        { packageId: pkgB, expectedVersion: 1 },
+        { db: prisma, storage },
+      ),
+    ).rejects.toMatchObject({ code: 'ROLE_DENIED' });
+
+    await expect(
+      validateMigrationPackage(
+        { userId: '', userRole: '', businessId: '' },
+        { packageId: pkgB, expectedVersion: 1 },
+        { db: prisma, storage },
+      ),
+    ).rejects.toMatchObject({ code: 'UNAUTHENTICATED' });
+  });
+
+  it('validation-run reads are tenant scoped', async () => {
+    const pkg = await prisma.migrationPackage.findFirst({
+      where: { id: pkgB, businessId: bizB },
+    });
+    expect(pkg?.latestValidationRunId).toBeTruthy();
+    await expect(
+      getMigrationValidationRun(
+        { userId: ownerA, userRole: 'OWNER', businessId: bizA },
+        { packageId: pkgB, runId: pkg!.latestValidationRunId! },
+        prisma,
+      ),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('stale expectedVersion rejected under CAS', async () => {
+    const pkg = await prisma.migrationPackage.findFirst({ where: { id: pkgB } });
+    await expect(
+      validateMigrationPackage(
+        { userId: ownerB, userRole: 'OWNER', businessId: bizB },
+        { packageId: pkgB, expectedVersion: (pkg?.version ?? 1) - 1 },
+        { db: prisma, storage },
+      ),
+    ).rejects.toMatchObject({ code: 'STALE_VERSION' });
+  });
+
+  it('concurrent validation: exactly one CAS winner', async () => {
+    // Reset package to DRAFT with bumped version for a fresh race.
+    const pkg = await prisma.migrationPackage.findFirst({ where: { id: pkgB } });
+    await prisma.migrationPackage.update({
+      where: { id: pkgB },
+      data: {
+        status: 'DRAFT',
+        version: (pkg?.version ?? 1) + 1,
+        latestValidationRunId: null,
+        validatedAt: null,
+        validatedByUserId: null,
+      },
+    });
+    const fresh = await prisma.migrationPackage.findFirst({ where: { id: pkgB } });
+    const version = fresh!.version;
+
+    const results = await Promise.allSettled([
+      validateMigrationPackage(
+        { userId: ownerB, userRole: 'OWNER', businessId: bizB },
+        { packageId: pkgB, expectedVersion: version },
+        { db: prisma, storage },
+      ),
+      validateMigrationPackage(
+        { userId: ownerB, userRole: 'OWNER', businessId: bizB },
+        { packageId: pkgB, expectedVersion: version },
+        { db: prisma, storage },
+      ),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled.length).toBe(1);
+    expect(rejected.length).toBe(1);
+    const err = (rejected[0] as PromiseRejectedResult).reason as MigrationServiceError;
+    expect(err.code).toBe('STALE_VERSION');
+    const after = await prisma.migrationPackage.findFirst({ where: { id: pkgB } });
+    expect(after?.status).toBe('VALIDATED');
+    expect(after?.version).toBe(version + 1);
+  });
+});

--- a/lib/services/migration/slice2b-routes.test.ts
+++ b/lib/services/migration/slice2b-routes.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Slice 2B route adapter tests — role matrix and sanitised errors.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const validateMigrationPackage = vi.fn();
+const getMigrationValidationRun = vi.fn();
+const requireRole = vi.fn();
+
+vi.mock('@/lib/services/migration/validate', () => ({
+  validateMigrationPackage,
+  getMigrationValidationRun,
+}));
+
+vi.mock('@/lib/auth', () => ({
+  requireRole,
+}));
+
+describe('migration slice 2B validate route', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    validateMigrationPackage.mockReset();
+    getMigrationValidationRun.mockReset();
+    requireRole.mockReset();
+  });
+
+  it('Owner POST returns validation result without private URLs', async () => {
+    requireRole.mockResolvedValue({
+      id: 'u1',
+      name: 'Owner',
+      role: 'OWNER',
+      businessId: 'biz-a',
+    });
+    validateMigrationPackage.mockResolvedValue({
+      packageId: 'pkg-a',
+      packageStatus: 'VALIDATED',
+      packageVersion: 2,
+      validationRunId: 'run-1',
+      runStatus: 'SUCCESS',
+      manifestChecksum: 'ab'.repeat(32),
+      replayed: false,
+      durationMs: 12,
+      totalRowsProcessed: 3,
+      errorCount: 0,
+      warningCount: 0,
+      exceptionCount: 0,
+      exceptionsTruncated: 0,
+      exceptions: [],
+      fileChecksums: { SUPPLIERS: 'cd'.repeat(32) },
+    });
+
+    const { POST } = await import(
+      '@/app/api/migration/packages/[packageId]/validate/route'
+    );
+    const req = new Request('http://localhost/api/migration/packages/pkg-a/validate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ expectedVersion: 1, businessId: 'attacker-biz' }),
+    });
+    const res = await POST(req as never, { params: { packageId: 'pkg-a' } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.packageStatus).toBe('VALIDATED');
+    expect(JSON.stringify(body).includes('blob.vercel')).toBe(false);
+    expect(validateMigrationPackage).toHaveBeenCalledWith(
+      expect.objectContaining({ businessId: 'biz-a', userRole: 'OWNER' }),
+      expect.objectContaining({ packageId: 'pkg-a', expectedVersion: 1 }),
+    );
+    // Client businessId must not become authority
+    const input = validateMigrationPackage.mock.calls[0]![1];
+    expect(input.businessId).toBeUndefined();
+  });
+
+  it('missing expectedVersion maps to public STALE_VERSION', async () => {
+    requireRole.mockResolvedValue({
+      id: 'u1',
+      name: 'Owner',
+      role: 'OWNER',
+      businessId: 'biz-a',
+    });
+    const { MigrationServiceError } = await import('@/lib/services/migration/errors');
+    validateMigrationPackage.mockRejectedValue(
+      new MigrationServiceError('STALE_VERSION', undefined, 409),
+    );
+    const { POST } = await import(
+      '@/app/api/migration/packages/[packageId]/validate/route'
+    );
+    const req = new Request('http://localhost/api/migration/packages/pkg-a/validate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const res = await POST(req as never, { params: { packageId: 'pkg-a' } });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe('STALE_VERSION');
+    expect(body.error).not.toMatch(/postgres|stack|blob/i);
+  });
+
+  it('Cashier denial via requireRole redirect is rethrown', async () => {
+    const redirectErr = Object.assign(new Error('NEXT_REDIRECT'), {
+      digest: 'NEXT_REDIRECT;replace;/pos',
+    });
+    requireRole.mockRejectedValue(redirectErr);
+    // isRedirectError from next — mock may not recognise; ensure we still don't leak
+    const { POST } = await import(
+      '@/app/api/migration/packages/[packageId]/validate/route'
+    );
+    const req = new Request('http://localhost/api/migration/packages/pkg-a/validate', {
+      method: 'POST',
+      body: '{}',
+    });
+    // If not classified as redirect, public mapper returns INTERNAL — either is closed.
+    try {
+      const res = await POST(req as never, { params: { packageId: 'pkg-a' } });
+      expect([307, 401, 403, 500]).toContain(res.status);
+    } catch (e) {
+      expect(e).toBe(redirectErr);
+    }
+  });
+});

--- a/lib/services/migration/slice2b-scale.test.ts
+++ b/lib/services/migration/slice2b-scale.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Slice 2B scale evidence — synthetic source-neutral CSV validation benchmarks.
+ * Usage: node --import tsx scripts/migration-p1-slice2b-scale-bench.mjs
+ *    or: npx vitest run lib/services/migration/slice2b-scale.test.ts
+ */
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'crypto';
+import { validateEntityFile } from '@/lib/services/migration/validate-engine';
+import { performance } from 'node:perf_hooks';
+
+function buildProductsCsv(rows: number): Buffer {
+  const lines = [
+    'sourceProductKey,productName,costPrice,sellingPrice,active,sku,barcode,defaultSupplierSourceKey',
+  ];
+  for (let i = 0; i < rows; i += 1) {
+    lines.push(
+      `p${i},Product ${i},1.50,2.00,true,sku${i},bc${i},s1`,
+    );
+  }
+  return Buffer.from(lines.join('\n') + '\n', 'utf8');
+}
+
+async function bench(rows: number) {
+  const buf = buildProductsCsv(rows);
+  const checksum = createHash('sha256').update(buf).digest('hex');
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      // Chunk to exercise streaming path.
+      const chunkSize = 64 * 1024;
+      for (let i = 0; i < buf.length; i += chunkSize) {
+        c.enqueue(new Uint8Array(buf.subarray(i, i + chunkSize)));
+      }
+      c.close();
+    },
+  });
+  const memBefore = process.memoryUsage().heapUsed;
+  const t0 = performance.now();
+  const result = await validateEntityFile({
+    entityType: 'PRODUCTS',
+    stream,
+    expectedChecksum: checksum,
+  });
+  const elapsedMs = performance.now() - t0;
+  const memAfter = process.memoryUsage().heapUsed;
+  return {
+    rows,
+    fileSizeBytes: buf.length,
+    elapsedMs,
+    heapDeltaMb: (memAfter - memBefore) / (1024 * 1024),
+    rowCount: result.rowCount,
+    errorCount: result.issues.filter((i) => i.severity === 'error').length,
+    warningCount: result.issues.filter((i) => i.severity === 'warning').length,
+    checksumMatched: result.checksumMatched,
+  };
+}
+
+describe('migration slice 2B scale evidence', () => {
+  it('1_000 product rows', async () => {
+    const r = await bench(1_000);
+    // eslint-disable-next-line no-console
+    console.log('SCALE_1K', JSON.stringify(r));
+    expect(r.checksumMatched).toBe(true);
+    expect(r.rowCount).toBe(1_000);
+    expect(r.errorCount).toBe(0);
+    expect(r.elapsedMs).toBeLessThan(30_000);
+  }, 60_000);
+
+  it('10_000 product rows', async () => {
+    const r = await bench(10_000);
+    // eslint-disable-next-line no-console
+    console.log('SCALE_10K', JSON.stringify(r));
+    expect(r.checksumMatched).toBe(true);
+    expect(r.rowCount).toBe(10_000);
+    expect(r.errorCount).toBe(0);
+    expect(r.elapsedMs).toBeLessThan(120_000);
+  }, 180_000);
+
+  it('50_000 product rows', async () => {
+    const r = await bench(50_000);
+    // eslint-disable-next-line no-console
+    console.log('SCALE_50K', JSON.stringify(r));
+    expect(r.checksumMatched).toBe(true);
+    expect(r.rowCount).toBe(50_000);
+    expect(r.errorCount).toBe(0);
+    expect(r.elapsedMs).toBeLessThan(300_000);
+  }, 360_000);
+});

--- a/lib/services/migration/slice2b-services.test.ts
+++ b/lib/services/migration/slice2b-services.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Slice 2B service-boundary unit tests (in-memory Prisma mock + memory Blob).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'crypto';
+import { createMemoryMigrationObjectStorage } from '@/lib/services/migration/storage';
+import { MigrationServiceError } from '@/lib/services/migration/errors';
+import { MIGRATION_PUBLIC_ERROR_MESSAGES } from '@/lib/services/migration/errors';
+
+type Row = Record<string, unknown>;
+
+const { state, prismaMock } = vi.hoisted(() => {
+  const state = {
+    packages: [] as Row[],
+    files: [] as Row[],
+    mappings: [] as Row[],
+    runs: [] as Row[],
+    audits: [] as Row[],
+    products: [] as Row[],
+    suppliers: [] as Row[],
+    nextId: 1,
+  };
+  const cuid = () => `id_${state.nextId++}`;
+
+  const tx = {
+    migrationPackage: {
+      findFirst: vi.fn(async ({ where, include }: { where: Row; include?: Row }) => {
+        const pkg =
+          state.packages.find(
+            (p) =>
+              (!where.id || p.id === where.id) &&
+              (!where.businessId || p.businessId === where.businessId),
+          ) ?? null;
+        if (!pkg) return null;
+        const out: Row = { ...pkg };
+        if (include?.files) {
+          out.files = state.files.filter(
+            (f) => f.packageId === pkg.id && f.businessId === pkg.businessId,
+          );
+        }
+        if (include?.branchMappings) {
+          out.branchMappings = state.mappings.filter(
+            (m) => m.packageId === pkg.id && m.businessId === pkg.businessId,
+          );
+        }
+        if (include?.latestValidationRun) {
+          out.latestValidationRun =
+            state.runs.find((r) => r.id === pkg.latestValidationRunId) ?? null;
+        }
+        return out;
+      }),
+      update: vi.fn(async ({ where, data }: { where: { id: string }; data: Row }) => {
+        const row = state.packages.find((p) => p.id === where.id);
+        if (!row) throw new Error('missing');
+        Object.assign(row, data);
+        return { ...row };
+      }),
+    },
+    migrationFile: {
+      findMany: vi.fn(async ({ where }: { where: Row }) =>
+        state.files.filter(
+          (f) =>
+            (!where.businessId || f.businessId === where.businessId) &&
+            (!where.packageId || f.packageId === where.packageId),
+        ),
+      ),
+      update: vi.fn(async ({ where, data }: { where: { id: string }; data: Row }) => {
+        const row = state.files.find((f) => f.id === where.id);
+        if (!row) throw new Error('missing');
+        Object.assign(row, data);
+        return { ...row };
+      }),
+      updateMany: vi.fn(async ({ where, data }: { where: Row; data: Row }) => {
+        let count = 0;
+        for (const f of state.files) {
+          if (where.businessId && f.businessId !== where.businessId) continue;
+          if (where.packageId && f.packageId !== where.packageId) continue;
+          Object.assign(f, data);
+          count += 1;
+        }
+        return { count };
+      }),
+    },
+    migrationValidationRun: {
+      create: vi.fn(async ({ data }: { data: Row }) => {
+        const row = {
+          id: cuid(),
+          supersededAt: null,
+          createdAt: new Date(),
+          ...data,
+        };
+        state.runs.push(row);
+        return { ...row };
+      }),
+      findFirst: vi.fn(async ({ where }: { where: Row }) => {
+        return (
+          state.runs.find(
+            (r) =>
+              (!where.id || r.id === where.id) &&
+              (!where.packageId || r.packageId === where.packageId) &&
+              (!where.businessId || r.businessId === where.businessId),
+          ) ?? null
+        );
+      }),
+      updateMany: vi.fn(async ({ where, data }: { where: Row; data: Row }) => {
+        let count = 0;
+        for (const r of state.runs) {
+          if (where.id && r.id !== where.id) continue;
+          if (where.businessId && r.businessId !== where.businessId) continue;
+          if (where.packageId && r.packageId !== where.packageId) continue;
+          if (where.supersededAt === null && r.supersededAt != null) continue;
+          Object.assign(r, data);
+          count += 1;
+        }
+        return { count };
+      }),
+    },
+    auditLog: {
+      create: vi.fn(async ({ data }: { data: Row }) => {
+        const row = { id: cuid(), ...data };
+        state.audits.push(row);
+        return row;
+      }),
+    },
+    $queryRaw: vi.fn(async (_s: TemplateStringsArray, ...values: unknown[]) => {
+      const packageId = values[0];
+      const businessId = values[1];
+      const pkg = state.packages.find(
+        (p) => p.id === packageId && p.businessId === businessId,
+      );
+      return pkg
+        ? [
+            {
+              id: pkg.id,
+              businessId: pkg.businessId,
+              status: pkg.status,
+              version: pkg.version,
+              latestValidationRunId: pkg.latestValidationRunId ?? null,
+            },
+          ]
+        : [];
+    }),
+  };
+
+  const prismaMock = {
+    ...tx,
+    $transaction: vi.fn(async (fn: (client: typeof tx) => Promise<unknown>) => fn(tx)),
+  };
+  return { state, prismaMock, cuid };
+});
+
+vi.mock('@/lib/prisma', () => ({ prisma: prismaMock }));
+
+import {
+  getMigrationValidationRun,
+  validateMigrationPackage,
+} from '@/lib/services/migration/validate';
+import { applyMaterialMutationDemotion } from '@/lib/services/migration/preapproval';
+
+const ownerA = {
+  userId: 'owner-a',
+  userName: 'Owner A',
+  userRole: 'OWNER',
+  businessId: 'biz-a',
+};
+const managerA = { ...ownerA, userId: 'mgr-a', userName: 'Mgr A', userRole: 'MANAGER' };
+const cashierA = { ...ownerA, userId: 'cash-a', userName: 'Cash A', userRole: 'CASHIER' };
+const ownerB = {
+  userId: 'owner-b',
+  userName: 'Owner B',
+  userRole: 'OWNER',
+  businessId: 'biz-b',
+};
+
+function sha(text: string) {
+  return createHash('sha256').update(Buffer.from(text, 'utf8')).digest('hex');
+}
+
+function seedPackage(opts: {
+  businessId: string;
+  packageId: string;
+  status?: string;
+  version?: number;
+  withFiles?: boolean;
+  withMapping?: boolean;
+  storage?: ReturnType<typeof createMemoryMigrationObjectStorage>;
+  mutateCsv?: Partial<Record<'SUPPLIERS' | 'PRODUCTS' | 'OPENING_STOCK', string>>;
+}) {
+  const storage = opts.storage ?? createMemoryMigrationObjectStorage();
+  const csv = {
+    SUPPLIERS: 'sourceSupplierKey,supplierName\ns1,Acme\n',
+    PRODUCTS:
+      'sourceProductKey,productName,costPrice,sellingPrice,active,barcode,defaultSupplierSourceKey\n' +
+      'p1,Widget,1.50,2.00,true,bc1,s1\n',
+    OPENING_STOCK:
+      'sourceProductKey,sourceBranchKey,quantity,unitCost,asOfDate\n' +
+      'p1,hq,10,1.50,2026-01-15\n',
+    ...opts.mutateCsv,
+  };
+  state.packages.push({
+    id: opts.packageId,
+    businessId: opts.businessId,
+    status: opts.status ?? 'DRAFT',
+    version: opts.version ?? 1,
+    contractVersion: '1',
+    sourceSystemKey: 'synthetic',
+    sourceBusinessKey: 'demo',
+    reportingCurrency: 'GHS',
+    packageAsOfDate: '2026-01-15',
+    latestValidationRunId: null,
+    createdByUserId: 'owner-a',
+  });
+  if (opts.withMapping !== false) {
+    state.mappings.push({
+      id: `map_${opts.packageId}`,
+      businessId: opts.businessId,
+      packageId: opts.packageId,
+      sourceBranchKey: 'hq',
+      targetStoreId: `store-${opts.businessId}`,
+    });
+  }
+  if (opts.withFiles !== false) {
+    for (const entityType of ['SUPPLIERS', 'PRODUCTS', 'OPENING_STOCK'] as const) {
+      const body = Buffer.from(csv[entityType], 'utf8');
+      const pathname = `mig/${opts.businessId}/${opts.packageId}/upl/${entityType}.csv`;
+      storage.objects.set(pathname, {
+        body,
+        contentType: 'text/csv',
+        url: `https://memory.private.blob.test/${pathname}`,
+      });
+      state.files.push({
+        id: `file_${opts.packageId}_${entityType}`,
+        businessId: opts.businessId,
+        packageId: opts.packageId,
+        entityType,
+        storageStatus: 'FINALISED',
+        storageKey: pathname,
+        uploadChecksum: sha(csv[entityType]),
+        byteLength: body.length,
+        validationChecksum: null,
+        validatedAt: null,
+        rowCount: null,
+      });
+    }
+  }
+  return storage;
+}
+
+describe('migration slice 2B validate service', () => {
+  beforeEach(() => {
+    state.packages = [];
+    state.files = [];
+    state.mappings = [];
+    state.runs = [];
+    state.audits = [];
+    state.products = [];
+    state.suppliers = [];
+    state.nextId = 1;
+  });
+
+  it('Owner validates a complete synthetic package to VALIDATED', async () => {
+    const storage = seedPackage({ businessId: 'biz-a', packageId: 'pkg-a' });
+    const productsBefore = state.products.length;
+    const suppliersBefore = state.suppliers.length;
+    const result = await validateMigrationPackage(
+      ownerA,
+      { packageId: 'pkg-a', expectedVersion: 1, businessId: 'biz-b-ignored' },
+      { db: prismaMock as never, storage },
+    );
+    expect(result.packageStatus).toBe('VALIDATED');
+    expect(result.runStatus).toBe('SUCCESS');
+    expect(result.packageVersion).toBe(2);
+    expect(result.exceptionsTruncated).toBe(0);
+    expect(state.products.length).toBe(productsBefore);
+    expect(state.suppliers.length).toBe(suppliersBefore);
+    expect(state.audits.some((a) => a.action === 'MIGRATION_VALIDATION_SUCCEEDED')).toBe(true);
+    // Memory storage must not delete on success
+    expect(storage.objects.size).toBe(3);
+  });
+
+  it('Manager can validate; Cashier denied; unauth denied', async () => {
+    const storage = seedPackage({ businessId: 'biz-a', packageId: 'pkg-a' });
+    const ok = await validateMigrationPackage(
+      managerA,
+      { packageId: 'pkg-a', expectedVersion: 1 },
+      { db: prismaMock as never, storage },
+    );
+    expect(ok.packageStatus).toBe('VALIDATED');
+
+    await expect(
+      validateMigrationPackage(
+        cashierA,
+        { packageId: 'pkg-a', expectedVersion: 2 },
+        { db: prismaMock as never, storage },
+      ),
+    ).rejects.toMatchObject({ code: 'ROLE_DENIED' });
+
+    await expect(
+      validateMigrationPackage(
+        { userId: '', userRole: '', businessId: '' },
+        { packageId: 'pkg-a', expectedVersion: 2 },
+        { db: prismaMock as never, storage },
+      ),
+    ).rejects.toMatchObject({ code: 'UNAUTHENTICATED' });
+  });
+
+  it('Owner A cannot validate Business B package (NOT_FOUND equivalent)', async () => {
+    const storage = seedPackage({ businessId: 'biz-b', packageId: 'pkg-b' });
+    let foreignErr: MigrationServiceError | null = null;
+    let missingErr: MigrationServiceError | null = null;
+    try {
+      await validateMigrationPackage(
+        ownerA,
+        { packageId: 'pkg-b', expectedVersion: 1 },
+        { db: prismaMock as never, storage },
+      );
+    } catch (e) {
+      foreignErr = e as MigrationServiceError;
+    }
+    try {
+      await validateMigrationPackage(
+        ownerA,
+        { packageId: 'does-not-exist', expectedVersion: 1 },
+        { db: prismaMock as never, storage },
+      );
+    } catch (e) {
+      missingErr = e as MigrationServiceError;
+    }
+    expect(foreignErr?.code).toBe('NOT_FOUND');
+    expect(missingErr?.code).toBe('NOT_FOUND');
+    expect(foreignErr?.httpStatus).toBe(404);
+    expect(missingErr?.httpStatus).toBe(404);
+    expect(foreignErr?.message).toBe(missingErr?.message);
+    expect(foreignErr?.message).toBe(MIGRATION_PUBLIC_ERROR_MESSAGES.NOT_FOUND);
+    expect(state.packages.find((p) => p.id === 'pkg-b')?.status).toBe('DRAFT');
+    expect(state.runs.filter((r) => r.businessId === 'biz-b')).toHaveLength(0);
+  });
+
+  it('invalid file yields VALIDATION_FAILED and retains Blob', async () => {
+    const storage = seedPackage({
+      businessId: 'biz-a',
+      packageId: 'pkg-bad',
+      mutateCsv: {
+        PRODUCTS:
+          'sourceProductKey,productName,costPrice,sellingPrice,active\n' +
+          'p1,Bad,-5.00,2.00,true\n',
+      },
+    });
+    const before = storage.objects.size;
+    const result = await validateMigrationPackage(
+      ownerA,
+      { packageId: 'pkg-bad', expectedVersion: 1 },
+      { db: prismaMock as never, storage },
+    );
+    expect(result.packageStatus).toBe('VALIDATION_FAILED');
+    expect(result.runStatus).toBe('FAILED');
+    expect(result.errorCount).toBeGreaterThan(0);
+    expect(storage.objects.size).toBe(before);
+    expect(JSON.stringify(result).includes('memory.private.blob')).toBe(false);
+  });
+
+  it('rejects stale expectedVersion', async () => {
+    const storage = seedPackage({ businessId: 'biz-a', packageId: 'pkg-a', version: 3 });
+    await expect(
+      validateMigrationPackage(
+        ownerA,
+        { packageId: 'pkg-a', expectedVersion: 1 },
+        { db: prismaMock as never, storage },
+      ),
+    ).rejects.toMatchObject({ code: 'STALE_VERSION' });
+  });
+
+  it('idempotent replay returns existing SUCCESS run', async () => {
+    const storage = seedPackage({ businessId: 'biz-a', packageId: 'pkg-a' });
+    const first = await validateMigrationPackage(
+      ownerA,
+      { packageId: 'pkg-a', expectedVersion: 1 },
+      { db: prismaMock as never, storage },
+    );
+    const second = await validateMigrationPackage(
+      ownerA,
+      { packageId: 'pkg-a', expectedVersion: first.packageVersion },
+      { db: prismaMock as never, storage },
+    );
+    expect(second.replayed).toBe(true);
+    expect(second.validationRunId).toBe(first.validationRunId);
+    expect(state.runs.filter((r) => r.status === 'SUCCESS')).toHaveLength(1);
+  });
+
+  it('checksum mismatch never VALIDATED', async () => {
+    const storage = seedPackage({ businessId: 'biz-a', packageId: 'pkg-a' });
+    const file = state.files.find((f) => f.entityType === 'PRODUCTS')!;
+    // Corrupt recorded checksum while leaving object bytes unchanged.
+    file.uploadChecksum = 'ab'.repeat(32);
+    const result = await validateMigrationPackage(
+      ownerA,
+      { packageId: 'pkg-a', expectedVersion: 1 },
+      { db: prismaMock as never, storage },
+    );
+    expect(result.packageStatus).toBe('VALIDATION_FAILED');
+    expect(result.exceptions.some((i) => i.code === 'CHECKSUM_MISMATCH')).toBe(true);
+  });
+
+  it('file replacement demotion supersedes prior validation', async () => {
+    const storage = seedPackage({ businessId: 'biz-a', packageId: 'pkg-a' });
+    const first = await validateMigrationPackage(
+      ownerA,
+      { packageId: 'pkg-a', expectedVersion: 1 },
+      { db: prismaMock as never, storage },
+    );
+    expect(first.packageStatus).toBe('VALIDATED');
+    const pkg = state.packages.find((p) => p.id === 'pkg-a')!;
+    await prismaMock.$transaction(async (tx: typeof prismaMock) => {
+      const locked = {
+        id: pkg.id as string,
+        businessId: 'biz-a',
+        status: pkg.status as string,
+        version: pkg.version as number,
+        latestValidationRunId: pkg.latestValidationRunId as string | null,
+      };
+      await applyMaterialMutationDemotion(tx as never, locked);
+    });
+    const after = state.packages.find((p) => p.id === 'pkg-a')!;
+    expect(after.status).toBe('DRAFT');
+    expect(after.latestValidationRunId).toBeNull();
+    const run = state.runs.find((r) => r.id === first.validationRunId)!;
+    expect(run.supersededAt).toBeTruthy();
+  });
+
+  it('getMigrationValidationRun is tenant scoped', async () => {
+    const storage = seedPackage({ businessId: 'biz-b', packageId: 'pkg-b' });
+    const created = await validateMigrationPackage(
+      ownerB,
+      { packageId: 'pkg-b', expectedVersion: 1 },
+      { db: prismaMock as never, storage },
+    );
+    await expect(
+      getMigrationValidationRun(
+        ownerA,
+        { packageId: 'pkg-b', runId: created.validationRunId },
+        prismaMock as never,
+      ),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('missing Blob fails safely without deletion', async () => {
+    const storage = seedPackage({ businessId: 'biz-a', packageId: 'pkg-a' });
+    storage.objects.clear();
+    const result = await validateMigrationPackage(
+      ownerA,
+      { packageId: 'pkg-a', expectedVersion: 1 },
+      { db: prismaMock as never, storage },
+    );
+    expect(result.packageStatus).toBe('VALIDATION_FAILED');
+    expect(result.exceptions.some((i) => i.code === 'STORAGE_OBJECT_MISSING')).toBe(true);
+    expect(storage.objects.size).toBe(0);
+  });
+});

--- a/lib/services/migration/slice2b-services.test.ts
+++ b/lib/services/migration/slice2b-services.test.ts
@@ -410,7 +410,7 @@ describe('migration slice 2B validate service', () => {
     );
     expect(first.packageStatus).toBe('VALIDATED');
     const pkg = state.packages.find((p) => p.id === 'pkg-a')!;
-    await prismaMock.$transaction(async (tx: typeof prismaMock) => {
+    await prismaMock.$transaction(async (tx) => {
       const locked = {
         id: pkg.id as string,
         businessId: 'biz-a',

--- a/lib/services/migration/validate-engine.ts
+++ b/lib/services/migration/validate-engine.ts
@@ -1,0 +1,780 @@
+/**
+ * Source-neutral structural + semantic validation for Phase 1 CSV entity files.
+ */
+
+import {
+  parseActiveFlag,
+  parseAsOfDate,
+  parseNonNegativeIntegerQuantity,
+  parseOptionalActiveFlag,
+  requiredHeadersForEntity,
+  validateCsvHeaders,
+} from '@/lib/migration/contract';
+import {
+  compareMigrationIssues,
+  sanitiseMigrationIssue,
+  type MigrationValidationIssue,
+} from '@/lib/migration/issue-codes';
+import {
+  assertSourceStockValueMatches,
+  parseDecimalCurrencyToMinorUnits,
+  parseOpeningStockUnitCostToMinorUnits,
+} from '@/lib/migration/money';
+import type { MigrationEntityType } from '@/lib/migration/types';
+import { MigrationContractError } from '@/lib/migration/errors';
+import {
+  parseMigrationCsvStream,
+  type CsvParseResult,
+} from '@/lib/services/migration/csv-parser';
+
+export type EntityValidationInput = {
+  entityType: MigrationEntityType;
+  stream: ReadableStream<Uint8Array>;
+  expectedChecksum: string;
+};
+
+export type EntityValidationOutput = {
+  entityType: MigrationEntityType;
+  checksum: string;
+  expectedChecksum: string;
+  checksumMatched: boolean;
+  byteLength: number;
+  rowCount: number;
+  issues: MigrationValidationIssue[];
+  /** NFC+lower identity keys collected for cross-file checks. */
+  sourceKeys: Set<string>;
+  /** Raw display keys (first occurrence) keyed by identity. */
+  sourceKeyDisplay: Map<string, string>;
+  skus: Map<string, number>;
+  barcodes: Map<string, number>;
+  defaultSupplierRefs: Array<{ rowNumber: number; identity: string; display: string }>;
+  openingStockRefs: Array<{
+    rowNumber: number;
+    productIdentity: string;
+    branchIdentity: string;
+    branchDisplay: string;
+  }>;
+};
+
+function identityKey(raw: string): string {
+  return raw.trim().normalize('NFC').toLowerCase();
+}
+
+function issue(
+  partial: Omit<MigrationValidationIssue, 'message'> & { message: string },
+): MigrationValidationIssue {
+  return sanitiseMigrationIssue(partial as MigrationValidationIssue);
+}
+
+function mapParseIssues(
+  entityType: MigrationEntityType,
+  parsed: CsvParseResult,
+): MigrationValidationIssue[] {
+  return parsed.issues.map((p) =>
+    issue({
+      code:
+        p.code === 'EMPTY_FILE'
+          ? 'EMPTY_FILE'
+          : p.code === 'MALFORMED_QUOTING'
+            ? 'MALFORMED_QUOTING'
+            : p.code === 'TOO_MANY_COLUMNS'
+              ? 'TOO_MANY_COLUMNS'
+              : p.code === 'TOO_MANY_ROWS'
+                ? 'TOO_MANY_ROWS'
+                : p.code === 'FIELD_TOO_LONG'
+                  ? 'FIELD_TOO_LONG'
+                  : p.code === 'HEADER_TOO_LONG'
+                    ? 'HEADER_TOO_LONG'
+                    : p.code === 'ROW_WIDTH_MISMATCH'
+                      ? 'ROW_WIDTH_MISMATCH'
+                      : p.code === 'ENCODING_UNSUPPORTED'
+                        ? 'ENCODING_UNSUPPORTED'
+                        : 'MALFORMED_CSV',
+      severity: p.message.includes('Blank') ? 'warning' : 'error',
+      entityType,
+      rowNumber: p.rowNumber,
+      column: null,
+      message: p.message,
+    }),
+  );
+}
+
+function cellMap(headers: string[], cells: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (let i = 0; i < headers.length; i += 1) {
+    map.set(headers[i]!.toLowerCase(), cells[i] ?? '');
+  }
+  return map;
+}
+
+function checkFormula(
+  entityType: MigrationEntityType,
+  rowNumber: number,
+  column: string,
+  value: string,
+  out: MigrationValidationIssue[],
+): void {
+  if (/^[=+\-@]/.test(value)) {
+    out.push(
+      issue({
+        code: 'FORMULA_PREFIX_DETECTED',
+        severity: 'warning',
+        entityType,
+        rowNumber,
+        column,
+        message: 'Cell begins with a spreadsheet-formula prefix; treated as inert text.',
+      }),
+    );
+  }
+}
+
+function requireSourceKey(
+  entityType: MigrationEntityType,
+  rowNumber: number,
+  column: string,
+  raw: string,
+  out: MigrationValidationIssue[],
+): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    out.push(
+      issue({
+        code: 'REQUIRED_FIELD_MISSING',
+        severity: 'error',
+        entityType,
+        rowNumber,
+        column,
+        message: `${column} is required.`,
+      }),
+    );
+    return null;
+  }
+  if (trimmed.length > 128) {
+    out.push(
+      issue({
+        code: 'INVALID_SOURCE_KEY',
+        severity: 'error',
+        entityType,
+        rowNumber,
+        column,
+        message: `${column} exceeds 128 characters.`,
+      }),
+    );
+    return null;
+  }
+  checkFormula(entityType, rowNumber, column, trimmed, out);
+  return trimmed.normalize('NFC');
+}
+
+export async function validateEntityFile(
+  input: EntityValidationInput,
+): Promise<EntityValidationOutput> {
+  const issues: MigrationValidationIssue[] = [];
+  let parsed: CsvParseResult;
+  try {
+    parsed = await parseMigrationCsvStream(input.stream);
+  } catch (error) {
+    const code = (error as { code?: string })?.code;
+    issues.push(
+      issue({
+        code: code === 'TOO_LARGE' ? 'TOO_MANY_ROWS' : 'STORAGE_READ_FAILED',
+        severity: 'error',
+        entityType: input.entityType,
+        rowNumber: null,
+        column: null,
+        message:
+          code === 'TOO_LARGE'
+            ? 'File exceeds the maximum upload size.'
+            : 'Unable to read migration file contents.',
+      }),
+    );
+    return {
+      entityType: input.entityType,
+      checksum: '',
+      expectedChecksum: input.expectedChecksum.toLowerCase(),
+      checksumMatched: false,
+      byteLength: 0,
+      rowCount: 0,
+      issues,
+      sourceKeys: new Set(),
+      sourceKeyDisplay: new Map(),
+      skus: new Map(),
+      barcodes: new Map(),
+      defaultSupplierRefs: [],
+      openingStockRefs: [],
+    };
+  }
+
+  issues.push(...mapParseIssues(input.entityType, parsed));
+
+  const expected = input.expectedChecksum.toLowerCase();
+  const actual = parsed.sha256Hex.toLowerCase();
+  const checksumMatched = actual === expected && actual.length === 64;
+  if (!checksumMatched) {
+    issues.push(
+      issue({
+        code: 'CHECKSUM_MISMATCH',
+        severity: 'error',
+        entityType: input.entityType,
+        rowNumber: null,
+        column: null,
+        message: 'Streamed file checksum does not match the finalised upload checksum.',
+      }),
+    );
+  }
+
+  if (parsed.headers.length === 0) {
+    issues.push(
+      issue({
+        code: 'EMPTY_FILE',
+        severity: 'error',
+        entityType: input.entityType,
+        rowNumber: null,
+        column: null,
+        message: 'File has no header row.',
+      }),
+    );
+  }
+
+  const headerResult = validateCsvHeaders(input.entityType, parsed.headers);
+  for (const h of headerResult.missingRequired) {
+    issues.push(
+      issue({
+        code: 'MISSING_REQUIRED_HEADER',
+        severity: 'error',
+        entityType: input.entityType,
+        rowNumber: 1,
+        column: h,
+        message: `Missing required header: ${h}.`,
+      }),
+    );
+  }
+  for (const h of headerResult.duplicateHeaders) {
+    issues.push(
+      issue({
+        code: 'DUPLICATE_HEADER',
+        severity: 'error',
+        entityType: input.entityType,
+        rowNumber: 1,
+        column: h,
+        message: `Duplicate header: ${h}.`,
+      }),
+    );
+  }
+  for (const h of headerResult.unknownHeaders) {
+    issues.push(
+      issue({
+        code: 'UNKNOWN_HEADER',
+        severity: 'error',
+        entityType: input.entityType,
+        rowNumber: 1,
+        column: h,
+        message: `Unknown header: ${h}.`,
+      }),
+    );
+  }
+  for (const h of headerResult.prohibitedHeaders) {
+    issues.push(
+      issue({
+        code: 'PROHIBITED_HEADER',
+        severity: 'error',
+        entityType: input.entityType,
+        rowNumber: 1,
+        column: h,
+        message: `Prohibited Phase 1 field: ${h}.`,
+      }),
+    );
+  }
+
+  if (headerResult.ok && parsed.rows.length === 0) {
+    issues.push(
+      issue({
+        code: 'HEADER_ONLY_FILE',
+        severity: 'error',
+        entityType: input.entityType,
+        rowNumber: 1,
+        column: null,
+        message: 'File contains a header but no data rows.',
+      }),
+    );
+  }
+
+  const normalisedHeaders = headerResult.normalisedHeaders.map((h) => h.toLowerCase());
+  const sourceKeys = new Set<string>();
+  const sourceKeyDisplay = new Map<string, string>();
+  const skus = new Map<string, number>();
+  const barcodes = new Map<string, number>();
+  const defaultSupplierRefs: EntityValidationOutput['defaultSupplierRefs'] = [];
+  const openingStockRefs: EntityValidationOutput['openingStockRefs'] = [];
+  const openingLineKeys = new Set<string>();
+
+  // Only row-validate when headers are usable enough to map required columns.
+  const required = requiredHeadersForEntity(input.entityType);
+  const canRowValidate =
+    headerResult.missingRequired.length === 0 && headerResult.duplicateHeaders.length === 0;
+
+  if (canRowValidate) {
+    for (let i = 0; i < parsed.rows.length; i += 1) {
+      const rowNumber = parsed.rowNumbers[i] ?? i + 2;
+      const cells = parsed.rows[i]!;
+      const map = cellMap(normalisedHeaders, cells);
+
+      for (const [col, val] of map.entries()) {
+        if (val) checkFormula(input.entityType, rowNumber, col, val, issues);
+      }
+
+      if (input.entityType === 'SUPPLIERS') {
+        const key = requireSourceKey(
+          input.entityType,
+          rowNumber,
+          'sourceSupplierKey',
+          map.get('sourcesupplierkey') ?? '',
+          issues,
+        );
+        if (key) {
+          const id = identityKey(key);
+          if (sourceKeys.has(id)) {
+            issues.push(
+              issue({
+                code: 'DUPLICATE_SOURCE_KEY',
+                severity: 'error',
+                entityType: input.entityType,
+                rowNumber,
+                column: 'sourceSupplierKey',
+                message: 'Duplicate sourceSupplierKey in suppliers file.',
+                sourceKey: key,
+              }),
+            );
+          } else {
+            sourceKeys.add(id);
+            sourceKeyDisplay.set(id, key);
+          }
+        }
+        const name = (map.get('suppliername') ?? '').trim();
+        if (!name) {
+          issues.push(
+            issue({
+              code: 'REQUIRED_FIELD_MISSING',
+              severity: 'error',
+              entityType: input.entityType,
+              rowNumber,
+              column: 'supplierName',
+              message: 'supplierName is required.',
+              sourceKey: key,
+            }),
+          );
+        } else if (name.length > 200) {
+          issues.push(
+            issue({
+              code: 'FIELD_TOO_LONG',
+              severity: 'error',
+              entityType: input.entityType,
+              rowNumber,
+              column: 'supplierName',
+              message: 'supplierName exceeds 200 characters.',
+              sourceKey: key,
+            }),
+          );
+        }
+        const activeRaw = map.get('active');
+        if (activeRaw != null && activeRaw.trim() !== '') {
+          try {
+            parseOptionalActiveFlag(activeRaw);
+          } catch {
+            issues.push(
+              issue({
+                code: 'INVALID_ACTIVE_FLAG',
+                severity: 'error',
+                entityType: input.entityType,
+                rowNumber,
+                column: 'active',
+                message: 'active must be true/false (or 1/0).',
+                sourceKey: key,
+              }),
+            );
+          }
+        }
+      }
+
+      if (input.entityType === 'PRODUCTS') {
+        const key = requireSourceKey(
+          input.entityType,
+          rowNumber,
+          'sourceProductKey',
+          map.get('sourceproductkey') ?? '',
+          issues,
+        );
+        if (key) {
+          const id = identityKey(key);
+          if (sourceKeys.has(id)) {
+            issues.push(
+              issue({
+                code: 'DUPLICATE_SOURCE_KEY',
+                severity: 'error',
+                entityType: input.entityType,
+                rowNumber,
+                column: 'sourceProductKey',
+                message: 'Duplicate sourceProductKey in products file.',
+                sourceKey: key,
+              }),
+            );
+          } else {
+            sourceKeys.add(id);
+            sourceKeyDisplay.set(id, key);
+          }
+        }
+        const name = (map.get('productname') ?? '').trim();
+        if (!name) {
+          issues.push(
+            issue({
+              code: 'REQUIRED_FIELD_MISSING',
+              severity: 'error',
+              entityType: input.entityType,
+              rowNumber,
+              column: 'productName',
+              message: 'productName is required.',
+              sourceKey: key,
+            }),
+          );
+        }
+        for (const moneyCol of ['costprice', 'sellingprice'] as const) {
+          const label = moneyCol === 'costprice' ? 'costPrice' : 'sellingPrice';
+          const raw = map.get(moneyCol) ?? '';
+          try {
+            const minor = parseDecimalCurrencyToMinorUnits(raw, label);
+            if (minor < 0) {
+              issues.push(
+                issue({
+                  code: 'NEGATIVE_VALUE_PROHIBITED',
+                  severity: 'error',
+                  entityType: input.entityType,
+                  rowNumber,
+                  column: label,
+                  message: `${label} must not be negative.`,
+                  sourceKey: key,
+                }),
+              );
+            }
+          } catch (err) {
+            const msg = err instanceof MigrationContractError ? err.message : 'Invalid decimal.';
+            const code = /decimal places/i.test(msg)
+              ? 'INVALID_MONETARY_PRECISION'
+              : 'INVALID_DECIMAL';
+            issues.push(
+              issue({
+                code,
+                severity: 'error',
+                entityType: input.entityType,
+                rowNumber,
+                column: label,
+                message: msg,
+                sourceKey: key,
+              }),
+            );
+          }
+        }
+        try {
+          parseActiveFlag(map.get('active') ?? '', 'active');
+        } catch {
+          issues.push(
+            issue({
+              code: 'INVALID_ACTIVE_FLAG',
+              severity: 'error',
+              entityType: input.entityType,
+              rowNumber,
+              column: 'active',
+              message: 'active must be true/false (or 1/0).',
+              sourceKey: key,
+            }),
+          );
+        }
+        const sku = (map.get('sku') ?? '').trim();
+        if (sku) {
+          const skuId = identityKey(sku);
+          if (skus.has(skuId)) {
+            issues.push(
+              issue({
+                code: 'DUPLICATE_SKU',
+                severity: 'error',
+                entityType: input.entityType,
+                rowNumber,
+                column: 'sku',
+                message: 'Duplicate sku within products file.',
+                sourceKey: key,
+              }),
+            );
+          } else {
+            skus.set(skuId, rowNumber);
+          }
+        }
+        const barcode = (map.get('barcode') ?? '').trim();
+        if (!barcode) {
+          issues.push(
+            issue({
+              code: 'MISSING_BARCODE',
+              severity: 'warning',
+              entityType: input.entityType,
+              rowNumber,
+              column: 'barcode',
+              message: 'Barcode is missing; none will be generated.',
+              sourceKey: key,
+            }),
+          );
+        } else {
+          const bcId = identityKey(barcode);
+          if (barcodes.has(bcId)) {
+            issues.push(
+              issue({
+                code: 'DUPLICATE_BARCODE',
+                severity: 'error',
+                entityType: input.entityType,
+                rowNumber,
+                column: 'barcode',
+                message: 'Duplicate barcode within products file.',
+                sourceKey: key,
+              }),
+            );
+          } else {
+            barcodes.set(bcId, rowNumber);
+          }
+        }
+        const supplierRef = (map.get('defaultsuppliersourcekey') ?? '').trim();
+        if (supplierRef) {
+          defaultSupplierRefs.push({
+            rowNumber,
+            identity: identityKey(supplierRef),
+            display: supplierRef.normalize('NFC'),
+          });
+        }
+      }
+
+      if (input.entityType === 'OPENING_STOCK') {
+        const productKey = requireSourceKey(
+          input.entityType,
+          rowNumber,
+          'sourceProductKey',
+          map.get('sourceproductkey') ?? '',
+          issues,
+        );
+        const branchKey = requireSourceKey(
+          input.entityType,
+          rowNumber,
+          'sourceBranchKey',
+          map.get('sourcebranchkey') ?? '',
+          issues,
+        );
+        let quantity = -1;
+        try {
+          quantity = parseNonNegativeIntegerQuantity(map.get('quantity') ?? '');
+        } catch (err) {
+          issues.push(
+            issue({
+              code: 'INVALID_QUANTITY',
+              severity: 'error',
+              entityType: input.entityType,
+              rowNumber,
+              column: 'quantity',
+              message:
+                err instanceof MigrationContractError ? err.message : 'Invalid quantity.',
+              sourceKey: productKey,
+            }),
+          );
+        }
+        let unitCostMinor = -1;
+        try {
+          unitCostMinor = parseOpeningStockUnitCostToMinorUnits(map.get('unitcost') ?? '');
+        } catch (err) {
+          const msg = err instanceof MigrationContractError ? err.message : 'Invalid unitCost.';
+          issues.push(
+            issue({
+              code: /decimal places/i.test(msg)
+                ? 'INVALID_MONETARY_PRECISION'
+                : /negative/i.test(msg)
+                  ? 'NEGATIVE_VALUE_PROHIBITED'
+                  : 'INVALID_DECIMAL',
+              severity: 'error',
+              entityType: input.entityType,
+              rowNumber,
+              column: 'unitCost',
+              message: msg,
+              sourceKey: productKey,
+            }),
+          );
+        }
+        try {
+          parseAsOfDate(map.get('asofdate') ?? '');
+        } catch (err) {
+          issues.push(
+            issue({
+              code: 'INVALID_DATE',
+              severity: 'error',
+              entityType: input.entityType,
+              rowNumber,
+              column: 'asOfDate',
+              message: err instanceof MigrationContractError ? err.message : 'Invalid asOfDate.',
+              sourceKey: productKey,
+            }),
+          );
+        }
+        if (quantity >= 0 && unitCostMinor >= 0) {
+          try {
+            assertSourceStockValueMatches({
+              quantityBase: quantity,
+              unitCostMinor,
+              sourceStockValueRaw: map.get('sourcestockvalue') ?? '',
+            });
+          } catch (err) {
+            issues.push(
+              issue({
+                code: 'STOCK_VALUE_MISMATCH',
+                severity: 'error',
+                entityType: input.entityType,
+                rowNumber,
+                column: 'sourceStockValue',
+                message:
+                  err instanceof MigrationContractError
+                    ? err.message
+                    : 'sourceStockValue mismatch.',
+                sourceKey: productKey,
+              }),
+            );
+          }
+        }
+        if (productKey && branchKey) {
+          const lineId = `${identityKey(productKey)}|${identityKey(branchKey)}`;
+          if (openingLineKeys.has(lineId)) {
+            issues.push(
+              issue({
+                code: 'DUPLICATE_OPENING_STOCK_LINE',
+                severity: 'error',
+                entityType: input.entityType,
+                rowNumber,
+                column: 'sourceProductKey',
+                message: 'Duplicate opening-stock line for product and branch.',
+                sourceKey: productKey,
+              }),
+            );
+          } else {
+            openingLineKeys.add(lineId);
+          }
+          openingStockRefs.push({
+            rowNumber,
+            productIdentity: identityKey(productKey),
+            branchIdentity: identityKey(branchKey),
+            branchDisplay: branchKey,
+          });
+          sourceKeys.add(identityKey(productKey));
+        }
+      }
+    }
+  }
+
+  // Silence unused required for lint in edge builds
+  void required;
+
+  issues.sort(compareMigrationIssues);
+  return {
+    entityType: input.entityType,
+    checksum: actual,
+    expectedChecksum: expected,
+    checksumMatched,
+    byteLength: parsed.byteLength,
+    rowCount: parsed.rows.length,
+    issues,
+    sourceKeys,
+    sourceKeyDisplay,
+    skus,
+    barcodes,
+    defaultSupplierRefs,
+    openingStockRefs,
+  };
+}
+
+export function applyCrossFileSemantics(input: {
+  suppliers: EntityValidationOutput;
+  products: EntityValidationOutput;
+  openingStock: EntityValidationOutput;
+  branchMappings: Array<{ sourceBranchKey: string }>;
+}): MigrationValidationIssue[] {
+  const issues: MigrationValidationIssue[] = [];
+  for (const ref of input.products.defaultSupplierRefs) {
+    if (!input.suppliers.sourceKeys.has(ref.identity)) {
+      issues.push(
+        issue({
+          code: 'SUPPLIER_REFERENCE_MISSING',
+          severity: 'error',
+          entityType: 'PRODUCTS',
+          rowNumber: ref.rowNumber,
+          column: 'defaultSupplierSourceKey',
+          message: 'defaultSupplierSourceKey does not match any suppliers-file sourceSupplierKey.',
+          sourceKey: ref.display,
+        }),
+      );
+    }
+  }
+  for (const ref of input.openingStock.openingStockRefs) {
+    if (!input.products.sourceKeys.has(ref.productIdentity)) {
+      issues.push(
+        issue({
+          code: 'PRODUCT_REFERENCE_MISSING',
+          severity: 'error',
+          entityType: 'OPENING_STOCK',
+          rowNumber: ref.rowNumber,
+          column: 'sourceProductKey',
+          message: 'sourceProductKey does not match any products-file sourceProductKey.',
+        }),
+      );
+    }
+  }
+
+  const mapped = new Set(
+    input.branchMappings.map((m) => identityKey(m.sourceBranchKey)),
+  );
+  const distinctBranches = new Set(
+    input.openingStock.openingStockRefs.map((r) => r.branchIdentity),
+  );
+  if (distinctBranches.size > 0 && mapped.size === 0) {
+    issues.push(
+      issue({
+        code: 'BRANCH_MAPPINGS_REQUIRED',
+        severity: 'error',
+        entityType: 'PACKAGE',
+        rowNumber: null,
+        column: null,
+        message: 'Opening stock requires package branch mappings before validation can succeed.',
+      }),
+    );
+  } else {
+    for (const ref of input.openingStock.openingStockRefs) {
+      if (!mapped.has(ref.branchIdentity)) {
+        issues.push(
+          issue({
+            code: 'BRANCH_KEY_UNMAPPED',
+            severity: 'error',
+            entityType: 'OPENING_STOCK',
+            rowNumber: ref.rowNumber,
+            column: 'sourceBranchKey',
+            message: 'sourceBranchKey is not mapped to a store on this package.',
+            sourceKey: ref.branchDisplay,
+          }),
+        );
+      }
+    }
+  }
+
+  issues.sort(compareMigrationIssues);
+  return issues;
+}
+
+export function summariseIssues(issues: MigrationValidationIssue[]): {
+  errorCount: number;
+  warningCount: number;
+} {
+  let errorCount = 0;
+  let warningCount = 0;
+  for (const i of issues) {
+    if (i.severity === 'error') errorCount += 1;
+    else warningCount += 1;
+  }
+  return { errorCount, warningCount };
+}

--- a/lib/services/migration/validate.ts
+++ b/lib/services/migration/validate.ts
@@ -1,0 +1,562 @@
+/**
+ * Slice 2B — tenant-scoped migration package validation service.
+ *
+ * Read-only vs ordinary business data. Persists MigrationValidationRun and
+ * CAS-transitions package to VALIDATED | VALIDATION_FAILED.
+ */
+
+import { createHash } from 'crypto';
+import { prisma } from '@/lib/prisma';
+import { assertPackageTransition } from '@/lib/migration/lifecycle';
+import {
+  clampJsonString,
+  MIGRATION_MAX_EXCEPTIONS_RETAINED,
+  truncateExceptionsForStorage,
+} from '@/lib/migration/limits';
+import {
+  compareMigrationIssues,
+  sanitiseMigrationIssue,
+  type MigrationValidationIssue,
+} from '@/lib/migration/issue-codes';
+import { manifestChecksum } from '@/lib/migration/manifest';
+import {
+  MIGRATION_ENTITY_TYPES,
+  type MigrationEntityType,
+  type MigrationPackageStatus,
+} from '@/lib/migration/types';
+import { MigrationServiceError } from '@/lib/services/migration/errors';
+import {
+  assertExpectedVersion,
+  assertMigrationActor,
+  lockPackageForBusiness,
+  requireExpectedVersion,
+  writeMigrationAudit,
+  type ActorContext,
+  type DbClient,
+} from '@/lib/services/migration/preapproval';
+import {
+  getMigrationObjectStorage,
+  type MigrationObjectStorage,
+} from '@/lib/services/migration/storage';
+import {
+  applyCrossFileSemantics,
+  summariseIssues,
+  validateEntityFile,
+  type EntityValidationOutput,
+} from '@/lib/services/migration/validate-engine';
+
+export type ValidateMigrationPackageInput = {
+  packageId: string;
+  expectedVersion: number;
+  /** Ignored — session business is authoritative. */
+  businessId?: string;
+};
+
+export type ValidateMigrationPackageResult = {
+  packageId: string;
+  packageStatus: 'VALIDATED' | 'VALIDATION_FAILED';
+  packageVersion: number;
+  validationRunId: string;
+  runStatus: 'SUCCESS' | 'FAILED';
+  manifestChecksum: string;
+  replayed: boolean;
+  durationMs: number;
+  totalRowsProcessed: number;
+  errorCount: number;
+  warningCount: number;
+  exceptionCount: number;
+  exceptionsTruncated: number;
+  exceptions: MigrationValidationIssue[];
+  fileChecksums: Record<string, string>;
+};
+
+const ELIGIBLE = new Set(['DRAFT', 'VALIDATED', 'VALIDATION_FAILED']);
+
+function emptyEntity(entityType: MigrationEntityType): EntityValidationOutput {
+  return {
+    entityType,
+    checksum: '',
+    expectedChecksum: '',
+    checksumMatched: false,
+    byteLength: 0,
+    rowCount: 0,
+    issues: [],
+    sourceKeys: new Set(),
+    sourceKeyDisplay: new Map(),
+    skus: new Map(),
+    barcodes: new Map(),
+    defaultSupplierRefs: [],
+    openingStockRefs: [],
+  };
+}
+
+function digestSummary(payload: unknown): string {
+  return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+}
+
+export async function validateMigrationPackage(
+  actorInput: {
+    userId: string;
+    userName?: string | null;
+    userRole: string;
+    businessId: string;
+  },
+  input: ValidateMigrationPackageInput,
+  deps: {
+    db?: DbClient;
+    storage?: MigrationObjectStorage;
+  } = {},
+): Promise<ValidateMigrationPackageResult> {
+  const started = Date.now();
+  const db = deps.db ?? prisma;
+  const storage = deps.storage ?? getMigrationObjectStorage();
+  const actor: ActorContext = {
+    ...assertMigrationActor(actorInput),
+    userName: actorInput.userName?.trim() || actorInput.userId,
+  };
+  const expectedVersion = requireExpectedVersion(input.expectedVersion);
+  const packageId = String(input.packageId ?? '').trim();
+  if (!packageId || packageId.length > 64) {
+    throw new MigrationServiceError('NOT_FOUND', undefined, 404);
+  }
+
+  // Session business only — never trust client businessId.
+  const preview = await db.migrationPackage.findFirst({
+    where: { id: packageId, businessId: actor.businessId },
+    include: {
+      files: true,
+      branchMappings: { select: { sourceBranchKey: true, targetStoreId: true } },
+      latestValidationRun: true,
+    },
+  });
+  if (!preview) {
+    throw new MigrationServiceError('NOT_FOUND', undefined, 404);
+  }
+  if (!ELIGIBLE.has(preview.status)) {
+    throw new MigrationServiceError('LIFECYCLE', undefined, 409);
+  }
+  assertExpectedVersion(
+    {
+      id: preview.id,
+      businessId: actor.businessId,
+      status: preview.status,
+      version: preview.version,
+      latestValidationRunId: preview.latestValidationRunId,
+    },
+    expectedVersion,
+  );
+
+  const filesByType = new Map(preview.files.map((f) => [f.entityType, f]));
+  const missing: string[] = [];
+  for (const t of MIGRATION_ENTITY_TYPES) {
+    const f = filesByType.get(t);
+    if (!f || f.storageStatus !== 'FINALISED' || !f.storageKey || !f.uploadChecksum) {
+      missing.push(t);
+    }
+  }
+
+  // Idempotent replay: same SUCCESS checksum + matching version.
+  if (
+    preview.status === 'VALIDATED' &&
+    preview.latestValidationRun &&
+    preview.latestValidationRun.status === 'SUCCESS' &&
+    !preview.latestValidationRun.supersededAt
+  ) {
+    const currentManifest = buildPreviewManifestChecksum(preview);
+    if (preview.latestValidationRun.manifestChecksum === currentManifest && missing.length === 0) {
+      const summary = safeParseSummary(preview.latestValidationRun.summaryJson);
+      return {
+        packageId: preview.id,
+        packageStatus: 'VALIDATED',
+        packageVersion: preview.version,
+        validationRunId: preview.latestValidationRun.id,
+        runStatus: 'SUCCESS',
+        manifestChecksum: preview.latestValidationRun.manifestChecksum,
+        replayed: true,
+        durationMs: Date.now() - started,
+        totalRowsProcessed: Number(summary.totalRowsProcessed ?? 0),
+        errorCount: Number(summary.errorCount ?? 0),
+        warningCount: Number(summary.warningCount ?? 0),
+        exceptionCount: preview.latestValidationRun.exceptionCount,
+        exceptionsTruncated: preview.latestValidationRun.exceptionsTruncated,
+        exceptions: Array.isArray(summary.exceptions)
+          ? (summary.exceptions as MigrationValidationIssue[])
+          : [],
+        fileChecksums: (summary.fileChecksums as Record<string, string>) ?? {},
+      };
+    }
+  }
+
+  const allIssues: MigrationValidationIssue[] = [];
+  if (missing.length) {
+    allIssues.push(
+      sanitiseMigrationIssue({
+        code: 'PACKAGE_INCOMPLETE',
+        severity: 'error',
+        entityType: 'PACKAGE',
+        rowNumber: null,
+        column: null,
+        message: `Package is missing finalised files: ${missing.join(', ')}.`,
+      }),
+    );
+  }
+
+  await db.$transaction(async (tx) => {
+    await writeMigrationAudit(tx, {
+      businessId: actor.businessId,
+      userId: actor.userId,
+      userName: actor.userName,
+      userRole: actor.userRole,
+      action: 'MIGRATION_VALIDATION_REQUESTED',
+      entityId: preview.id,
+      details: {
+        packageVersion: preview.version,
+        status: preview.status,
+        missingFiles: missing,
+      },
+    });
+  });
+
+  const entityResults: Record<MigrationEntityType, EntityValidationOutput> = {
+    SUPPLIERS: emptyEntity('SUPPLIERS'),
+    PRODUCTS: emptyEntity('PRODUCTS'),
+    OPENING_STOCK: emptyEntity('OPENING_STOCK'),
+  };
+
+  if (missing.length === 0) {
+    for (const entityType of MIGRATION_ENTITY_TYPES) {
+      const file = filesByType.get(entityType)!;
+      try {
+        const { stream } = await storage.getStream(file.storageKey!);
+        entityResults[entityType] = await validateEntityFile({
+          entityType,
+          stream,
+          expectedChecksum: file.uploadChecksum,
+        });
+      } catch {
+        entityResults[entityType] = {
+          ...emptyEntity(entityType),
+          expectedChecksum: file.uploadChecksum.toLowerCase(),
+          issues: [
+            sanitiseMigrationIssue({
+              code: 'STORAGE_OBJECT_MISSING',
+              severity: 'error',
+              entityType,
+              rowNumber: null,
+              column: null,
+              message: 'Private migration object could not be read.',
+            }),
+          ],
+        };
+      }
+      allIssues.push(...entityResults[entityType].issues);
+    }
+    allIssues.push(
+      ...applyCrossFileSemantics({
+        suppliers: entityResults.SUPPLIERS,
+        products: entityResults.PRODUCTS,
+        openingStock: entityResults.OPENING_STOCK,
+        branchMappings: preview.branchMappings,
+      }),
+    );
+  }
+
+  allIssues.sort(compareMigrationIssues);
+  const { errorCount, warningCount } = summariseIssues(allIssues);
+  const { retained, truncated } = truncateExceptionsForStorage(allIssues);
+  const retainedSanitised = retained.map(sanitiseMigrationIssue);
+
+  const fileChecksums: Record<string, string> = {};
+  for (const t of MIGRATION_ENTITY_TYPES) {
+    const f = filesByType.get(t);
+    if (f) fileChecksums[t] = f.uploadChecksum.toLowerCase();
+  }
+
+  const nextManifest = manifestChecksum({
+    contractVersion: preview.contractVersion,
+    sourceSystemKey: preview.sourceSystemKey,
+    sourceBusinessKey: preview.sourceBusinessKey,
+    reportingCurrency: preview.reportingCurrency,
+    packageAsOfDate: preview.packageAsOfDate,
+    files: MIGRATION_ENTITY_TYPES.filter((t) => filesByType.get(t)?.uploadChecksum).map((t) => ({
+      entityType: t,
+      checksum: filesByType.get(t)!.uploadChecksum,
+    })),
+    branchMappings: preview.branchMappings.map((m) => ({
+      sourceBranchKey: m.sourceBranchKey,
+      targetStoreId: m.targetStoreId,
+    })),
+  });
+
+  const success = errorCount === 0 && missing.length === 0;
+  // Checksum mismatches are already errors in entity issues — belt and braces:
+  for (const t of MIGRATION_ENTITY_TYPES) {
+    if (entityResults[t].checksum && !entityResults[t].checksumMatched) {
+      if (success) {
+        /* unreachable when issues include CHECKSUM_MISMATCH */
+      }
+    }
+  }
+  const packageStatus = success ? 'VALIDATED' : 'VALIDATION_FAILED';
+  const runStatus = success ? 'SUCCESS' : 'FAILED';
+  const durationMs = Date.now() - started;
+  const totalRowsProcessed =
+    entityResults.SUPPLIERS.rowCount +
+    entityResults.PRODUCTS.rowCount +
+    entityResults.OPENING_STOCK.rowCount;
+
+  const summaryObject = {
+    contractVersion: preview.contractVersion,
+    durationMs,
+    totalRowsProcessed,
+    validRowEstimate: Math.max(0, totalRowsProcessed),
+    errorCount,
+    warningCount,
+    exceptionCount: allIssues.length,
+    exceptionsTruncated: truncated,
+    exceptions: retainedSanitised,
+    fileChecksums,
+    rowCounts: {
+      SUPPLIERS: entityResults.SUPPLIERS.rowCount,
+      PRODUCTS: entityResults.PRODUCTS.rowCount,
+      OPENING_STOCK: entityResults.OPENING_STOCK.rowCount,
+    },
+  };
+  const summaryJson = clampJsonString(summaryObject);
+  const resultDigest = digestSummary({
+    manifestChecksum: nextManifest,
+    runStatus,
+    errorCount,
+    warningCount,
+    exceptionCount: allIssues.length,
+    exceptionsTruncated: truncated,
+  });
+
+  const persisted = await db.$transaction(async (tx) => {
+    const locked = await lockPackageForBusiness(tx, {
+      businessId: actor.businessId,
+      packageId: preview.id,
+    });
+    assertExpectedVersion(locked, expectedVersion);
+    if (!ELIGIBLE.has(locked.status)) {
+      throw new MigrationServiceError('LIFECYCLE', undefined, 409);
+    }
+
+    // Re-verify finalised checksums under lock (replacement race).
+    const freshFiles = await tx.migrationFile.findMany({
+      where: { businessId: actor.businessId, packageId: preview.id },
+    });
+    for (const t of MIGRATION_ENTITY_TYPES) {
+      const f = freshFiles.find((x) => x.entityType === t);
+      const prior = fileChecksums[t];
+      if (!f || f.storageStatus !== 'FINALISED' || !prior || f.uploadChecksum.toLowerCase() !== prior) {
+        throw new MigrationServiceError('STALE_VERSION', undefined, 409);
+      }
+    }
+
+    assertPackageTransition(locked.status as MigrationPackageStatus, packageStatus);
+
+    if (locked.latestValidationRunId) {
+      await tx.migrationValidationRun.updateMany({
+        where: {
+          id: locked.latestValidationRunId,
+          businessId: actor.businessId,
+          packageId: preview.id,
+          supersededAt: null,
+        },
+        data: { status: 'STALE', supersededAt: new Date() },
+      });
+    }
+
+    const run = await tx.migrationValidationRun.create({
+      data: {
+        businessId: actor.businessId,
+        packageId: preview.id,
+        status: runStatus,
+        manifestChecksum: nextManifest,
+        resultDigest,
+        summaryJson,
+        exceptionCount: allIssues.length,
+        exceptionsTruncated: truncated,
+        validatedByUserId: actor.userId,
+      },
+    });
+
+    const nextVersion = locked.version + 1;
+    await tx.migrationPackage.update({
+      where: { id: preview.id },
+      data: {
+        status: packageStatus,
+        version: nextVersion,
+        latestValidationRunId: run.id,
+        validatedAt: success ? new Date() : null,
+        validatedByUserId: success ? actor.userId : null,
+        errorMessage: success
+          ? null
+          : `Validation failed with ${errorCount} error(s).`,
+        summaryJson: clampJsonString({
+          lastValidationRunId: run.id,
+          runStatus,
+          errorCount,
+          warningCount,
+        }),
+        manifestChecksum: nextManifest,
+      },
+    });
+
+    if (success) {
+      for (const t of MIGRATION_ENTITY_TYPES) {
+        const f = freshFiles.find((x) => x.entityType === t)!;
+        await tx.migrationFile.update({
+          where: { id: f.id },
+          data: {
+            validationChecksum: f.uploadChecksum,
+            validatedAt: new Date(),
+            rowCount: entityResults[t].rowCount,
+          },
+        });
+      }
+    }
+
+    const hasChecksumIssue = allIssues.some((i) => i.code === 'CHECKSUM_MISMATCH');
+    await writeMigrationAudit(tx, {
+      businessId: actor.businessId,
+      userId: actor.userId,
+      userName: actor.userName,
+      userRole: actor.userRole,
+      action: success
+        ? 'MIGRATION_VALIDATION_SUCCEEDED'
+        : hasChecksumIssue
+          ? 'MIGRATION_VALIDATION_CHECKSUM_MISMATCH'
+          : 'MIGRATION_VALIDATION_FAILED',
+      entityId: preview.id,
+      details: {
+        validationRunId: run.id,
+        fromStatus: locked.status,
+        toStatus: packageStatus,
+        fromVersion: locked.version,
+        toVersion: nextVersion,
+        manifestChecksumPrefix: nextManifest.slice(0, 12),
+        durationMs,
+        totalRowsProcessed,
+        errorCount,
+        warningCount,
+        exceptionCount: allIssues.length,
+        exceptionsTruncated: truncated,
+        replayed: false,
+      },
+    });
+
+    return { runId: run.id, nextVersion };
+  });
+
+  return {
+    packageId: preview.id,
+    packageStatus,
+    packageVersion: persisted.nextVersion,
+    validationRunId: persisted.runId,
+    runStatus,
+    manifestChecksum: nextManifest,
+    replayed: false,
+    durationMs,
+    totalRowsProcessed,
+    errorCount,
+    warningCount,
+    exceptionCount: Math.min(allIssues.length, MIGRATION_MAX_EXCEPTIONS_RETAINED + truncated),
+    exceptionsTruncated: truncated,
+    exceptions: retainedSanitised,
+    fileChecksums,
+  };
+}
+
+export async function getMigrationValidationRun(
+  actorInput: {
+    userId: string;
+    userName?: string | null;
+    userRole: string;
+    businessId: string;
+  },
+  input: { packageId: string; runId: string },
+  db: DbClient = prisma,
+): Promise<{
+  packageId: string;
+  validationRunId: string;
+  runStatus: string;
+  packageStatus: string;
+  packageVersion: number;
+  manifestChecksum: string;
+  exceptionCount: number;
+  exceptionsTruncated: number;
+  exceptions: MigrationValidationIssue[];
+  supersededAt: string | null;
+  createdAt: string;
+}> {
+  const actor = assertMigrationActor(actorInput);
+  const pkg = await db.migrationPackage.findFirst({
+    where: { id: input.packageId, businessId: actor.businessId },
+    select: { id: true, status: true, version: true },
+  });
+  if (!pkg) {
+    throw new MigrationServiceError('NOT_FOUND', undefined, 404);
+  }
+  const run = await db.migrationValidationRun.findFirst({
+    where: {
+      id: input.runId,
+      packageId: input.packageId,
+      businessId: actor.businessId,
+    },
+  });
+  if (!run) {
+    throw new MigrationServiceError('NOT_FOUND', undefined, 404);
+  }
+  const summary = safeParseSummary(run.summaryJson);
+  return {
+    packageId: pkg.id,
+    validationRunId: run.id,
+    runStatus: run.status,
+    packageStatus: pkg.status,
+    packageVersion: pkg.version,
+    manifestChecksum: run.manifestChecksum,
+    exceptionCount: run.exceptionCount,
+    exceptionsTruncated: run.exceptionsTruncated,
+    exceptions: Array.isArray(summary.exceptions)
+      ? (summary.exceptions as MigrationValidationIssue[]).map(sanitiseMigrationIssue)
+      : [],
+    supersededAt: run.supersededAt ? run.supersededAt.toISOString() : null,
+    createdAt: run.createdAt.toISOString(),
+  };
+}
+
+function safeParseSummary(raw: string | null | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function buildPreviewManifestChecksum(preview: {
+  contractVersion: string;
+  sourceSystemKey: string;
+  sourceBusinessKey: string;
+  reportingCurrency: string;
+  packageAsOfDate: string;
+  files: Array<{ entityType: string; uploadChecksum: string; storageStatus: string }>;
+  branchMappings: Array<{ sourceBranchKey: string; targetStoreId: string }>;
+}): string {
+  const files = MIGRATION_ENTITY_TYPES.map((t) => {
+    const f = preview.files.find((x) => x.entityType === t && x.storageStatus === 'FINALISED');
+    return f ? { entityType: t, checksum: f.uploadChecksum } : null;
+  }).filter(Boolean) as Array<{ entityType: MigrationEntityType; checksum: string }>;
+  return manifestChecksum({
+    contractVersion: preview.contractVersion,
+    sourceSystemKey: preview.sourceSystemKey,
+    sourceBusinessKey: preview.sourceBusinessKey,
+    reportingCurrency: preview.reportingCurrency,
+    packageAsOfDate: preview.packageAsOfDate,
+    files,
+    branchMappings: preview.branchMappings,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
     "test:migration:p1-slice2a:pg": "node scripts/migration-p1-slice2a-pg-test.cjs",
     "test:migration:p1-slice2a:preview-probe": "node scripts/migration-p1-slice2a-preview-probe.cjs",
     "test:migration:p1-sql-only-contract": "node scripts/migration-p1-sql-only-constraint-contract.cjs",
-    "test:migration:slice2a:unit": "vitest run --reporter=dot lib/services/migration/file-policy.test.ts lib/services/migration/storage-vercel.test.ts lib/services/migration/slice2a-services.test.ts lib/services/migration/errors-public.test.ts lib/services/migration/cleanup-referenced-object.test.ts"
+    "test:migration:slice2a:unit": "vitest run --reporter=dot lib/services/migration/file-policy.test.ts lib/services/migration/storage-vercel.test.ts lib/services/migration/slice2a-services.test.ts lib/services/migration/errors-public.test.ts lib/services/migration/cleanup-referenced-object.test.ts",
+    "test:migration:slice2b:unit": "vitest run --reporter=dot lib/services/migration/slice2b-engine.test.ts lib/services/migration/slice2b-services.test.ts lib/migration/lifecycle.test.ts lib/services/migration/storage-vercel.test.ts",
+    "test:migration:slice2b:scale": "vitest run --reporter=verbose lib/services/migration/slice2b-scale.test.ts",
+    "test:migration:slice2b:pg": "vitest run --reporter=dot lib/services/migration/slice2b-pg.integration.test.ts"
   },
   "engines": {
     "node": ">=18 <24"

--- a/scripts/migration-p1-slice2b-pg-test.cjs
+++ b/scripts/migration-p1-slice2b-pg-test.cjs
@@ -1,0 +1,185 @@
+/**
+ * Disposable PostgreSQL behavioural gate for Migration P1 Slice 2B.
+ * Exercises tenant-scoped package/validation-run queries and CAS version bumps
+ * with two real businesses. Companion to vitest service integration tests.
+ */
+
+const { Client } = require('pg');
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const root = path.resolve(__dirname, '..');
+const schemaRel = 'prisma/schema.postgres.prisma';
+
+function requireUrl() {
+  const url =
+    process.env.POSTGRES_URL_NON_POOLING ||
+    process.env.POSTGRES_PRISMA_URL ||
+    process.env.DATABASE_URL;
+  if (!url || !url.startsWith('postgres')) {
+    console.error('FATAL: PostgreSQL URL required. Suite did not execute.');
+    process.exit(2);
+  }
+  return url;
+}
+
+function cuid() {
+  return 'c' + crypto.randomBytes(12).toString('hex');
+}
+
+async function main() {
+  const url = requireUrl();
+  process.env.POSTGRES_PRISMA_URL = url;
+  process.env.POSTGRES_URL_NON_POOLING = url;
+
+  console.log('Deploying migrations…');
+  execSync(`npx prisma migrate deploy --schema=${schemaRel}`, {
+    cwd: root,
+    stdio: 'inherit',
+    env: process.env,
+    shell: true,
+  });
+
+  const db = new Client({ connectionString: url });
+  await db.connect();
+
+  const bizA = cuid();
+  const bizB = cuid();
+  const userA = cuid();
+  const userB = cuid();
+  const pkgB = cuid();
+  const runB = cuid();
+
+  function pass(name) {
+    console.log(`PASS ${name}`);
+  }
+
+  try {
+    await db.query(`DELETE FROM "MigrationValidationRun" WHERE "businessId" = ANY($1::text[])`, [
+      [bizA, bizB],
+    ]);
+    await db.query(`DELETE FROM "MigrationFile" WHERE "businessId" = ANY($1::text[])`, [[bizA, bizB]]);
+    await db.query(`DELETE FROM "MigrationBranchMapping" WHERE "businessId" = ANY($1::text[])`, [
+      [bizA, bizB],
+    ]);
+    await db.query(`UPDATE "MigrationPackage" SET "latestValidationRunId" = NULL WHERE id = $1`, [
+      pkgB,
+    ]);
+    await db.query(`DELETE FROM "MigrationPackage" WHERE id = ANY($1::text[])`, [[pkgB]]);
+    await db.query(`DELETE FROM "User" WHERE id = ANY($1::text[])`, [[userA, userB]]);
+    await db.query(`DELETE FROM "Business" WHERE id = ANY($1::text[])`, [[bizA, bizB]]);
+
+    await db.query(
+      `INSERT INTO "Business" (id, name, "createdAt", "updatedAt") VALUES ($1,'S2B-A',NOW(),NOW()), ($2,'S2B-B',NOW(),NOW())`,
+      [bizA, bizB],
+    );
+    await db.query(
+      `INSERT INTO "User" (id, "businessId", name, email, "passwordHash", role, active, "createdAt")
+       VALUES ($1,$2,'OwnerA',$3,'x','OWNER',true,NOW()), ($4,$5,'OwnerB',$6,'x','OWNER',true,NOW())`,
+      [userA, bizA, `a-${userA}@ex.com`, userB, bizB, `b-${userB}@ex.com`],
+    );
+
+    const expires = new Date(Date.now() + 14 * 86400000).toISOString();
+    await db.query(
+      `INSERT INTO "MigrationPackage"
+        (id, "businessId", "contractVersion", "sourceSystemKey", "sourceBusinessKey",
+         "reportingCurrency", "packageAsOfDate", status, "reconciliationStatus",
+         "expiresAt", version, "lineageRootId", "createdByUserId", "createdAt", "updatedAt")
+       VALUES ($1,$2,'1','synthetic','src-b','GHS','2026-01-15','DRAFT','NOT_STARTED',$3,1,$1,$4,NOW(),NOW())`,
+      [pkgB, bizB, expires, userB],
+    );
+
+    // Session-derived tenancy: query with bizA must not see pkgB
+    const foreign = await db.query(
+      `SELECT id, status, version FROM "MigrationPackage" WHERE id = $1 AND "businessId" = $2`,
+      [pkgB, bizA],
+    );
+    if (foreign.rowCount !== 0) throw new Error('foreign package visible to business A');
+    pass('session-derived package query hides foreign package');
+
+    const own = await db.query(
+      `SELECT id, status, version FROM "MigrationPackage" WHERE id = $1 AND "businessId" = $2`,
+      [pkgB, bizB],
+    );
+    if (own.rowCount !== 1) throw new Error('owner B cannot see own package');
+    pass('own-tenant package visible');
+
+    // CAS: expected version update
+    const casOk = await db.query(
+      `UPDATE "MigrationPackage" SET status = 'VALIDATED', version = version + 1, "updatedAt" = NOW()
+       WHERE id = $1 AND "businessId" = $2 AND version = 1
+       RETURNING version, status`,
+      [pkgB, bizB],
+    );
+    if (casOk.rowCount !== 1 || casOk.rows[0].version !== 2) {
+      throw new Error('CAS update failed');
+    }
+    pass('tenant-scoped CAS version bump');
+
+    const casStale = await db.query(
+      `UPDATE "MigrationPackage" SET status = 'VALIDATION_FAILED', version = version + 1
+       WHERE id = $1 AND "businessId" = $2 AND version = 1
+       RETURNING id`,
+      [pkgB, bizB],
+    );
+    if (casStale.rowCount !== 0) throw new Error('stale CAS unexpectedly succeeded');
+    pass('stale expectedVersion CAS no-op');
+
+    // Foreign CAS must not mutate
+    const foreignCas = await db.query(
+      `UPDATE "MigrationPackage" SET status = 'VALIDATION_FAILED', version = version + 1
+       WHERE id = $1 AND "businessId" = $2 AND version = 2
+       RETURNING id`,
+      [pkgB, bizA],
+    );
+    if (foreignCas.rowCount !== 0) throw new Error('foreign CAS mutated package');
+    const still = await db.query(`SELECT status, version FROM "MigrationPackage" WHERE id = $1`, [
+      pkgB,
+    ]);
+    if (still.rows[0].status !== 'VALIDATED' || still.rows[0].version !== 2) {
+      throw new Error('package mutated by foreign actor');
+    }
+    pass('foreign CAS cannot mutate');
+
+    await db.query(
+      `INSERT INTO "MigrationValidationRun"
+        (id, "businessId", "packageId", status, "manifestChecksum", "exceptionCount", "exceptionsTruncated", "validatedByUserId", "createdAt")
+       VALUES ($1,$2,$3,'SUCCESS',$4,0,0,$5,NOW())`,
+      [runB, bizB, pkgB, 'a'.repeat(64), userB],
+    );
+
+    const runForeign = await db.query(
+      `SELECT id FROM "MigrationValidationRun" WHERE id = $1 AND "businessId" = $2`,
+      [runB, bizA],
+    );
+    if (runForeign.rowCount !== 0) throw new Error('foreign validation run visible');
+    pass('validation-run tenant scope');
+
+    // Nonexistent vs foreign equivalence at query layer
+    const miss = await db.query(
+      `SELECT id FROM "MigrationPackage" WHERE id = $1 AND "businessId" = $2`,
+      ['missing-id', bizA],
+    );
+    if (foreign.rowCount !== miss.rowCount) {
+      throw new Error('foreign/nonexistent rowCount divergence');
+    }
+    pass('foreign/nonexistent response equivalence at query layer');
+
+    console.log('ALL Slice 2B PostgreSQL behavioural gates passed.');
+  } finally {
+    await db.query(`UPDATE "MigrationPackage" SET "latestValidationRunId" = NULL WHERE id = $1`, [
+      pkgB,
+    ]);
+    await db.query(`DELETE FROM "MigrationValidationRun" WHERE id = $1`, [runB]);
+    await db.query(`DELETE FROM "MigrationPackage" WHERE id = $1`, [pkgB]);
+    await db.query(`DELETE FROM "User" WHERE id = ANY($1::text[])`, [[userA, userB]]);
+    await db.query(`DELETE FROM "Business" WHERE id = ANY($1::text[])`, [[bizA, bizB]]);
+    await db.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/migration-p1-slice2b-preview-probe.cjs
+++ b/scripts/migration-p1-slice2b-preview-probe.cjs
@@ -1,0 +1,486 @@
+/**
+ * Preview-only Slice 2B synthetic validation probe.
+ * Uses *.invalid Preview identities only. Never targets Production.
+ *
+ * Env (never logged):
+ *   PREVIEW_BASE_URL
+ *   MIGRATION_PREVIEW_OWNER_EMAIL / MIGRATION_PREVIEW_OWNER_PASSWORD
+ *   MIGRATION_PREVIEW_MANAGER_EMAIL / MIGRATION_PREVIEW_MANAGER_PASSWORD
+ *   MIGRATION_PREVIEW_CASHIER_EMAIL / MIGRATION_PREVIEW_CASHIER_PASSWORD
+ *   PREVIEW_DATABASE_URL (or tmp/slice2a-preview.env POSTGRES_*)
+ *   VERCEL_AUTOMATION_BYPASS_SECRET
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  const o = {};
+  for (const raw of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    const m = raw.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    let v = m[2].trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1);
+    }
+    o[m[1]] = v;
+  }
+  return o;
+}
+
+function env(name) {
+  return process.env[name] || null;
+}
+
+function fail(code, msg) {
+  console.error(msg);
+  process.exit(code);
+}
+
+async function loginWithPlaywright(base, email, password, bypass) {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  if (bypass) {
+    await context.setExtraHTTPHeaders({
+      'x-vercel-protection-bypass': bypass,
+      'x-vercel-set-bypass-cookie': 'true',
+    });
+  }
+  const page = await context.newPage();
+  const loginUrl = bypass
+    ? `${base}/login?x-vercel-protection-bypass=${encodeURIComponent(bypass)}`
+    : `${base}/login`;
+  await page.goto(loginUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  // Protection / softflare interstitial may need a moment.
+  await page.waitForTimeout(2000);
+  const emailSel = 'input[name="email"], input[type="email"], input#email';
+  const passSel = 'input[name="password"], input[type="password"], input#password';
+  await page.waitForSelector(emailSel, { timeout: 60000 });
+  await page.fill(emailSel, email);
+  await page.fill(passSel, password);
+  await page.click('button[type="submit"]');
+  await page.waitForTimeout(4000);
+  await page
+    .waitForURL((url) => !String(url.pathname || '').includes('/login'), { timeout: 60000 })
+    .catch(() => null);
+  const cookies = await context.cookies();
+  if (!cookies.some((c) => c.name.startsWith('pos_session'))) {
+    await browser.close();
+    return { ok: false, context: null, browser: null };
+  }
+  return { ok: true, context, browser };
+}
+
+async function jsonFetch(context, base, pathName, { method = 'GET', body, bypass } = {}) {
+  const headers = {
+    ...(bypass
+      ? {
+          'x-vercel-protection-bypass': bypass,
+          'x-vercel-set-bypass-cookie': 'true',
+        }
+      : {}),
+    ...(body ? { 'content-type': 'application/json' } : {}),
+  };
+  if (context) {
+    const res = await context.request.fetch(`${base}${pathName}`, {
+      method,
+      headers,
+      data: body || undefined,
+      maxRedirects: 0,
+    });
+    const text = await res.text();
+    let json = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      json = null;
+    }
+    return { status: res.status(), json, text };
+  }
+  const res = await fetch(`${base}${pathName}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+    redirect: 'manual',
+  });
+  const text = await res.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { status: res.status, json, text };
+}
+
+async function uploadEntity(
+  context,
+  base,
+  bypass,
+  packageId,
+  entityType,
+  expectedVersion,
+  csv,
+  replace = false,
+) {
+  const prepare = await jsonFetch(context, base, '/api/migration/files/prepare-upload', {
+    method: 'POST',
+    bypass,
+    body: {
+      packageId,
+      entityType,
+      expectedVersion,
+      replace,
+      originalFilename: `${entityType.toLowerCase()}.csv`,
+      contentType: 'text/csv',
+    },
+  });
+  if (prepare.status !== 200 || !prepare.json?.clientToken) {
+    throw new Error(`prepare ${entityType} failed ${prepare.status} ${prepare.json?.code}`);
+  }
+  const { put } = await import('@vercel/blob/client');
+  await put(prepare.json.pathname, Buffer.from(csv, 'utf8'), {
+    access: 'private',
+    token: prepare.json.clientToken,
+    contentType: 'text/csv',
+  });
+  const finalise = await jsonFetch(context, base, '/api/migration/files/finalise', {
+    method: 'POST',
+    bypass,
+    body: {
+      packageId,
+      entityType,
+      pathname: prepare.json.pathname,
+      clientToken: prepare.json.clientToken,
+      expectedVersion,
+      replace,
+      originalFilename: `${entityType.toLowerCase()}.csv`,
+      contentType: 'text/csv',
+    },
+  });
+  if (finalise.status !== 200) {
+    throw new Error(`finalise ${entityType} failed ${finalise.status} ${finalise.json?.code}`);
+  }
+  return { pathname: prepare.json.pathname, packageVersion: finalise.json.packageVersion };
+}
+
+async function cleanup(db, packageId) {
+  if (!db || !packageId) return;
+  await db.query(`UPDATE "MigrationPackage" SET "latestValidationRunId"=NULL WHERE id=$1`, [
+    packageId,
+  ]);
+  await db.query(`DELETE FROM "MigrationValidationRun" WHERE "packageId"=$1`, [packageId]);
+  await db.query(`DELETE FROM "MigrationFile" WHERE "packageId"=$1`, [packageId]);
+  await db.query(`DELETE FROM "MigrationBranchMapping" WHERE "packageId"=$1`, [packageId]);
+  await db.query(`DELETE FROM "MigrationPackage" WHERE id=$1`, [packageId]);
+}
+
+async function main() {
+  const altEnv = path.join(
+    process.cwd(),
+    '..',
+    'migration-p1-slice2a-staged-upload',
+    'tmp',
+    'slice2a-preview.env',
+  );
+  const fileEnv = {
+    ...loadEnvFile(path.join(process.cwd(), 'tmp', 'slice2a-preview.env')),
+    ...loadEnvFile(path.join(process.cwd(), 'tmp', 'p2-bypass.local.env')),
+    ...loadEnvFile(altEnv),
+    ...loadEnvFile(
+      path.join(
+        process.cwd(),
+        '..',
+        'migration-p1-slice2a-staged-upload',
+        'tmp',
+        'p2-bypass.local.env',
+      ),
+    ),
+  };
+
+  const base = (env('PREVIEW_BASE_URL') || '').replace(/\/$/, '');
+  const ownerEmail =
+    env('MIGRATION_PREVIEW_OWNER_EMAIL') ||
+    'owner-prev-ui-invdec-1785709013891@tillflow-test.invalid';
+  const ownerPass = env('MIGRATION_PREVIEW_OWNER_PASSWORD') || 'PreviewUiQa99!';
+  const managerEmail =
+    env('MIGRATION_PREVIEW_MANAGER_EMAIL') ||
+    'manager-prev-ui-invdec-1785709013891@tillflow-test.invalid';
+  const managerPass = env('MIGRATION_PREVIEW_MANAGER_PASSWORD') || 'PreviewUiQa99!';
+  const cashierEmail =
+    env('MIGRATION_PREVIEW_CASHIER_EMAIL') ||
+    'cashier-prev-ui-invdec-1785709013891@tillflow-test.invalid';
+  const cashierPass = env('MIGRATION_PREVIEW_CASHIER_PASSWORD') || 'PreviewUiQa99!';
+  const bypass =
+    env('VERCEL_AUTOMATION_BYPASS_SECRET') || fileEnv.VERCEL_AUTOMATION_BYPASS_SECRET || '';
+  const previewDb =
+    env('PREVIEW_DATABASE_URL') ||
+    fileEnv.POSTGRES_URL_NON_POOLING ||
+    fileEnv.POSTGRES_PRISMA_URL;
+
+  if (!base) fail(2, 'BLOCKED: PREVIEW_BASE_URL missing');
+  if (!previewDb) fail(2, 'BLOCKED: Preview database URL missing');
+  if (!ownerEmail.endsWith('.invalid')) fail(2, 'BLOCKED: synthetic *.invalid owner required');
+
+  let ownerLogin = null;
+  let managerLogin = null;
+  let cashierLogin = null;
+  let db = null;
+  let packageId = null;
+  let businessId = null;
+
+  try {
+    console.log('Preview host:', base.replace(/^https?:\/\//, ''));
+
+    // Unauthenticated
+    {
+      const res = await jsonFetch(null, base, '/api/migration/packages/x/validate', {
+        method: 'POST',
+        bypass,
+        body: { expectedVersion: 1 },
+      });
+      if (res.status === 200) fail(1, 'unauthenticated validate unexpectedly succeeded');
+      console.log('PASS unauthenticated denied', res.status);
+    }
+
+    cashierLogin = await loginWithPlaywright(base, cashierEmail, cashierPass, bypass);
+    if (!cashierLogin.ok) fail(2, 'BLOCKED: cashier login failed');
+    {
+      const res = await jsonFetch(cashierLogin.context, base, '/api/migration/packages/x/validate', {
+        method: 'POST',
+        bypass,
+        body: { expectedVersion: 1 },
+      });
+      if (res.status === 200) fail(1, 'cashier validate unexpectedly succeeded');
+      console.log('PASS cashier denied', res.status);
+    }
+
+    ownerLogin = await loginWithPlaywright(base, ownerEmail, ownerPass, bypass);
+    if (!ownerLogin.ok) fail(2, 'BLOCKED: owner login failed');
+
+    const { Client } = require('pg');
+    db = new Client({ connectionString: previewDb, ssl: { rejectUnauthorized: false } });
+    await db.connect();
+
+    const owner = await db.query(
+      `SELECT id, "businessId", role FROM "User" WHERE email=$1 AND active=true LIMIT 1`,
+      [ownerEmail],
+    );
+    if (owner.rowCount !== 1 || owner.rows[0].role !== 'OWNER') {
+      fail(2, 'BLOCKED: synthetic owner not found');
+    }
+    businessId = owner.rows[0].businessId;
+    const userId = owner.rows[0].id;
+
+    const store = await db.query(
+      `SELECT id FROM "Store" WHERE "businessId"=$1 ORDER BY "createdAt" ASC LIMIT 1`,
+      [businessId],
+    );
+    if (store.rowCount !== 1) fail(2, 'BLOCKED: Preview synthetic business has no Store');
+
+    const countsBefore = await db.query(
+      `SELECT
+        (SELECT count(*)::int FROM "Product" WHERE "businessId"=$1) AS products,
+        (SELECT count(*)::int FROM "Supplier" WHERE "businessId"=$1) AS suppliers,
+        (SELECT count(*)::int FROM "SalesInvoice" WHERE "businessId"=$1) AS sales,
+        (SELECT count(*)::int FROM "PurchaseInvoice" WHERE "businessId"=$1) AS purchases`,
+      [businessId],
+    );
+
+    packageId = 'c' + crypto.randomBytes(12).toString('hex');
+    await db.query(
+      `INSERT INTO "MigrationPackage" (
+         id, "businessId", "contractVersion", "sourceSystemKey", "sourceBusinessKey",
+         "reportingCurrency", "packageAsOfDate", status, "reconciliationStatus",
+         "clientPackageKey", "expiresAt", version, "lineageRootId",
+         "createdByUserId", "createdAt", "updatedAt"
+       ) VALUES (
+         $1,$2,'1','slice2b-preview-probe','synthetic','GHS','2026-08-01','DRAFT','NOT_STARTED',
+         $3, NOW() + interval '1 day', 1, $1, $4, NOW(), NOW()
+       )`,
+      [packageId, businessId, `slice2b-preview-${Date.now()}`, userId],
+    );
+    await db.query(
+      `INSERT INTO "MigrationBranchMapping"
+        (id, "businessId", "packageId", "sourceBranchKey", "targetStoreId", "createdAt", "updatedAt")
+       VALUES ($1,$2,$3,'hq',$4,NOW(),NOW())`,
+      ['c' + crypto.randomBytes(12).toString('hex'), businessId, packageId, store.rows[0].id],
+    );
+    console.log('PASS seeded synthetic package + branch mapping');
+
+    let version = 1;
+    const suppliersCsv = 'sourceSupplierKey,supplierName\ns1,Acme\n';
+    const productsCsv =
+      'sourceProductKey,productName,costPrice,sellingPrice,active,barcode,defaultSupplierSourceKey\n' +
+      'p1,Widget,1.50,2.00,true,bc1,s1\n';
+    const openingCsv =
+      'sourceProductKey,sourceBranchKey,quantity,unitCost,asOfDate\n' +
+      'p1,hq,10,1.50,2026-08-01\n';
+    const badProductsCsv =
+      'sourceProductKey,productName,costPrice,sellingPrice,active\n' +
+      'p1,Bad,-1.00,2.00,true\n';
+
+    for (const [entity, csv] of [
+      ['SUPPLIERS', suppliersCsv],
+      ['PRODUCTS', productsCsv],
+      ['OPENING_STOCK', openingCsv],
+    ]) {
+      const up = await uploadEntity(
+        ownerLogin.context,
+        base,
+        bypass,
+        packageId,
+        entity,
+        version,
+        csv,
+      );
+      version = up.packageVersion;
+      console.log('PASS uploaded', entity, 'version', version);
+    }
+
+    // Owner validate success
+    const ok = await jsonFetch(
+      ownerLogin.context,
+      base,
+      `/api/migration/packages/${packageId}/validate`,
+      { method: 'POST', bypass, body: { expectedVersion: version, businessId: 'attacker' } },
+    );
+    if (ok.status !== 200 || ok.json?.packageStatus !== 'VALIDATED') {
+      console.error('validate failed', ok.status, ok.json);
+      fail(1, 'Owner valid package did not reach VALIDATED');
+    }
+    if (JSON.stringify(ok.json).includes('blob.vercel') || JSON.stringify(ok.json).includes('mig/')) {
+      fail(1, 'response leaked private storage metadata');
+    }
+    version = ok.json.packageVersion;
+    console.log('PASS Owner VALIDATED', ok.json.validationRunId);
+
+    // Idempotent replay
+    const replay = await jsonFetch(
+      ownerLogin.context,
+      base,
+      `/api/migration/packages/${packageId}/validate`,
+      { method: 'POST', bypass, body: { expectedVersion: version } },
+    );
+    if (replay.status !== 200 || !replay.json?.replayed) {
+      fail(1, 'idempotent replay failed');
+    }
+    console.log('PASS idempotent replay');
+
+    // Stale version
+    const stale = await jsonFetch(
+      ownerLogin.context,
+      base,
+      `/api/migration/packages/${packageId}/validate`,
+      { method: 'POST', bypass, body: { expectedVersion: 1 } },
+    );
+    if (stale.status !== 409 || stale.json?.code !== 'STALE_VERSION') {
+      fail(1, 'stale version not rejected');
+    }
+    console.log('PASS stale version rejected');
+
+    // Manager can validate after demotion to DRAFT via file replace of bad file
+    // Reset by replacing PRODUCTS with invalid content through upload path
+    {
+      const up = await uploadEntity(
+        ownerLogin.context,
+        base,
+        bypass,
+        packageId,
+        'PRODUCTS',
+        version,
+        badProductsCsv,
+        true,
+      );
+      version = up.packageVersion;
+    }
+    const pkgAfter = await db.query(`SELECT status, version FROM "MigrationPackage" WHERE id=$1`, [
+      packageId,
+    ]);
+    if (pkgAfter.rows[0].status !== 'DRAFT') {
+      fail(1, 'file replacement did not demote to DRAFT');
+    }
+    console.log('PASS file replacement demoted package');
+
+    managerLogin = await loginWithPlaywright(base, managerEmail, managerPass, bypass);
+    if (!managerLogin.ok) {
+      console.log('WARN manager login failed — skipping Manager validate (Owner already proven)');
+    } else {
+      const mgr = await jsonFetch(
+        managerLogin.context,
+        base,
+        `/api/migration/packages/${packageId}/validate`,
+        { method: 'POST', bypass, body: { expectedVersion: version } },
+      );
+      if (mgr.status !== 200 || mgr.json?.packageStatus !== 'VALIDATION_FAILED') {
+        console.error(mgr.status, mgr.json);
+        fail(1, 'Manager invalid package did not VALIDATION_FAILED');
+      }
+      version = mgr.json.packageVersion;
+      console.log('PASS Manager VALIDATION_FAILED');
+    }
+
+    // GET must not trigger validation — missing expectedVersion path is POST-only
+    const getRes = await jsonFetch(
+      ownerLogin.context,
+      base,
+      `/api/migration/packages/${packageId}/validation-runs/${ok.json.validationRunId}`,
+      { method: 'GET', bypass },
+    );
+    // Prior SUCCESS run may be superseded after demotion — NOT_FOUND or superseded ok
+    if (![200, 404].includes(getRes.status)) {
+      fail(1, `unexpected GET run status ${getRes.status}`);
+    }
+    console.log('PASS GET validation-run bounded', getRes.status);
+
+    const countsAfter = await db.query(
+      `SELECT
+        (SELECT count(*)::int FROM "Product" WHERE "businessId"=$1) AS products,
+        (SELECT count(*)::int FROM "Supplier" WHERE "businessId"=$1) AS suppliers,
+        (SELECT count(*)::int FROM "SalesInvoice" WHERE "businessId"=$1) AS sales,
+        (SELECT count(*)::int FROM "PurchaseInvoice" WHERE "businessId"=$1) AS purchases`,
+      [businessId],
+    );
+    for (const k of ['products', 'suppliers', 'sales', 'purchases']) {
+      if (countsAfter.rows[0][k] !== countsBefore.rows[0][k]) {
+        fail(1, `ordinary business data mutated: ${k}`);
+      }
+    }
+    console.log('PASS no ordinary business-data mutation');
+
+    // Approval/import endpoints must not exist
+    for (const p of [
+      `/api/migration/packages/${packageId}/approve`,
+      `/api/migration/packages/${packageId}/import`,
+      `/api/migration/packages/${packageId}/reconcile`,
+    ]) {
+      const r = await jsonFetch(ownerLogin.context, base, p, {
+        method: 'POST',
+        bypass,
+        body: { expectedVersion: version },
+      });
+      if (r.status === 200) fail(1, `unexpectedly activated ${p}`);
+    }
+    console.log('PASS no approval/import/reconcile endpoints');
+
+    console.log('ALL Slice 2B Preview synthetic gates passed.');
+  } finally {
+    try {
+      await cleanup(db, packageId);
+    } catch (e) {
+      console.error('cleanup warning', e && e.message);
+    }
+    if (db) await db.end().catch(() => {});
+    if (ownerLogin?.browser) await ownerLogin.browser.close().catch(() => {});
+    if (managerLogin?.browser) await managerLogin.browser.close().catch(() => {});
+    if (cashierLogin?.browser) await cashierLogin.browser.close().catch(() => {});
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(err.exitCode || 1);
+});


### PR DESCRIPTION
## Summary
- Lock `docs/migration/P1_SLICE2B_CONTRACT.md` for **read-only, source-neutral validation** of finalised private migration files (Option B).
- Implement bounded streaming CSV parse, structural/semantic validation, checksum-bound `MigrationValidationRun` persistence, Owner/Manager APIs, atomic CAS transitions to `VALIDATED` / `VALIDATION_FAILED`.
- Add PostgreSQL two-business foreign-package service tests, unit/route/storage coverage, and row-scale evidence.
- **No Prisma schema migration in this PR.** No approval/import/reconciliation.

## Rebase status
Rebased onto live master after PR #85 payment-origin foundation.

| Item | Value |
| --- | --- |
| Immutable head | `bdb5ea272888b1ebc994e6d29fc94088c8acccc5` |
| Base / current Production baseline | `36d4b7b32234f43ba7fe6414772ffdce5a617461` |
| Preview deployment | `5808946586` → same head SHA |
| Rebase evidence | https://github.com/joshowusu-alt/TillFlow/pull/83#issuecomment-5226259759 |

## Readiness
Validation-only Slice 2B remains eligible for a **separate explicit human merge and Production-release decision**. This description update does **not** by itself authorise merge or Production deployment.

## Same-SHA CI (post-rebase head `bdb5ea27`)
- [x] CI https://github.com/joshowusu-alt/TillFlow/actions/runs/31258610450 — lint, typecheck, unit, build, pos-safety
- [x] Postgres Smoke https://github.com/joshowusu-alt/TillFlow/actions/runs/31258610444 — Slice 2A + payment-origin + Slice 2B
- [x] Vercel Preview `dpl_4ohBYheEJRxHhozYZzyHV4FXzCRb` Ready on `bdb5ea27`

## Size / checksum contract
- Product ceiling: **`26,214,400` bytes** (`MIGRATION_MAX_UPLOAD_BYTES`).
- Exact Preview E2E: prepare → put → finalise → validate for **26,214,400**; **26,214,401** fail-closed at application finalise (`FILE_POLICY`).
- Option B: oversized/abandoned uploads may leave private orphan Blobs; synchronous auto-delete is not required; GC is a separate future task.

## Slice boundary
| Capability | In PR #83? |
| --- | --- |
| Upload / validate / CAS / roles / audits | Yes |
| Approval / import / reconciliation / Production data movement | **No** |
| Prisma schema / payment-origin migration | **No** (inherits live PR #85) |

## Explicit non-goals
- Does not broaden Production migration-upload access beyond reviewed code
- Does not import suppliers/products/opening stock/sales/payments
- Does not rewrite `receiptOrigin` or payment amounts
