### PR TITLE
fix(reports): Home Today scope, money received drill-down, Cash Drawer clarity

### DIFF
--- a/.github/workflows/postgres-smoke.yml
+++ b/.github/workflows/postgres-smoke.yml
@@ -13,6 +13,9 @@ on:
       - 'scripts/migration-p1-sql-only-constraint-contract.cjs'
       - 'scripts/payment-receipt-origin-pg-test.cjs'
       - 'lib/payments/**'
+      - 'lib/reports/money-received.ts'
+      - 'lib/reports/money-received-classify.ts'
+      - 'lib/reports/money-received.pg.test.ts'
       - 'docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md'
       - 'docs/migration/P1_SLICE2A_CONTRACT.md'
       - 'docs/migration/P1_SLICE2B_CONTRACT.md'
@@ -78,6 +81,12 @@ jobs:
 
       - name: Payment receipt-origin PostgreSQL behavioural suite
         run: npm run test:payment-receipt-origin:pg
+
+      - name: Money received reporting PostgreSQL suite
+        run: npx vitest run --reporter=dot lib/reports/money-received.pg.test.ts
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public
+          POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public
 
       - name: Migration P1 Slice 2B PostgreSQL behavioural suite
         run: node scripts/migration-p1-slice2b-pg-test.cjs

--- a/.github/workflows/postgres-smoke.yml
+++ b/.github/workflows/postgres-smoke.yml
@@ -17,6 +17,7 @@ on:
       - 'lib/reports/money-received-classify.ts'
       - 'lib/reports/money-received.pg.test.ts'
       - 'lib/reports/money-received-scale.pg.test.ts'
+      - 'lib/reports/money-received-unknown-method.pg.test.ts'
       - 'docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md'
       - 'docs/migration/P1_SLICE2A_CONTRACT.md'
       - 'docs/migration/P1_SLICE2B_CONTRACT.md'
@@ -84,7 +85,7 @@ jobs:
         run: npm run test:payment-receipt-origin:pg
 
       - name: Money received reporting PostgreSQL suite
-        run: npx vitest run --reporter=dot lib/reports/money-received.pg.test.ts lib/reports/money-received-scale.pg.test.ts
+        run: npx vitest run --reporter=dot lib/reports/money-received.pg.test.ts lib/reports/money-received-scale.pg.test.ts lib/reports/money-received-unknown-method.pg.test.ts
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public
           POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public

--- a/.github/workflows/postgres-smoke.yml
+++ b/.github/workflows/postgres-smoke.yml
@@ -16,6 +16,7 @@ on:
       - 'lib/reports/money-received.ts'
       - 'lib/reports/money-received-classify.ts'
       - 'lib/reports/money-received.pg.test.ts'
+      - 'lib/reports/money-received-scale.pg.test.ts'
       - 'docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md'
       - 'docs/migration/P1_SLICE2A_CONTRACT.md'
       - 'docs/migration/P1_SLICE2B_CONTRACT.md'
@@ -83,7 +84,7 @@ jobs:
         run: npm run test:payment-receipt-origin:pg
 
       - name: Money received reporting PostgreSQL suite
-        run: npx vitest run --reporter=dot lib/reports/money-received.pg.test.ts
+        run: npx vitest run --reporter=dot lib/reports/money-received.pg.test.ts lib/reports/money-received-scale.pg.test.ts
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public
           POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public

--- a/.github/workflows/postgres-smoke.yml
+++ b/.github/workflows/postgres-smoke.yml
@@ -18,6 +18,8 @@ on:
       - 'lib/reports/money-received.pg.test.ts'
       - 'lib/reports/money-received-scale.pg.test.ts'
       - 'lib/reports/money-received-unknown-method.pg.test.ts'
+      - 'lib/reports/money-received-store-scope.pg.test.ts'
+      - 'lib/reports/reporting-scope.ts'
       - 'docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md'
       - 'docs/migration/P1_SLICE2A_CONTRACT.md'
       - 'docs/migration/P1_SLICE2B_CONTRACT.md'
@@ -85,7 +87,7 @@ jobs:
         run: npm run test:payment-receipt-origin:pg
 
       - name: Money received reporting PostgreSQL suite
-        run: npx vitest run --reporter=dot lib/reports/money-received.pg.test.ts lib/reports/money-received-scale.pg.test.ts lib/reports/money-received-unknown-method.pg.test.ts
+        run: npx vitest run --reporter=dot lib/reports/money-received.pg.test.ts lib/reports/money-received-scale.pg.test.ts lib/reports/money-received-unknown-method.pg.test.ts lib/reports/money-received-store-scope.pg.test.ts
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public
           POSTGRES_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/tillflow_ci?schema=public

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ perf.db-journal
 /tmp/*preview*.env
 
 .env*.local
+
+# Local Preview probe secrets (never commit)
+tmp/*.local.env
+tmp/reporting-preview.local.env

--- a/app/(protected)/reports/cash-drawer/page.tsx
+++ b/app/(protected)/reports/cash-drawer/page.tsx
@@ -10,7 +10,12 @@ import { formatDateTime, formatMoney } from '@/lib/format';
 import { requireBusiness } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { resolveReportDateRange } from '@/lib/reports/date-parsing';
-import { getBusinessStores, resolveStoreSelection } from '@/lib/services/stores';
+import { getBusinessStores } from '@/lib/services/stores';
+import {
+  isReportingScopeStoreError,
+  resolveAuthorisedStoreId,
+} from '@/lib/reports/reporting-scope';
+import { notFound } from 'next/navigation';
 import {
   CASH_DRAWER_BREAKDOWN_ORDER,
   CASH_DRAWER_ENTRY_LABELS,
@@ -49,7 +54,16 @@ export default async function CashDrawerReportPage({
 
   const { start: from, end: to, fromInputValue: fromIso, toInputValue: toIso } = resolveReportDateRange(searchParams, weekAgo, today);
   const { stores } = await getBusinessStores(business.id, searchParams?.storeId);
-  const selectedStoreId = resolveStoreSelection(stores, searchParams?.storeId, 'ALL') ?? 'ALL';
+  let selectedStoreId: string;
+  try {
+    selectedStoreId = resolveAuthorisedStoreId({
+      storeId: searchParams?.storeId,
+      allowedStoreIds: stores.map((store) => store.id),
+    });
+  } catch (error) {
+    if (isReportingScopeStoreError(error)) notFound();
+    throw error;
+  }
   const requestedPageSize = parseInt(searchParams?.pageSize ?? '20', 10) || 20;
   const pageSize = PAGE_SIZE_OPTIONS.includes(requestedPageSize as 10 | 20 | 50) ? requestedPageSize : 20;
   const requestedPage = Math.max(1, parseInt(searchParams?.page ?? '1', 10) || 1);

--- a/app/(protected)/reports/cash-drawer/page.tsx
+++ b/app/(protected)/reports/cash-drawer/page.tsx
@@ -143,11 +143,18 @@ export default async function CashDrawerReportPage({
       />
 
       <section className="rounded-2xl border border-blue-100 bg-blue-50/70 px-4 py-3 text-sm leading-relaxed text-blue-900 shadow-sm">
-        This report covers physical cash only. MoMo, card, and bank transfer receipts are not included here — see the{' '}
-        <a href="/reports/dashboard" className="font-semibold underline underline-offset-2">
-          Trading Report
+        This report covers physical cash movements only — notes and coins in the till.
+        MoMo, card, and bank transfer receipts are electronic payments and are not included here.
+        Inspect them under{' '}
+        <a href="/reports/dashboard#money-received" className="font-semibold underline underline-offset-2">
+          Trading Report → Money received
+        </a>
+        {' '}or the{' '}
+        <a href="/reports/receipts?period=today&storeId=ALL" className="font-semibold underline underline-offset-2">
+          Money received
         </a>{' '}
-        for all payment methods.
+        payment list. Cash Drawer follows shift open times and till activity, so figures may differ
+        from calendar-day cash receipts.
       </section>
 
       <ReportFilterCard

--- a/app/(protected)/reports/dashboard/TradingDashboardContent.tsx
+++ b/app/(protected)/reports/dashboard/TradingDashboardContent.tsx
@@ -9,18 +9,34 @@ import { computeOutstandingBalance } from '@/lib/accounting';
 import { classifyInventoryState, getReceivableAgeBucket } from '@/lib/reports/operational-metrics';
 import { unstable_cache } from 'next/cache';
 import { measureServerOperation, PERFORMANCE_THRESHOLDS_MS } from '@/lib/observability';
+import {
+  getMoneyReceivedSummary,
+  RECEIPT_METHOD_LABELS,
+  type ReceiptPaymentMethod,
+} from '@/lib/reports/money-received';
+import {
+  buildReportingScopeSearchParams,
+  moneyReceivedHref,
+  type ReportingPeriodKey,
+  type ReportingScope,
+} from '@/lib/reports/reporting-scope';
+import { getSalesRevenueSummary } from '@/lib/reports/sales-revenue';
 
 type TradingDashboardContentProps = {
   businessId: string;
   businessName: string;
   currency: string;
+  timeZone: string;
   userId: string;
   userName: string | null;
   userEmail: string;
   selectedStoreId: string;
   fromIso: string;
   toIso: string;
+  periodKey: ReportingPeriodKey;
+  /** Inclusive start ISO */
   startIso: string;
+  /** Exclusive end ISO */
   endIso: string;
   isToday: boolean;
 };
@@ -33,7 +49,9 @@ async function _getTradingDashboardSnapshot(
   selectedStoreId: string,
 ) {
   const start = new Date(startIso);
-  const end = new Date(endIso);
+  const endExclusive = new Date(endIso);
+  // Income statement helper still uses inclusive end — pass last in-range instant.
+  const endInclusiveForJournals = new Date(endExclusive.getTime() - 1);
   const storeFilter = selectedStoreId === 'ALL' ? {} : { storeId: selectedStoreId };
 
   const [
@@ -55,7 +73,7 @@ async function _getTradingDashboardSnapshot(
       where: {
         businessId,
         ...storeFilter,
-        createdAt: { gte: start, lte: end },
+        createdAt: { gte: start, lt: endExclusive },
         paymentStatus: { notIn: ['RETURNED', 'VOID'] },
       },
       _sum: { totalPence: true },
@@ -63,7 +81,7 @@ async function _getTradingDashboardSnapshot(
     prisma.salesPayment.groupBy({
       by: ['method'],
       where: {
-        receivedAt: { gte: start, lte: end },
+        receivedAt: { gte: start, lt: endExclusive },
         status: { notIn: ['FAILED', 'CANCELLED', 'VOID'] },
         salesInvoice: {
           businessId,
@@ -73,7 +91,7 @@ async function _getTradingDashboardSnapshot(
       },
       _sum: { amountPence: true },
     }),
-    getIncomeStatement(businessId, start, end),
+    getIncomeStatement(businessId, start, endInclusiveForJournals),
     prisma.salesInvoice.findMany({
       where: {
         businessId,
@@ -130,7 +148,7 @@ async function _getTradingDashboardSnapshot(
         salesInvoice: {
           businessId,
           ...(selectedStoreId === 'ALL' ? {} : { storeId: selectedStoreId }),
-          createdAt: { gte: start, lte: end },
+          createdAt: { gte: start, lt: endExclusive },
           paymentStatus: { notIn: ['RETURNED', 'VOID'] },
         },
       },
@@ -149,7 +167,7 @@ async function _getTradingDashboardSnapshot(
       where: {
         store: { businessId },
         ...(selectedStoreId === 'ALL' ? {} : { storeId: selectedStoreId }),
-        createdAt: { gte: start, lte: end },
+        createdAt: { gte: start, lt: endExclusive },
       },
       select: {
         direction: true,
@@ -164,7 +182,7 @@ async function _getTradingDashboardSnapshot(
       where: {
         businessId,
         ...storeFilter,
-        createdAt: { gte: start, lte: end },
+        createdAt: { gte: start, lt: endExclusive },
         paymentStatus: 'VOID',
       },
       select: { totalPence: true, cashierUser: { select: { name: true } } },
@@ -174,7 +192,7 @@ async function _getTradingDashboardSnapshot(
       where: {
         store: { businessId },
         ...(selectedStoreId === 'ALL' ? {} : { storeId: selectedStoreId }),
-        createdAt: { gte: start, lte: end },
+        createdAt: { gte: start, lt: endExclusive },
         type: 'RETURN',
       },
       select: { refundAmountPence: true },
@@ -188,7 +206,7 @@ async function _getTradingDashboardSnapshot(
             ...(selectedStoreId === 'ALL' ? {} : { id: selectedStoreId }),
           },
         },
-        closedAt: { gte: start, lte: end },
+        closedAt: { gte: start, lt: endExclusive },
         variance: { not: null },
       },
       select: { variance: true, user: { select: { name: true } } },
@@ -199,7 +217,7 @@ async function _getTradingDashboardSnapshot(
         salesInvoice: {
           businessId,
           ...(selectedStoreId === 'ALL' ? {} : { storeId: selectedStoreId }),
-          createdAt: { gte: start, lte: end },
+          createdAt: { gte: start, lt: endExclusive },
           paymentStatus: { notIn: ['RETURNED', 'VOID'] },
         },
         lineCostPence: { gt: 0 },
@@ -215,7 +233,7 @@ async function _getTradingDashboardSnapshot(
         salesInvoice: {
           businessId,
           ...(selectedStoreId === 'ALL' ? {} : { storeId: selectedStoreId }),
-          createdAt: { gte: start, lte: end },
+          createdAt: { gte: start, lt: endExclusive },
           paymentStatus: { notIn: ['RETURNED', 'VOID'] },
         },
         lineCostPence: 0,
@@ -284,22 +302,76 @@ export default async function TradingDashboardContent({
   businessId,
   businessName,
   currency,
+  timeZone,
   userId,
   userName,
   userEmail,
   selectedStoreId,
   fromIso,
   toIso,
+  periodKey,
   startIso,
   endIso,
   isToday,
 }: TradingDashboardContentProps) {
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
+  const scope: ReportingScope = {
+    businessId,
+    timeZone,
+    periodKey,
+    startInclusive: new Date(startIso),
+    endExclusive: new Date(endIso),
+    fromInputValue: fromIso,
+    toInputValue: toIso,
+    storeId: selectedStoreId === 'ALL' ? 'ALL' : selectedStoreId,
+  };
 
   const storeFilter = selectedStoreId === 'ALL' ? {} : { storeId: selectedStoreId };
+
+  const [
+    snapshot,
+    moneyReceived,
+    salesRevenue,
+  ] = await Promise.all([
+    measureServerOperation(
+      'report.trading-dashboard.snapshot',
+      () => getCachedTradingDashboardSnapshot(
+        businessId,
+        currency,
+        startIso,
+        endIso,
+        selectedStoreId,
+      ),
+      {
+        businessId,
+        storeId: selectedStoreId,
+        route: '/reports/dashboard',
+        cacheState: 'cached-wrapper',
+      },
+      { thresholdMs: PERFORMANCE_THRESHOLDS_MS.report, operationType: 'report' },
+    ),
+    measureServerOperation(
+      'report.trading-dashboard.money-received',
+      () => getMoneyReceivedSummary(scope),
+      {
+        businessId,
+        storeId: selectedStoreId,
+        route: '/reports/dashboard',
+        cacheState: 'uncached-money-received',
+      },
+      { thresholdMs: PERFORMANCE_THRESHOLDS_MS.report, operationType: 'report' },
+    ),
+    measureServerOperation(
+      'report.trading-dashboard.sales-revenue',
+      () => getSalesRevenueSummary(scope),
+      {
+        businessId,
+        storeId: selectedStoreId,
+        route: '/reports/dashboard',
+        cacheState: 'uncached-sales-revenue',
+      },
+      { thresholdMs: PERFORMANCE_THRESHOLDS_MS.report, operationType: 'report' },
+    ),
+  ]);
 
   const {
     salesAgg,
@@ -317,29 +389,13 @@ export default async function TradingDashboardContent({
     uncostedMarginGroups,
     bestSellerProducts,
     uncostedProducts,
-  } = await measureServerOperation(
-    'report.trading-dashboard.snapshot',
-    () => getCachedTradingDashboardSnapshot(
-      businessId,
-      currency,
-      startIso,
-      endIso,
-      selectedStoreId,
-    ),
-    {
-      businessId,
-      storeId: selectedStoreId,
-      route: '/reports/dashboard',
-      cacheState: 'cached-wrapper',
-    },
-    { thresholdMs: PERFORMANCE_THRESHOLDS_MS.report, operationType: 'report' },
-  );
+  } = snapshot;
 
   const bestSellerProductMap = new Map(bestSellerProducts.map((product) => [product.id, product]));
   const uncostedProductCostMap = new Map(uncostedProducts.map((product) => [product.id, product.defaultCostBasePence]));
 
-  // Summarise sales — already aggregated by DB
-  const totalSales = salesAgg._sum.totalPence ?? 0;
+  // Summarise sales — shared sales-revenue contract (matches Home)
+  const totalSales = salesRevenue.salesRevenuePence;
   // GP from sale lines — consistent with margins/analytics/KPIs
   const costedGrossMargin =
     (costedMarginAgg._sum.lineSubtotalPence ?? 0) - (costedMarginAgg._sum.lineCostPence ?? 0);
@@ -354,13 +410,11 @@ export default async function TradingDashboardContent({
   // Expenses and NP still from journals (accounting source of truth for expense tracking)
   const npPercent = totalSales > 0 ? Math.round(((totalGrossMargin - income.otherExpenses) / totalSales) * 100) : 0;
 
-  // Payment split — already grouped by DB
-  const paymentSplit = { CASH: 0, CARD: 0, TRANSFER: 0, MOBILE_MONEY: 0 };
-  for (const p of paymentsByMethod) {
-    const k = p.method as keyof typeof paymentSplit;
-    if (k in paymentSplit) paymentSplit[k] = p._sum.amountPence ?? 0;
-  }
-  const totalPaymentReceipts = Object.values(paymentSplit).reduce((sum, amount) => sum + amount, 0);
+  // Money received — payment records (authoritative for method totals)
+  const paymentSplit = moneyReceived.byMethod;
+  const totalPaymentReceipts = moneyReceived.totalPence;
+  void salesAgg;
+  void paymentsByMethod;
 
   // AR / AP
   const outstandingAR = outstandingSales.reduce((s, inv) => s + computeOutstandingBalance(inv), 0);
@@ -418,7 +472,7 @@ export default async function TradingDashboardContent({
         where: {
           businessId,
           ...storeFilter,
-          createdAt: { gte: todayStart },
+          createdAt: { gte: scope.startInclusive },
           paymentStatus: { notIn: ['VOID', 'RETURNED'] },
         },
         orderBy: { createdAt: 'desc' },
@@ -454,9 +508,9 @@ export default async function TradingDashboardContent({
     selectedStoreId === 'ALL'
       ? 'Figures use the selected period across all branches. Expenses and net profit use business-wide accounting records.'
       : 'Sales are filtered to this branch. Expenses and net profit use the business-wide accounting records currently available.';
-  const cashDrawerParams = new URLSearchParams({ from: fromIso, to: toIso });
-  if (selectedStoreId !== 'ALL') cashDrawerParams.set('storeId', selectedStoreId);
+  const cashDrawerParams = buildReportingScopeSearchParams(scope);
   const cashDrawerHref = `/reports/cash-drawer?${cashDrawerParams.toString()}`;
+  const receiptsHref = moneyReceivedHref(scope);
 
   const firstName = (userName ?? '').trim().split(/\s+/)[0] || userEmail.split('@')[0] || 'there';
   const lastSaleChipLabel =
@@ -504,7 +558,12 @@ export default async function TradingDashboardContent({
 
       {/* KPI row */}
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
-        <StatCard label="Sales" value={formatMoney(totalSales, currency)} tone="accent" />
+        <StatCard
+          label="Sales revenue"
+          value={formatMoney(totalSales, currency)}
+          tone="accent"
+          helper="Recognised sales for this period (not money received)."
+        />
         <StatCard
           label={`Gross Profit (${gpPercent}%)`}
           value={formatMoney(totalGrossMargin, currency)}
@@ -518,10 +577,26 @@ export default async function TradingDashboardContent({
           tone={npPercent >= 10 ? 'success' : npPercent >= 0 ? 'warn' : 'danger'}
           helper="Profit after expenses."
         />
-        <StatCard label="What customers owe" value={formatMoney(outstandingAR, currency)} helper="Current customer credit balance, not just this period. Record receipts when customers pay." />
+        <StatCard
+          label="Credit sales (unpaid)"
+          value={formatMoney(salesRevenue.creditSalesOutstandingPence, currency)}
+          helper="Unpaid portion of sales in this period. Not counted as money received."
+        />
         <a href="/payments/supplier-payments" className="block min-w-0">
           <StatCard label="What you owe suppliers" value={formatMoney(outstandingAP, currency)} helper="Current supplier balances. Record supplier payments when purchases are paid." />
         </a>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+        <p>
+          <strong>Sales revenue</strong> ({formatMoney(totalSales, currency)}) can differ from{' '}
+          <strong>Money received</strong> ({formatMoney(totalPaymentReceipts, currency)}).
+          Credit sales raise revenue before cash arrives; later credit collections raise receipts without new revenue.
+          Physical Cash Drawer totals follow till/shift cash movements and will not always match cash receipts.
+        </p>
+        <p className="mt-1 text-xs text-slate-500">
+          What customers owe overall (all periods): {formatMoney(outstandingAR, currency)}.
+        </p>
       </div>
 
       {/* Data-quality warning: extremely negative GP almost always means wrong cost prices */}
@@ -537,41 +612,71 @@ export default async function TradingDashboardContent({
         </div>
       )}
 
-      {/* Payment split + Activity highlights */}
+      {/* Money received + Activity highlights */}
       <div className="grid gap-6 lg:grid-cols-2">
-        <div className="card p-4 sm:p-6">
-          <div className="mb-4">
-            <h2 className="text-base font-display font-semibold sm:text-lg">How money came in</h2>
-            <p className="mt-1 text-xs leading-relaxed text-black/50">
-              Shows payment receipts by method. This can differ from sales when customers pay old credit.
-            </p>
+        <div className="card p-4 sm:p-6" id="money-received">
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-base font-display font-semibold sm:text-lg">Money received</h2>
+              <p className="mt-1 text-xs leading-relaxed text-black/50">
+                Payment receipts by method for this period (from payment records). Includes money
+                received at sale and later credit collections. Tap a method to inspect supporting payments.
+              </p>
+            </div>
+            <a href={receiptsHref} className="shrink-0 text-xs font-medium text-accent underline-offset-2 hover:underline">
+              All receipts →
+            </a>
+          </div>
+          <div className="mb-4 grid grid-cols-2 gap-2 text-xs">
+            <div className="rounded-lg border border-emerald-100 bg-emerald-50/70 px-3 py-2">
+              <div className="text-emerald-800/70">Received at sale</div>
+              <div className="mt-0.5 font-semibold text-emerald-900">
+                {formatMoney(moneyReceived.receivedAtSalePence, currency)}
+              </div>
+            </div>
+            <div className="rounded-lg border border-amber-100 bg-amber-50/70 px-3 py-2">
+              <div className="text-amber-800/70">Later credit collected</div>
+              <div className="mt-0.5 font-semibold text-amber-900">
+                {formatMoney(moneyReceived.laterCreditCollectionPence, currency)}
+              </div>
+            </div>
           </div>
           <div className="space-y-3 text-sm">
             {(
               [
-                { label: 'Cash', key: 'CASH', cls: 'bg-emerald-500', text: 'text-emerald-700' },
-                { label: 'Mobile Money (MoMo)', key: 'MOBILE_MONEY', cls: 'bg-amber-500', text: 'text-amber-700' },
-                { label: 'Card', key: 'CARD', cls: 'bg-blue-500', text: 'text-accent' },
-                { label: 'Bank Transfer', key: 'TRANSFER', cls: 'bg-purple-500', text: 'text-purple-700' },
+                { label: RECEIPT_METHOD_LABELS.CASH, key: 'CASH' as ReceiptPaymentMethod, cls: 'bg-emerald-500', text: 'text-emerald-700' },
+                { label: RECEIPT_METHOD_LABELS.MOBILE_MONEY, key: 'MOBILE_MONEY' as ReceiptPaymentMethod, cls: 'bg-amber-500', text: 'text-amber-700' },
+                { label: RECEIPT_METHOD_LABELS.CARD, key: 'CARD' as ReceiptPaymentMethod, cls: 'bg-blue-500', text: 'text-accent' },
+                { label: RECEIPT_METHOD_LABELS.TRANSFER, key: 'TRANSFER' as ReceiptPaymentMethod, cls: 'bg-purple-500', text: 'text-purple-700' },
               ] as const
             ).map(({ label, key, cls, text }) => {
-              const amount = paymentSplit[key as keyof typeof paymentSplit];
+              const amount = paymentSplit[key];
               const pct = totalPaymentReceipts > 0 ? Math.round((amount / totalPaymentReceipts) * 100) : 0;
+              const href = moneyReceivedHref(scope, key);
               return (
-                <div key={key}>
+                <a
+                  key={key}
+                  href={href}
+                  className="block rounded-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                  aria-label={`View ${label} payment records: ${formatMoney(amount, currency)}`}
+                >
                   <div className="mb-1 flex justify-between text-xs">
-                    <span className="text-black/60">{label}</span>
+                    <span className="text-black/60 underline-offset-2 group-hover:underline">{label}</span>
                     <span className={`font-semibold ${text}`}>
                       {formatMoney(amount, currency)} ({pct}%)
                     </span>
                   </div>
-                  <div className="h-1.5 rounded-full bg-black/5 overflow-hidden">
+                  <div className="h-1.5 overflow-hidden rounded-full bg-black/5">
                     <div className={`h-1.5 rounded-full ${cls}`} style={{ width: `${Math.min(pct, 100)}%` }} />
                   </div>
-                </div>
+                </a>
               );
             })}
           </div>
+          <p className="mt-3 text-[11px] leading-relaxed text-black/45">
+            Electronic payments (MoMo, card, bank transfer) are listed here — not in the Cash Drawer.
+            Physical cash till movements: <a href={cashDrawerHref} className="font-medium underline underline-offset-2">Cash Drawer</a>.
+          </p>
         </div>
 
         <div className="card p-4 sm:p-6">

--- a/app/(protected)/reports/dashboard/TradingDashboardContent.tsx
+++ b/app/(protected)/reports/dashboard/TradingDashboardContent.tsx
@@ -12,7 +12,6 @@ import { measureServerOperation, PERFORMANCE_THRESHOLDS_MS } from '@/lib/observa
 import {
   getMoneyReceivedSummary,
   RECEIPT_METHOD_LABELS,
-  type ReceiptPaymentMethod,
 } from '@/lib/reports/money-received';
 import {
   buildReportingScopeSearchParams,
@@ -656,10 +655,11 @@ export default async function TradingDashboardContent({
           <div className="space-y-3 text-sm">
             {(
               [
-                { label: RECEIPT_METHOD_LABELS.CASH, key: 'CASH' as ReceiptPaymentMethod, cls: 'bg-emerald-500', text: 'text-emerald-700' },
-                { label: RECEIPT_METHOD_LABELS.MOBILE_MONEY, key: 'MOBILE_MONEY' as ReceiptPaymentMethod, cls: 'bg-amber-500', text: 'text-amber-700' },
-                { label: RECEIPT_METHOD_LABELS.CARD, key: 'CARD' as ReceiptPaymentMethod, cls: 'bg-blue-500', text: 'text-accent' },
-                { label: RECEIPT_METHOD_LABELS.TRANSFER, key: 'TRANSFER' as ReceiptPaymentMethod, cls: 'bg-purple-500', text: 'text-purple-700' },
+                { label: RECEIPT_METHOD_LABELS.CASH, key: 'CASH' as const, cls: 'bg-emerald-500', text: 'text-emerald-700' },
+                { label: RECEIPT_METHOD_LABELS.MOBILE_MONEY, key: 'MOBILE_MONEY' as const, cls: 'bg-amber-500', text: 'text-amber-700' },
+                { label: RECEIPT_METHOD_LABELS.CARD, key: 'CARD' as const, cls: 'bg-blue-500', text: 'text-accent' },
+                { label: RECEIPT_METHOD_LABELS.TRANSFER, key: 'TRANSFER' as const, cls: 'bg-purple-500', text: 'text-purple-700' },
+                { label: RECEIPT_METHOD_LABELS.UNKNOWN, key: 'UNKNOWN' as const, cls: 'bg-slate-400', text: 'text-slate-700' },
               ] as const
             ).map(({ label, key, cls, text }) => {
               const amount = paymentSplit[key];
@@ -685,6 +685,12 @@ export default async function TradingDashboardContent({
               );
             })}
           </div>
+          {moneyReceived.byMethod.UNKNOWN !== 0 ? (
+            <p className="mt-2 text-[11px] leading-relaxed text-black/50">
+              Unknown/Other includes stored payment methods outside the recognised set
+              (blank, differently cased, legacy or future values). They remain in the total.
+            </p>
+          ) : null}
           <p className="mt-3 text-[11px] leading-relaxed text-black/45">
             Electronic payments (MoMo, card, bank transfer) are listed here — not in the Cash Drawer.
             Physical cash till movements: <a href={cashDrawerHref} className="font-medium underline underline-offset-2">Cash Drawer</a>.

--- a/app/(protected)/reports/dashboard/TradingDashboardContent.tsx
+++ b/app/(protected)/reports/dashboard/TradingDashboardContent.tsx
@@ -627,7 +627,7 @@ export default async function TradingDashboardContent({
               All receipts →
             </a>
           </div>
-          <div className="mb-4 grid grid-cols-2 gap-2 text-xs">
+          <div className="mb-4 grid grid-cols-2 gap-2 text-xs sm:grid-cols-3">
             <div className="rounded-lg border border-emerald-100 bg-emerald-50/70 px-3 py-2">
               <div className="text-emerald-800/70">Received at sale</div>
               <div className="mt-0.5 font-semibold text-emerald-900">
@@ -640,7 +640,19 @@ export default async function TradingDashboardContent({
                 {formatMoney(moneyReceived.laterCreditCollectionPence, currency)}
               </div>
             </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2 col-span-2 sm:col-span-1">
+              <div className="text-slate-600">Historical — not classified</div>
+              <div className="mt-0.5 font-semibold text-slate-800">
+                {formatMoney(moneyReceived.unknownHistoricalOriginPence, currency)}
+              </div>
+            </div>
           </div>
+          {moneyReceived.unknownHistoricalOriginPence !== 0 ? (
+            <p className="mb-3 text-[11px] leading-relaxed text-black/50">
+              Some older payments have no durable receipt origin. They remain in the total above
+              and are not guessed from timestamps.
+            </p>
+          ) : null}
           <div className="space-y-3 text-sm">
             {(
               [

--- a/app/(protected)/reports/dashboard/page.tsx
+++ b/app/(protected)/reports/dashboard/page.tsx
@@ -5,7 +5,10 @@ import ReportSectionSkeleton from '@/components/reports/ReportSectionSkeleton';
 import { requireBusiness } from '@/lib/auth';
 import { recordOwnerDashboardView, recordOwnerReportView } from '@/app/actions/activation';
 import { getBusinessStores } from '@/lib/services/stores';
-import { resolveReportDateRange } from '@/lib/reports/date-parsing';
+import {
+  isReportingScopeToday,
+  resolveReportingScope,
+} from '@/lib/reports/reporting-scope';
 import TradingDashboardContent from './TradingDashboardContent';
 
 export const dynamic = 'force-dynamic';
@@ -13,7 +16,7 @@ export const dynamic = 'force-dynamic';
 export default async function DashboardPage({
   searchParams,
 }: {
-  searchParams?: { from?: string; to?: string; storeId?: string };
+  searchParams?: { from?: string; to?: string; storeId?: string; period?: string };
 }) {
   const { business, user } = await requireBusiness(['MANAGER', 'OWNER']);
   if (user.role === 'OWNER') {
@@ -34,28 +37,26 @@ export default async function DashboardPage({
     searchParams?.storeId,
   );
 
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
+  const scope = resolveReportingScope({
+    businessId: business.id,
+    timeZone: (business as { timezone?: string | null }).timezone,
+    params: {
+      period: searchParams?.period,
+      from: searchParams?.from,
+      to: searchParams?.to,
+      storeId: rawStoreId ?? searchParams?.storeId ?? 'ALL',
+    },
+    defaultPeriod: '7d',
+    allowedStoreIds: stores.map((store) => store.id),
+  });
 
-  const defaultRangeStart = new Date(todayStart);
-  defaultRangeStart.setDate(defaultRangeStart.getDate() - 6);
-
-  const { start, end, fromInputValue: fromIso, toInputValue: toIso } = resolveReportDateRange(
-    searchParams,
-    defaultRangeStart,
-    todayEnd,
-  );
-
-  const selectedStoreId = rawStoreId ?? 'ALL';
-  const isToday =
-    start.toDateString() === todayStart.toDateString() &&
-    end.toDateString() === todayEnd.toDateString();
+  const selectedStoreId = scope.storeId;
+  const isToday = isReportingScopeToday(scope);
   const hasNonDefaultParams = !!(
-    searchParams?.from ||
-    searchParams?.to ||
-    (searchParams?.storeId && searchParams?.storeId !== 'ALL')
+    searchParams?.from
+    || searchParams?.to
+    || searchParams?.period
+    || (searchParams?.storeId && searchParams.storeId !== 'ALL')
   );
 
   return (
@@ -67,7 +68,9 @@ export default async function DashboardPage({
             {business.name}
           </h1>
           <p className="mt-1 text-sm text-muted">
-            {isToday ? 'Today (live)' : `${fromIso} to ${toIso}`}
+            {isToday
+              ? `Today (live) · ${scope.timeZone}`
+              : `${scope.fromInputValue} to ${scope.toInputValue} · ${scope.timeZone}`}
           </p>
         </div>
         <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-3">
@@ -78,7 +81,7 @@ export default async function DashboardPage({
         </div>
       </div>
 
-      <details className="details-mobile" open={hasNonDefaultParams}>
+      <details className="details-mobile" open={hasNonDefaultParams || isToday}>
         <summary className="flex cursor-pointer list-none items-center justify-between rounded-2xl border border-slate-200/80 bg-white/90 px-4 py-3 shadow-sm">
           <span className="text-sm font-semibold text-ink">Adjust date range / branch</span>
           <svg className="h-4 w-4 text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -88,16 +91,17 @@ export default async function DashboardPage({
         <div className="mt-2 space-y-2">
           <div className="rounded-xl border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-blue-900">
             <p>
-              Figures use the selected period and branch where supported. Sales and receipts may differ
-              because customer credit can be paid later.
+              <strong>Sales revenue</strong> is recognised sales for this period.
+              <strong> Money received</strong> is payment receipts (including later credit collections).
+              They can differ when customers buy on credit or pay old balances.
             </p>
             <p className="mt-1">
-              Customer and supplier balances show the current position, not only this period. Gross profit
-              uses sale-line cost snapshots.
+              Period uses the business timezone ({scope.timeZone}). Customer and supplier balances show the
+              current position, not only this period.
             </p>
           </div>
           <ReportFilterCard
-            columnsClassName={stores.length > 1 ? 'sm:grid-cols-4' : 'sm:grid-cols-3'}
+            columnsClassName={stores.length > 1 ? 'sm:grid-cols-5' : 'sm:grid-cols-4'}
             submitLabel="Apply filters"
             submitTone="primary"
             actions={
@@ -107,12 +111,20 @@ export default async function DashboardPage({
             }
           >
             <div>
+              <label className="label">Quick period</label>
+              <select className="input" name="period" defaultValue={scope.periodKey}>
+                <option value="today">Today</option>
+                <option value="7d">Last 7 days</option>
+                <option value="custom">Custom dates</option>
+              </select>
+            </div>
+            <div>
               <label className="label">From</label>
-              <input className="input" type="date" name="from" defaultValue={fromIso} />
+              <input className="input" type="date" name="from" defaultValue={scope.fromInputValue} />
             </div>
             <div>
               <label className="label">To</label>
-              <input className="input" type="date" name="to" defaultValue={toIso} />
+              <input className="input" type="date" name="to" defaultValue={scope.toInputValue} />
             </div>
             {stores.length > 1 ? (
               <div>
@@ -138,14 +150,16 @@ export default async function DashboardPage({
           businessId={business.id}
           businessName={business.name}
           currency={business.currency}
+          timeZone={scope.timeZone}
           userId={user.id}
           userName={user.name}
           userEmail={user.email}
           selectedStoreId={selectedStoreId}
-          fromIso={fromIso}
-          toIso={toIso}
-          startIso={start.toISOString()}
-          endIso={end.toISOString()}
+          fromIso={scope.fromInputValue}
+          toIso={scope.toInputValue}
+          periodKey={scope.periodKey}
+          startIso={scope.startInclusive.toISOString()}
+          endIso={scope.endExclusive.toISOString()}
           isToday={isToday}
         />
       </Suspense>

--- a/app/(protected)/reports/dashboard/page.tsx
+++ b/app/(protected)/reports/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import { notFound } from 'next/navigation';
 import RefreshIndicator from '@/components/RefreshIndicator';
 import ReportFilterCard from '@/components/reports/ReportFilterCard';
 import ReportSectionSkeleton from '@/components/reports/ReportSectionSkeleton';
@@ -6,6 +7,7 @@ import { requireBusiness } from '@/lib/auth';
 import { recordOwnerDashboardView, recordOwnerReportView } from '@/app/actions/activation';
 import { getBusinessStores } from '@/lib/services/stores';
 import {
+  isReportingScopeStoreError,
   isReportingScopeToday,
   resolveReportingScope,
 } from '@/lib/reports/reporting-scope';
@@ -32,23 +34,26 @@ export default async function DashboardPage({
     );
   }
 
-  const { stores, selectedStoreId: rawStoreId } = await getBusinessStores(
-    business.id,
-    searchParams?.storeId,
-  );
+  const { stores } = await getBusinessStores(business.id, searchParams?.storeId);
 
-  const scope = resolveReportingScope({
-    businessId: business.id,
-    timeZone: (business as { timezone?: string | null }).timezone,
-    params: {
-      period: searchParams?.period,
-      from: searchParams?.from,
-      to: searchParams?.to,
-      storeId: rawStoreId ?? searchParams?.storeId ?? 'ALL',
-    },
-    defaultPeriod: '7d',
-    allowedStoreIds: stores.map((store) => store.id),
-  });
+  let scope;
+  try {
+    scope = resolveReportingScope({
+      businessId: business.id,
+      timeZone: (business as { timezone?: string | null }).timezone,
+      params: {
+        period: searchParams?.period,
+        from: searchParams?.from,
+        to: searchParams?.to,
+        storeId: searchParams?.storeId,
+      },
+      defaultPeriod: '7d',
+      allowedStoreIds: stores.map((store) => store.id),
+    });
+  } catch (error) {
+    if (isReportingScopeStoreError(error)) notFound();
+    throw error;
+  }
 
   const selectedStoreId = scope.storeId;
   const isToday = isReportingScopeToday(scope);

--- a/app/(protected)/reports/receipts/page.tsx
+++ b/app/(protected)/reports/receipts/page.tsx
@@ -18,7 +18,7 @@ import {
   parseReceiptOriginParam,
   RECEIPT_CLASSIFICATION_LABELS,
   RECEIPT_METHOD_LABELS,
-  SUPPORTED_RECEIPT_METHODS,
+  RECEIPT_METHOD_BUCKETS,
   SUPPORTED_RECEIPT_ORIGINS,
 } from '@/lib/reports/money-received';
 
@@ -127,7 +127,7 @@ export default async function MoneyReceivedReceiptsPage({
           <label className="label">Payment method</label>
           <select className="input" name="method" defaultValue={method ?? ''}>
             <option value="">All methods</option>
-            {SUPPORTED_RECEIPT_METHODS.map((value) => (
+            {RECEIPT_METHOD_BUCKETS.map((value) => (
               <option key={value} value={value}>
                 {RECEIPT_METHOD_LABELS[value]}
               </option>

--- a/app/(protected)/reports/receipts/page.tsx
+++ b/app/(protected)/reports/receipts/page.tsx
@@ -15,9 +15,11 @@ import {
 import {
   listMoneyReceivedPayments,
   parseReceiptMethodParam,
+  parseReceiptOriginParam,
   RECEIPT_CLASSIFICATION_LABELS,
   RECEIPT_METHOD_LABELS,
   SUPPORTED_RECEIPT_METHODS,
+  SUPPORTED_RECEIPT_ORIGINS,
 } from '@/lib/reports/money-received';
 
 export const dynamic = 'force-dynamic';
@@ -31,6 +33,7 @@ export default async function MoneyReceivedReceiptsPage({
     storeId?: string;
     period?: string;
     method?: string;
+    origin?: string;
     page?: string;
     pageSize?: string;
   };
@@ -59,18 +62,21 @@ export default async function MoneyReceivedReceiptsPage({
   });
 
   const method = parseReceiptMethodParam(searchParams?.method);
+  const origin = parseReceiptOriginParam(searchParams?.origin);
   const page = Math.max(1, parseInt(searchParams?.page ?? '1', 10) || 1);
   const pageSize = Math.min(50, Math.max(1, parseInt(searchParams?.pageSize ?? '25', 10) || 25));
 
   const { rows, totalCount, totalPages, page: currentPage } = await listMoneyReceivedPayments({
     scope,
     method,
+    origin,
     page,
     pageSize,
   });
 
   const isToday = isReportingScopeToday(scope);
   const methodLabel = method ? RECEIPT_METHOD_LABELS[method] : 'All methods';
+  const originLabel = origin ? RECEIPT_CLASSIFICATION_LABELS[origin] : 'All origins';
 
   return (
     <div className="space-y-4 sm:space-y-5">
@@ -86,16 +92,18 @@ export default async function MoneyReceivedReceiptsPage({
 
       <section className="rounded-2xl border border-blue-100 bg-blue-50/70 px-4 py-3 text-sm text-blue-900">
         <p>
-          Showing <strong>{methodLabel}</strong> for{' '}
+          Showing <strong>{methodLabel}</strong>
+          {' · '}
+          <strong>{originLabel}</strong> for{' '}
           {isToday ? 'Today' : `${scope.fromInputValue} → ${scope.toInputValue}`}
           {scope.storeId === 'ALL' ? ' · All branches' : ''}.
-          Rows are individual <strong>SalesPayment</strong> records. Classification separates
-          money received at sale from later credit collections.
+          Rows are individual <strong>SalesPayment</strong> records. Origin comes from the
+          persisted payment field — historical payments without origin stay “not classified”.
         </p>
       </section>
 
       <ReportFilterCard
-        columnsClassName="sm:grid-cols-5"
+        columnsClassName="sm:grid-cols-6"
         submitLabel="Apply"
         submitTone="secondary"
       >
@@ -122,6 +130,17 @@ export default async function MoneyReceivedReceiptsPage({
             {SUPPORTED_RECEIPT_METHODS.map((value) => (
               <option key={value} value={value}>
                 {RECEIPT_METHOD_LABELS[value]}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="label">Receipt origin</label>
+          <select className="input" name="origin" defaultValue={origin ?? ''}>
+            <option value="">All origins</option>
+            {SUPPORTED_RECEIPT_ORIGINS.map((value) => (
+              <option key={value} value={value}>
+                {RECEIPT_CLASSIFICATION_LABELS[value]}
               </option>
             ))}
           </select>
@@ -210,7 +229,9 @@ export default async function MoneyReceivedReceiptsPage({
                         className={
                           row.classification === 'RECEIVED_AT_SALE'
                             ? 'rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-800'
-                            : 'rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800'
+                            : row.classification === 'LATER_CREDIT_COLLECTION'
+                              ? 'rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800'
+                              : 'rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700'
                         }
                       >
                         {row.classificationLabel}
@@ -258,6 +279,7 @@ export default async function MoneyReceivedReceiptsPage({
           to: scope.toInputValue,
           storeId: scope.storeId,
           method: method ?? undefined,
+          origin: origin ?? undefined,
           pageSize: String(pageSize),
         }}
       />
@@ -265,7 +287,7 @@ export default async function MoneyReceivedReceiptsPage({
       <p className="text-xs text-muted">
         Deep link for this view:{' '}
         <code className="rounded bg-slate-100 px-1 py-0.5 text-[10px]">
-          {moneyReceivedHref(scope, method ?? undefined)}
+          {moneyReceivedHref(scope, method ?? undefined, origin ?? undefined)}
         </code>
       </p>
     </div>

--- a/app/(protected)/reports/receipts/page.tsx
+++ b/app/(protected)/reports/receipts/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
 import PageHeader from '@/components/PageHeader';
 import Pagination from '@/components/Pagination';
 import ReportFilterCard from '@/components/reports/ReportFilterCard';
@@ -7,6 +8,7 @@ import { requireBusiness } from '@/lib/auth';
 import { formatDateTime, formatMoney } from '@/lib/format';
 import { getBusinessStores } from '@/lib/services/stores';
 import {
+  isReportingScopeStoreError,
   isReportingScopeToday,
   moneyReceivedHref,
   resolveReportingScope,
@@ -43,23 +45,26 @@ export default async function MoneyReceivedReceiptsPage({
     return <div className="card p-6">Setup Required</div>;
   }
 
-  const { stores, selectedStoreId: rawStoreId } = await getBusinessStores(
-    business.id,
-    searchParams?.storeId,
-  );
+  const { stores } = await getBusinessStores(business.id, searchParams?.storeId);
 
-  const scope = resolveReportingScope({
-    businessId: business.id,
-    timeZone: (business as { timezone?: string | null }).timezone,
-    params: {
-      period: searchParams?.period,
-      from: searchParams?.from,
-      to: searchParams?.to,
-      storeId: rawStoreId ?? searchParams?.storeId ?? 'ALL',
-    },
-    defaultPeriod: 'today',
-    allowedStoreIds: stores.map((store) => store.id),
-  });
+  let scope;
+  try {
+    scope = resolveReportingScope({
+      businessId: business.id,
+      timeZone: (business as { timezone?: string | null }).timezone,
+      params: {
+        period: searchParams?.period,
+        from: searchParams?.from,
+        to: searchParams?.to,
+        storeId: searchParams?.storeId,
+      },
+      defaultPeriod: 'today',
+      allowedStoreIds: stores.map((store) => store.id),
+    });
+  } catch (error) {
+    if (isReportingScopeStoreError(error)) notFound();
+    throw error;
+  }
 
   const method = parseReceiptMethodParam(searchParams?.method);
   const origin = parseReceiptOriginParam(searchParams?.origin);

--- a/app/(protected)/reports/receipts/page.tsx
+++ b/app/(protected)/reports/receipts/page.tsx
@@ -1,0 +1,273 @@
+import Link from 'next/link';
+import PageHeader from '@/components/PageHeader';
+import Pagination from '@/components/Pagination';
+import ReportFilterCard from '@/components/reports/ReportFilterCard';
+import { DataCard, DataCardField, DataCardHeader } from '@/components/DataCard';
+import { requireBusiness } from '@/lib/auth';
+import { formatDateTime, formatMoney } from '@/lib/format';
+import { getBusinessStores } from '@/lib/services/stores';
+import {
+  isReportingScopeToday,
+  moneyReceivedHref,
+  resolveReportingScope,
+  tradingReportHref,
+} from '@/lib/reports/reporting-scope';
+import {
+  listMoneyReceivedPayments,
+  parseReceiptMethodParam,
+  RECEIPT_CLASSIFICATION_LABELS,
+  RECEIPT_METHOD_LABELS,
+  SUPPORTED_RECEIPT_METHODS,
+} from '@/lib/reports/money-received';
+
+export const dynamic = 'force-dynamic';
+
+export default async function MoneyReceivedReceiptsPage({
+  searchParams,
+}: {
+  searchParams?: {
+    from?: string;
+    to?: string;
+    storeId?: string;
+    period?: string;
+    method?: string;
+    page?: string;
+    pageSize?: string;
+  };
+}) {
+  const { business } = await requireBusiness(['MANAGER', 'OWNER']);
+  if (!business) {
+    return <div className="card p-6">Setup Required</div>;
+  }
+
+  const { stores, selectedStoreId: rawStoreId } = await getBusinessStores(
+    business.id,
+    searchParams?.storeId,
+  );
+
+  const scope = resolveReportingScope({
+    businessId: business.id,
+    timeZone: (business as { timezone?: string | null }).timezone,
+    params: {
+      period: searchParams?.period,
+      from: searchParams?.from,
+      to: searchParams?.to,
+      storeId: rawStoreId ?? searchParams?.storeId ?? 'ALL',
+    },
+    defaultPeriod: 'today',
+    allowedStoreIds: stores.map((store) => store.id),
+  });
+
+  const method = parseReceiptMethodParam(searchParams?.method);
+  const page = Math.max(1, parseInt(searchParams?.page ?? '1', 10) || 1);
+  const pageSize = Math.min(50, Math.max(1, parseInt(searchParams?.pageSize ?? '25', 10) || 25));
+
+  const { rows, totalCount, totalPages, page: currentPage } = await listMoneyReceivedPayments({
+    scope,
+    method,
+    page,
+    pageSize,
+  });
+
+  const isToday = isReportingScopeToday(scope);
+  const methodLabel = method ? RECEIPT_METHOD_LABELS[method] : 'All methods';
+
+  return (
+    <div className="space-y-4 sm:space-y-5">
+      <PageHeader
+        title="Money received"
+        subtitle="Payment records for the selected period — not a sales list."
+        actions={
+          <Link href={tradingReportHref(scope)} className="btn-secondary text-sm">
+            Back to Trading Report
+          </Link>
+        }
+      />
+
+      <section className="rounded-2xl border border-blue-100 bg-blue-50/70 px-4 py-3 text-sm text-blue-900">
+        <p>
+          Showing <strong>{methodLabel}</strong> for{' '}
+          {isToday ? 'Today' : `${scope.fromInputValue} → ${scope.toInputValue}`}
+          {scope.storeId === 'ALL' ? ' · All branches' : ''}.
+          Rows are individual <strong>SalesPayment</strong> records. Classification separates
+          money received at sale from later credit collections.
+        </p>
+      </section>
+
+      <ReportFilterCard
+        columnsClassName="sm:grid-cols-5"
+        submitLabel="Apply"
+        submitTone="secondary"
+      >
+        <div>
+          <label className="label">Quick period</label>
+          <select className="input" name="period" defaultValue={scope.periodKey}>
+            <option value="today">Today</option>
+            <option value="7d">Last 7 days</option>
+            <option value="custom">Custom dates</option>
+          </select>
+        </div>
+        <div>
+          <label className="label">From</label>
+          <input className="input" type="date" name="from" defaultValue={scope.fromInputValue} />
+        </div>
+        <div>
+          <label className="label">To</label>
+          <input className="input" type="date" name="to" defaultValue={scope.toInputValue} />
+        </div>
+        <div>
+          <label className="label">Payment method</label>
+          <select className="input" name="method" defaultValue={method ?? ''}>
+            <option value="">All methods</option>
+            {SUPPORTED_RECEIPT_METHODS.map((value) => (
+              <option key={value} value={value}>
+                {RECEIPT_METHOD_LABELS[value]}
+              </option>
+            ))}
+          </select>
+        </div>
+        {stores.length > 1 ? (
+          <div>
+            <label className="label">Branch</label>
+            <select className="input" name="storeId" defaultValue={scope.storeId}>
+              <option value="ALL">All branches</option>
+              {stores.map((store) => (
+                <option key={store.id} value={store.id}>
+                  {store.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <input type="hidden" name="storeId" value={scope.storeId} />
+        )}
+      </ReportFilterCard>
+
+      <div className="text-sm text-muted">
+        {totalCount.toLocaleString()} payment{totalCount === 1 ? '' : 's'}
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="card px-4 py-10 text-center text-sm text-muted">
+          No payment records in this scope.
+        </div>
+      ) : (
+        <>
+          <div className="space-y-3 md:hidden">
+            {rows.map((row) => (
+              <DataCard key={row.paymentId}>
+                <DataCardHeader
+                  title={row.methodLabel}
+                  subtitle={formatDateTime(row.receivedAt)}
+                  aside={
+                    <span className="font-bold tabular-nums text-ink">
+                      {formatMoney(row.amountPence, business.currency)}
+                    </span>
+                  }
+                />
+                <DataCardField label="When received" value={RECEIPT_CLASSIFICATION_LABELS[row.classification]} />
+                <DataCardField label="Receipt" value={row.transactionNumber ?? row.invoiceId.slice(0, 8)} />
+                <DataCardField label="Branch" value={row.storeName} />
+                <DataCardField label="Till" value={row.tillName} />
+                <DataCardField label="Cashier" value={row.cashierName ?? '—'} />
+                <DataCardField label="Customer" value={row.customerName ?? '—'} />
+                <DataCardField label="Sale total" value={formatMoney(row.invoiceTotalPence, business.currency)} />
+                <DataCardField label="Reference" value={row.reference || row.provider || '—'} />
+                <div className="mt-2">
+                  <Link href={`/receipts/${row.invoiceId}`} className="text-xs font-medium text-accent underline-offset-2 hover:underline">
+                    Open receipt
+                  </Link>
+                </div>
+              </DataCard>
+            ))}
+          </div>
+
+          <div className="card hidden overflow-x-auto p-2 md:block">
+            <table className="table w-full min-w-[64rem]">
+              <thead>
+                <tr>
+                  <th>Received</th>
+                  <th>Method</th>
+                  <th>Type</th>
+                  <th>Amount</th>
+                  <th>Receipt #</th>
+                  <th>Branch</th>
+                  <th>Till</th>
+                  <th>Cashier</th>
+                  <th>Customer</th>
+                  <th>Sale total</th>
+                  <th>Reference</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.paymentId}>
+                    <td className="whitespace-nowrap text-sm">{formatDateTime(row.receivedAt)}</td>
+                    <td className="text-sm">{row.methodLabel}</td>
+                    <td className="text-sm">
+                      <span
+                        className={
+                          row.classification === 'RECEIVED_AT_SALE'
+                            ? 'rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-800'
+                            : 'rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800'
+                        }
+                      >
+                        {row.classificationLabel}
+                      </span>
+                      {row.paymentState === 'REVERSAL' ? (
+                        <span className="ml-1 rounded-full bg-rose-50 px-2 py-0.5 text-xs font-medium text-rose-700">
+                          Reversal
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="font-semibold tabular-nums">
+                      {formatMoney(row.amountPence, business.currency)}
+                    </td>
+                    <td className="font-mono text-xs">{row.transactionNumber ?? '—'}</td>
+                    <td className="text-sm">{row.storeName}</td>
+                    <td className="text-sm">{row.tillName}</td>
+                    <td className="text-sm">{row.cashierName ?? '—'}</td>
+                    <td className="text-sm">{row.customerName ?? '—'}</td>
+                    <td className="tabular-nums text-sm">
+                      {formatMoney(row.invoiceTotalPence, business.currency)}
+                    </td>
+                    <td className="max-w-[10rem] truncate text-xs text-muted" title={row.reference ?? undefined}>
+                      {row.reference || row.provider || '—'}
+                    </td>
+                    <td>
+                      <Link href={`/receipts/${row.invoiceId}`} className="text-xs font-medium text-accent underline-offset-2 hover:underline">
+                        Receipt
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        basePath="/reports/receipts"
+        searchParams={{
+          period: scope.periodKey,
+          from: scope.fromInputValue,
+          to: scope.toInputValue,
+          storeId: scope.storeId,
+          method: method ?? undefined,
+          pageSize: String(pageSize),
+        }}
+      />
+
+      <p className="text-xs text-muted">
+        Deep link for this view:{' '}
+        <code className="rounded bg-slate-100 px-1 py-0.5 text-[10px]">
+          {moneyReceivedHref(scope, method ?? undefined)}
+        </code>
+      </p>
+    </div>
+  );
+}

--- a/components/ReadinessJourney.test.tsx
+++ b/components/ReadinessJourney.test.tsx
@@ -219,7 +219,7 @@ describe('ReadinessJourney home stats', () => {
     const revenueValue = screen.getByText((_, element) =>
       element?.textContent?.replace(/\u00a0/g, ' ') === 'GH₵1,149.50'
     );
-    const revenueCard = screen.getByRole('link', { name: /Today's Revenue:/ });
+    const revenueCard = screen.getByRole('link', { name: /Today's Sales Revenue:/ });
 
     expect(revenueCard.parentElement).toHaveClass('grid-cols-2');
     expect(revenueCard).toHaveClass('min-w-0');
@@ -237,7 +237,7 @@ describe('ReadinessJourney home stats', () => {
 
     renderDashboard();
 
-    const revenueLabel = screen.getByText('Revenue');
+    const revenueLabel = screen.getByText('Sales revenue');
     const transactionsLabel = screen.getByText('Transactions');
     const expectedCashLabel = screen.getByText('Expected Cash');
     const transactionsCard = screen.getByRole('link', { name: /Today's Transactions:/ });
@@ -250,12 +250,12 @@ describe('ReadinessJourney home stats', () => {
       expect(label).toHaveClass('whitespace-nowrap');
     }
 
-    expect(screen.queryByText("Today's Revenue")).not.toBeInTheDocument();
+    expect(screen.queryByText("Today's Sales Revenue")).not.toBeInTheDocument();
     expect(screen.queryByText("Today's Transactions")).not.toBeInTheDocument();
     expect(screen.queryByText('Open Issues')).not.toBeInTheDocument();
     expect(transactionsCard).not.toHaveClass('col-span-2');
     expect(expectedCashCard).not.toHaveClass('col-span-2');
-    expect(screen.getByRole('link', { name: /Today's Revenue:/ })).toHaveClass('col-span-2');
+    expect(screen.getByRole('link', { name: /Today's Sales Revenue:/ })).toHaveClass('col-span-2');
   });
 
   it('drops very long revenue values to the smallest stat size', () => {
@@ -292,7 +292,7 @@ describe('ReadinessJourney home stats', () => {
 
     renderDashboard();
 
-    expect(within(screen.getByRole('link', { name: /Today's Revenue:/ })).getByText('GH₵467.50 today / GH₵7,000.00 yesterday')).toBeInTheDocument();
+    expect(within(screen.getByRole('link', { name: /Today's Sales Revenue:/ })).getByText('GH₵467.50 today / GH₵7,000.00 yesterday')).toBeInTheDocument();
     expect(within(screen.getByRole('link', { name: /Today's Transactions:/ })).queryByText(/yesterday/)).not.toBeInTheDocument();
     expect(screen.queryByText('Day in progress')).not.toBeInTheDocument();
     expect(screen.queryByText('-93% vs yesterday')).not.toBeInTheDocument();
@@ -304,7 +304,7 @@ describe('ReadinessJourney home stats', () => {
 
     renderDashboard();
 
-    expect(within(screen.getByRole('link', { name: /Today's Revenue:/ })).getByText('GH₵467.50 today / GH₵7,000.00 yesterday')).toBeInTheDocument();
+    expect(within(screen.getByRole('link', { name: /Today's Sales Revenue:/ })).getByText('GH₵467.50 today / GH₵7,000.00 yesterday')).toBeInTheDocument();
     expect(within(screen.getByRole('link', { name: /Today's Transactions:/ })).queryByText(/yesterday/)).not.toBeInTheDocument();
     expect(screen.queryByText(/vs yesterday/)).not.toBeInTheDocument();
   });
@@ -315,7 +315,7 @@ describe('ReadinessJourney home stats', () => {
 
     renderDashboard({ todayTransactionCount: 20 });
 
-    expect(within(screen.getByRole('link', { name: /Today's Revenue:/ })).getByText('GH₵467.50 today / GH₵7,000.00 yesterday')).toBeInTheDocument();
+    expect(within(screen.getByRole('link', { name: /Today's Sales Revenue:/ })).getByText('GH₵467.50 today / GH₵7,000.00 yesterday')).toBeInTheDocument();
     expect(within(screen.getByRole('link', { name: /Today's Transactions:/ })).queryByText(/yesterday/)).not.toBeInTheDocument();
     expect(screen.queryByText(/vs yesterday/)).not.toBeInTheDocument();
   });
@@ -365,7 +365,7 @@ describe('ReadinessJourney home stats', () => {
       openShiftCount: 1,
     });
 
-    expect(screen.getByRole('link', { name: /Today's Revenue: GH₵9,593.00/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Today's Sales Revenue: GH₵9,593.00/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Today's Transactions: 85/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Expected Cash: GH₵8,919.00/ })).toBeInTheDocument();
     expect(getNavTodaySales).not.toHaveBeenCalled();
@@ -382,7 +382,7 @@ describe('ReadinessJourney home stats', () => {
       openShiftSalesCount: 85,
     });
 
-    expect(screen.getByRole('link', { name: /Today's Revenue: GH₵9,593.00/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Today's Sales Revenue: GH₵9,593.00/ })).toBeInTheDocument();
     expect(screen.getByRole('status')).toHaveTextContent('4 areas need your attention today');
     expect(screen.getAllByText('4 areas need your attention today.')).toHaveLength(1); // Today's attention only
     expect(screen.getByText(/85 sales in this open shift/)).toBeInTheDocument();

--- a/components/ReadinessJourney.tsx
+++ b/components/ReadinessJourney.tsx
@@ -491,7 +491,7 @@ function WelcomeDashboard({
         { label: 'Expected Cash', displayLabel: 'Expected Cash', value: formatCurrency(data.expectedCashPence), href: '/reports/cash-drawer', footer: data.openShiftCount > 0 ? 'Current open till balance' : 'No open till', primary: false },
       ]
     : [
-        { label: "Today's Revenue", displayLabel: 'Revenue', value: formatCurrency(data.todayRevenuePence), href: '/reports/dashboard', footer: todayVsYesterdayText, primary: true },
+        { label: "Today's Sales Revenue", displayLabel: 'Sales revenue', value: formatCurrency(data.todayRevenuePence), href: '/reports/dashboard?period=today&storeId=ALL', footer: todayVsYesterdayText, primary: true },
         { label: "Today's Transactions", displayLabel: 'Transactions', value: data.todayTransactionCount.toLocaleString(), href: '/sales', footer: null, primary: false },
         { label: 'Expected Cash', displayLabel: 'Expected Cash', value: formatCurrency(data.expectedCashPence), href: '/reports/cash-drawer', footer: data.openShiftCount > 0 ? 'Current open till balance' : 'No open till', primary: false },
       ];

--- a/components/owner-home/HomePerformanceRetry.test.tsx
+++ b/components/owner-home/HomePerformanceRetry.test.tsx
@@ -41,6 +41,14 @@ const zeroSummary: HomePerformanceSummary = {
   expectedCashPence: 0,
   openShiftCount: 0,
   productCount: 812,
+  timeZone: 'Africa/Accra',
+  todayScope: {
+    periodKey: 'today',
+    fromInputValue: '2026-08-07',
+    toInputValue: '2026-08-07',
+    storeId: 'ALL',
+  },
+  tradingReportHref: '/reports/dashboard?period=today&from=2026-08-07&to=2026-08-07&storeId=ALL',
 };
 
 const dataSummary: HomePerformanceSummary = {
@@ -51,6 +59,14 @@ const dataSummary: HomePerformanceSummary = {
   expectedCashPence: 2_000_00,
   openShiftCount: 1,
   productCount: 812,
+  timeZone: 'Africa/Accra',
+  todayScope: {
+    periodKey: 'today',
+    fromInputValue: '2026-08-07',
+    toInputValue: '2026-08-07',
+    storeId: 'ALL',
+  },
+  tradingReportHref: '/reports/dashboard?period=today&from=2026-08-07&to=2026-08-07&storeId=ALL',
 };
 
 afterEach(() => {

--- a/components/owner-home/HomePerformanceSlot.tsx
+++ b/components/owner-home/HomePerformanceSlot.tsx
@@ -3,6 +3,7 @@ import { formatMoney } from '@/lib/format';
 import type { HomePerformanceSummary } from '@/lib/reports/home-performance-kpis';
 import { getStatValueSize } from '@/lib/owner-home/stat-value-size';
 import { HomePerformanceUnavailable } from '@/components/owner-home/section-errors';
+import { buildReportingScopeSearchParams } from '@/lib/reports/reporting-scope';
 
 export default async function HomePerformanceSlot({
   performancePromise,
@@ -22,6 +23,8 @@ export default async function HomePerformanceSlot({
   }
 
   const formatCurrency = (pence: number) => formatMoney(pence, currency);
+  const cashDrawerHref = `/reports/cash-drawer?${buildReportingScopeSearchParams(data.todayScope).toString()}`;
+  const salesTodayHref = `/sales?from=${encodeURIComponent(data.todayScope.fromInputValue)}&to=${encodeURIComponent(data.todayScope.toInputValue)}&storeId=ALL`;
 
   const todayVsYesterdayText =
     data.yesterdayRevenuePence > 0
@@ -43,7 +46,7 @@ export default async function HomePerformanceSlot({
             label: "Today's Transactions",
             displayLabel: 'Transactions',
             value: data.todayTransactionCount.toLocaleString(),
-            href: '/sales',
+            href: salesTodayHref,
             footer: null as string | null,
             primary: false,
           },
@@ -51,17 +54,17 @@ export default async function HomePerformanceSlot({
             label: 'Expected Cash',
             displayLabel: 'Expected Cash',
             value: formatCurrency(data.expectedCashPence),
-            href: '/reports/cash-drawer',
+            href: cashDrawerHref,
             footer: data.openShiftCount > 0 ? 'Current open till balance' : 'No open till',
             primary: false,
           },
         ]
       : [
           {
-            label: "Today's Revenue",
-            displayLabel: 'Revenue',
+            label: "Today's Sales Revenue",
+            displayLabel: 'Sales revenue',
             value: formatCurrency(data.todayRevenuePence),
-            href: '/reports/dashboard',
+            href: data.tradingReportHref,
             footer: todayVsYesterdayText,
             primary: true,
           },
@@ -69,7 +72,7 @@ export default async function HomePerformanceSlot({
             label: "Today's Transactions",
             displayLabel: 'Transactions',
             value: data.todayTransactionCount.toLocaleString(),
-            href: '/sales',
+            href: salesTodayHref,
             footer: null as string | null,
             primary: false,
           },
@@ -77,7 +80,7 @@ export default async function HomePerformanceSlot({
             label: 'Expected Cash',
             displayLabel: 'Expected Cash',
             value: formatCurrency(data.expectedCashPence),
-            href: '/reports/cash-drawer',
+            href: cashDrawerHref,
             footer: data.openShiftCount > 0 ? 'Current open till balance' : 'No open till',
             primary: false,
           },

--- a/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
+++ b/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
@@ -52,6 +52,10 @@
 
  * - Period bounds: business timezone, inclusive start / exclusive end.
 
+ * - Store scope is fail-closed: omitted → ALL; explicit ALL → ALL; valid accessible
+
+ *   store → that store; blank/whitespace/unknown/deleted/foreign → reject (never ALL).
+
  * - No PR #84 schema migration or historical origin/method backfill.
 
  */

--- a/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
+++ b/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
@@ -1,13 +1,21 @@
-/**
- * Option B reporting contract — Home revenue / money received / Cash Drawer.
- *
- * Locked product distinctions (do not invent alternate formulas):
- * - Sales revenue = Σ SalesInvoice.totalPence (exclude RETURNED/VOID), sale createdAt.
- * - Money received = Σ SalesPayment.amountPence (exclude FAILED/CANCELLED/VOID payments
- *   on non-voided invoices), payment receivedAt.
- * - Receipt classification: RECEIVED_AT_SALE vs LATER_CREDIT_COLLECTION via
- *   SALE_RECEIPT_GRACE_MS against invoice.createdAt (see money-received.ts).
- * - Cash Drawer remains physical-cash-only (CASH_SALE / CASH_DEBTOR / etc.).
- * - Period bounds: business timezone, inclusive start / exclusive end.
- */
-export {};
+/**
+ * Option B reporting contract — Home revenue / money received / Cash Drawer.
+ *
+ * Locked product distinctions (do not invent alternate formulas):
+ * - Sales revenue = Σ SalesInvoice.totalPence (exclude RETURNED/VOID), sale createdAt.
+ * - Money received = Σ SalesPayment.amountPence (exclude FAILED/CANCELLED/VOID payments
+ *   on non-voided invoices), payment receivedAt.
+ * - Receipt origin = persisted SalesPayment.receiptOrigin (PR #85). Reads use
+ *   resolveReceiptOrigin: NULL/empty → UNCLASSIFIED ("Historical — not classified").
+ *   Never infer origin from timestamps, payment method, or drawer activity.
+ * - Known buckets: RECEIVED_AT_SALE, LATER_CREDIT_COLLECTION.
+ * - Unknown bucket: historical NULL / UNCLASSIFIED — kept visible; not discarded to
+ *   force known-origin subtotals to equal total Money received.
+ * - Reconciliation (non-reversal identity):
+ *   total = received-at-sale + later collections + unknown historical (+ reversals tracked separately).
+ * - Cash Drawer remains physical-cash-only (CASH_SALE / CASH_DEBTOR / etc.).
+ * - Period bounds: business timezone, inclusive start / exclusive end.
+ * - No PR #84 schema migration or historical origin backfill.
+ */
+export {};
+

--- a/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
+++ b/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
@@ -11,8 +11,12 @@
  * - Known buckets: RECEIVED_AT_SALE, LATER_CREDIT_COLLECTION.
  * - Unknown bucket: historical NULL / UNCLASSIFIED — kept visible; not discarded to
  *   force known-origin subtotals to equal total Money received.
- * - Reconciliation (non-reversal identity):
- *   total = received-at-sale + later collections + unknown historical (+ reversals tracked separately).
+ * - Reconciliation:
+ *   total amount = Σ method groups (supported methods in fixtures)
+ *   total amount = received-at-sale + later collections + unknown historical
+ *   total count = origin counts
+ *   Signed reversals stay in their origin bucket (also surfaced as reversalPence).
+ * - Summary aggregation is complete DB SQL — never a capped in-memory findMany.
  * - Cash Drawer remains physical-cash-only (CASH_SALE / CASH_DEBTOR / etc.).
  * - Period bounds: business timezone, inclusive start / exclusive end.
  * - No PR #84 schema migration or historical origin backfill.

--- a/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
+++ b/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
@@ -1,25 +1,59 @@
-/**
- * Option B reporting contract — Home revenue / money received / Cash Drawer.
- *
- * Locked product distinctions (do not invent alternate formulas):
- * - Sales revenue = Σ SalesInvoice.totalPence (exclude RETURNED/VOID), sale createdAt.
- * - Money received = Σ SalesPayment.amountPence (exclude FAILED/CANCELLED/VOID payments
- *   on non-voided invoices), payment receivedAt.
- * - Receipt origin = persisted SalesPayment.receiptOrigin (PR #85). Reads use
- *   resolveReceiptOrigin: NULL/empty → UNCLASSIFIED ("Historical — not classified").
- *   Never infer origin from timestamps, payment method, or drawer activity.
- * - Known buckets: RECEIVED_AT_SALE, LATER_CREDIT_COLLECTION.
- * - Unknown bucket: historical NULL / UNCLASSIFIED — kept visible; not discarded to
- *   force known-origin subtotals to equal total Money received.
- * - Reconciliation:
- *   total amount = Σ method groups (supported methods in fixtures)
- *   total amount = received-at-sale + later collections + unknown historical
- *   total count = origin counts
- *   Signed reversals stay in their origin bucket (also surfaced as reversalPence).
- * - Summary aggregation is complete DB SQL — never a capped in-memory findMany.
- * - Cash Drawer remains physical-cash-only (CASH_SALE / CASH_DEBTOR / etc.).
- * - Period bounds: business timezone, inclusive start / exclusive end.
- * - No PR #84 schema migration or historical origin backfill.
- */
-export {};
-
+/**
+
+ * Option B reporting contract — Home revenue / money received / Cash Drawer.
+
+ *
+
+ * Locked product distinctions (do not invent alternate formulas):
+
+ * - Sales revenue = Σ SalesInvoice.totalPence (exclude RETURNED/VOID), sale createdAt.
+
+ * - Money received = Σ SalesPayment.amountPence (exclude FAILED/CANCELLED/VOID payments
+
+ *   on non-voided invoices), payment receivedAt.
+
+ * - Receipt origin = persisted SalesPayment.receiptOrigin (PR #85). Reads use
+
+ *   resolveReceiptOrigin: NULL/empty → UNCLASSIFIED ("Historical — not classified").
+
+ *   Never infer origin from timestamps, payment method, or drawer activity.
+
+ * - Known origin buckets: RECEIVED_AT_SALE, LATER_CREDIT_COLLECTION.
+
+ * - Unknown origin bucket: historical NULL / UNCLASSIFIED — kept visible; not discarded to
+
+ *   force known-origin subtotals to equal total Money received.
+
+ * - Payment method buckets (exact case-sensitive match only):
+
+ *   CASH, CARD, TRANSFER, MOBILE_MONEY, and UNKNOWN ("Unknown/Other").
+
+ *   Every stored method that is not an exact supported value (blank, whitespace,
+
+ *   wrong case, legacy, future, or unsupported) lands in UNKNOWN — never silently
+
+ *   remapped to a recognised method.
+
+ * - Reconciliation:
+
+ *   totalPence = CASH + CARD + TRANSFER + MOBILE_MONEY + UNKNOWN
+
+ *   totalCount = Σ method bucket counts
+
+ *   total amount = received-at-sale + later collections + unknown historical
+
+ *   total count = origin counts
+
+ *   Signed reversals stay in their origin/method buckets (also surfaced as reversalPence).
+
+ * - Summary aggregation is complete DB SQL — never a capped in-memory findMany.
+
+ * - Cash Drawer remains physical-cash-only (CASH_SALE / CASH_DEBTOR / etc.).
+
+ * - Period bounds: business timezone, inclusive start / exclusive end.
+
+ * - No PR #84 schema migration or historical origin/method backfill.
+
+ */
+
+export {};

--- a/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
+++ b/docs/reporting/OPTION_B_REVENUE_RECEIPTS_CONTRACT.md
@@ -1,0 +1,13 @@
+/**
+ * Option B reporting contract — Home revenue / money received / Cash Drawer.
+ *
+ * Locked product distinctions (do not invent alternate formulas):
+ * - Sales revenue = Σ SalesInvoice.totalPence (exclude RETURNED/VOID), sale createdAt.
+ * - Money received = Σ SalesPayment.amountPence (exclude FAILED/CANCELLED/VOID payments
+ *   on non-voided invoices), payment receivedAt.
+ * - Receipt classification: RECEIVED_AT_SALE vs LATER_CREDIT_COLLECTION via
+ *   SALE_RECEIPT_GRACE_MS against invoice.createdAt (see money-received.ts).
+ * - Cash Drawer remains physical-cash-only (CASH_SALE / CASH_DEBTOR / etc.).
+ * - Period bounds: business timezone, inclusive start / exclusive end.
+ */
+export {};

--- a/lib/billing-db-compat.ts
+++ b/lib/billing-db-compat.ts
@@ -4,6 +4,7 @@ const AUTH_LEGACY_SELECT = {
   id: true,
   name: true,
   currency: true,
+  timezone: true,
   vatEnabled: true,
   vatNumber: true,
   mode: true,

--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -92,6 +92,7 @@ export const REPORT_NAV_SECTIONS: NavigationSection[] = [
       { href: '/reports', label: 'Reports Hub', roles: ['MANAGER', 'OWNER'], iconKey: 'reportsHub' },
       { href: '/reports/command-center', label: 'Command Center', roles: ['MANAGER', 'OWNER'], iconKey: 'reports' },
       { href: '/reports/dashboard', label: 'Trading Report', roles: ['MANAGER', 'OWNER'], iconKey: 'analytics' },
+      { href: '/reports/receipts', label: 'Money Received', roles: ['MANAGER', 'OWNER'], iconKey: 'payments' },
       { href: '/reports/weekly-digest', label: 'Weekly Digest', roles: ['MANAGER', 'OWNER'], iconKey: 'reports' },
     ],
   },

--- a/lib/notifications/utils.ts
+++ b/lib/notifications/utils.ts
@@ -28,7 +28,7 @@ type ZonedDateParts = {
   second: number;
 };
 
-type LocalDateParts = Pick<ZonedDateParts, 'year' | 'month' | 'day'>;
+export type LocalDateParts = Pick<ZonedDateParts, 'year' | 'month' | 'day'>;
 
 const formatterCache = new Map<string, Intl.DateTimeFormat>();
 
@@ -139,6 +139,18 @@ function getNextLocalDate(parts: LocalDateParts): LocalDateParts {
 export function getBusinessDayBounds(date: Date, timeZone?: string | null) {
   const resolvedTimeZone = resolveBusinessTimeZone(timeZone);
   const localDate = getZonedDateParts(date, resolvedTimeZone);
+  return getBusinessCalendarDayBounds(localDate, resolvedTimeZone);
+}
+
+/**
+ * Inclusive start / exclusive end for a calendar Y-M-D in the business timezone.
+ * Prefer this over server-local setHours for reporting period boundaries.
+ */
+export function getBusinessCalendarDayBounds(
+  localDate: LocalDateParts,
+  timeZone?: string | null,
+) {
+  const resolvedTimeZone = resolveBusinessTimeZone(timeZone);
   const dayStart = zonedTimeToUtc(
     {
       year: localDate.year,
@@ -167,8 +179,34 @@ export function getBusinessDayBounds(date: Date, timeZone?: string | null) {
     timeZone: resolvedTimeZone,
     dayStart,
     dayEndExclusive,
-    localDate,
+    localDate: {
+      year: localDate.year,
+      month: localDate.month,
+      day: localDate.day,
+    },
   };
+}
+
+/** Parse YYYY-MM-DD into local date parts; returns null when malformed. */
+export function parseBusinessLocalDateKey(value: string | undefined | null): LocalDateParts | null {
+  const trimmed = value?.trim() ?? '';
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return null;
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  // Reject impossible calendar dates (e.g. 2026-02-31).
+  const probe = new Date(Date.UTC(year, month - 1, day));
+  if (
+    probe.getUTCFullYear() !== year
+    || probe.getUTCMonth() !== month - 1
+    || probe.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return { year, month, day };
 }
 
 export function formatBusinessDateLabel(date: Date, timeZone?: string | null) {

--- a/lib/reports/cash-drawer-clarity.test.ts
+++ b/lib/reports/cash-drawer-clarity.test.ts
@@ -11,10 +11,11 @@ describe('Cash Drawer report clarity pass', () => {
   it('adds cash-only scope copy without changing the route or title', () => {
     expect(page).toContain('title="Cash Drawer Report"');
     expect(page).toContain('Track cash expected and cash counted across all tills and shifts.');
-    expect(page).toContain('This report covers physical cash only.');
-    expect(page).toContain('MoMo, card, and bank transfer receipts are not included here');
-    expect(page).toContain('href="/reports/dashboard"');
-    expect(page).toContain('Trading Report');
+    expect(page).toContain('This report covers physical cash movements only');
+    expect(page).toContain('MoMo, card, and bank transfer receipts are electronic payments');
+    expect(page).toContain('href="/reports/dashboard#money-received"');
+    expect(page).toContain('Trading Report → Money received');
+    expect(page).toContain('href="/reports/receipts?period=today&storeId=ALL"');
   });
 
   it('uses owner-friendly stat labels, helpers, and Difference wording', () => {

--- a/lib/reports/dashboard-clarity.test.ts
+++ b/lib/reports/dashboard-clarity.test.ts
@@ -79,6 +79,14 @@ describe('Reports dashboard clarity pass', () => {
     expect(weeklyPage).not.toContain('Payment Receipts Split');
   });
 
+  it('Money received summary uses DB aggregation without legacy row cap', () => {
+    const moneyReceived = readSource('lib/reports/money-received.ts');
+    expect(moneyReceived).toContain('$queryRaw');
+    expect(moneyReceived).toContain('LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP');
+    expect(moneyReceived).not.toMatch(/take:\s*20_000/);
+    expect(moneyReceived).not.toContain('payerMsisdn');
+  });
+
   it('payment section helper clarifies receipts vs sales distinction on both reports', () => {
     const dashboard = readSource('app/(protected)/reports/dashboard/TradingDashboardContent.tsx');
     const weeklyPage = readSource('app/(protected)/reports/weekly-digest/page.tsx');

--- a/lib/reports/dashboard-clarity.test.ts
+++ b/lib/reports/dashboard-clarity.test.ts
@@ -199,6 +199,8 @@ describe('Reports dashboard clarity pass', () => {
     expect(dashboard).toContain('outstandingAR');
     expect(dashboard).toContain('outstandingAP');
     expect(dashboard).toContain('moneyReceived.byMethod');
+    expect(dashboard).toContain('RECEIPT_METHOD_LABELS.UNKNOWN');
+    expect(dashboard).toContain('Unknown/Other');
     expect(dashboard).toContain('totalGrossMargin');
     expect(dashboard).toContain('income.otherExpenses');
   });

--- a/lib/reports/dashboard-clarity.test.ts
+++ b/lib/reports/dashboard-clarity.test.ts
@@ -13,7 +13,7 @@ describe('Reports dashboard clarity pass', () => {
     const weeklyPage = readSource('app/(protected)/reports/weekly-digest/page.tsx');
     const weeklyService = readSource('lib/reports/weekly-digest.ts');
 
-    expect(dashboard).toContain('const totalPaymentReceipts = Object.values(paymentSplit)');
+    expect(dashboard).toContain('const totalPaymentReceipts = moneyReceived.totalPence');
     expect(dashboard).toContain('amount / totalPaymentReceipts');
     expect(weeklyService).toContain('totalReceiptsPence');
     expect(weeklyPage).toContain('amount / data.totalReceiptsPence');
@@ -22,7 +22,9 @@ describe('Reports dashboard clarity pass', () => {
   it('excludes failed, cancelled, and void sales payment statuses from receipt splits', () => {
     const dashboard = readSource('app/(protected)/reports/dashboard/TradingDashboardContent.tsx');
     const weeklyService = readSource('lib/reports/weekly-digest.ts');
+    const moneyReceived = readSource('lib/reports/money-received.ts');
 
+    expect(moneyReceived).toContain("REPORTING_EXCLUDED_PAYMENT_STATUSES");
     expect(dashboard).toContain("status: { notIn: ['FAILED', 'CANCELLED', 'VOID'] }");
     expect(weeklyService).toContain("status: { notIn: ['FAILED', 'CANCELLED', 'VOID'] }");
   });
@@ -36,7 +38,7 @@ describe('Reports dashboard clarity pass', () => {
     expect(dashboard).toContain('Closed-shift cash difference');
     expect(dashboard).toContain('Difference between expected and counted cash from closed shifts.');
     // Calculation logic unchanged
-    expect(dashboard).toContain('closedAt: { gte: start, lte: end }');
+    expect(dashboard).toContain('closedAt: { gte: start, lt: endExclusive }');
     expect(dashboard).toContain('Math.abs(v.variance ?? 0)');
     expect(weeklyPage).toContain('Closed-shift variance');
     expect(commandCenter).toContain('closed-shift cash variance');
@@ -61,13 +63,16 @@ describe('Reports dashboard clarity pass', () => {
   });
 
   // Phase 2A: Trading Report label / copy clarity
-  it('payment section heading uses owner-friendly "How money came in" label on both reports', () => {
+  it('payment section heading uses Money received with receipt semantics', () => {
     const dashboard = readSource('app/(protected)/reports/dashboard/TradingDashboardContent.tsx');
     const weeklyPage = readSource('app/(protected)/reports/weekly-digest/page.tsx');
 
-    expect(dashboard).toContain('How money came in');
+    expect(dashboard).toContain('Money received');
+    expect(dashboard).toContain('Received at sale');
+    expect(dashboard).toContain('Later credit collected');
+    expect(dashboard).toContain('moneyReceivedHref');
     expect(dashboard).not.toContain('Payment Receipts Split');
-    // Phase 2B: Weekly Digest also updated to "How money came in"
+    // Weekly Digest retains prior clarity label until a separate pass.
     expect(weeklyPage).toContain('How money came in');
     expect(weeklyPage).not.toContain('Payment Receipts Split');
   });
@@ -76,14 +81,16 @@ describe('Reports dashboard clarity pass', () => {
     const dashboard = readSource('app/(protected)/reports/dashboard/TradingDashboardContent.tsx');
     const weeklyPage = readSource('app/(protected)/reports/weekly-digest/page.tsx');
 
-    expect(dashboard).toContain('can differ from sales when customers pay old credit');
+    expect(dashboard).toContain('Includes money');
+    expect(dashboard).toContain('later credit collections');
     // Phase 2B: Weekly Digest uses consistent receipts distinction copy
     expect(weeklyPage).toContain('Receipts may include payments for older customer credit.');
   });
 
-  it('"What customers owe" replaces "Debtors (AR)" label', () => {
+  it('"Credit sales (unpaid)" replaces bare debtor KPI in the primary row', () => {
     const dashboard = readSource('app/(protected)/reports/dashboard/TradingDashboardContent.tsx');
-    expect(dashboard).toContain('What customers owe');
+    expect(dashboard).toContain('Credit sales (unpaid)');
+    expect(dashboard).toContain('What customers owe overall');
     expect(dashboard).not.toContain('Debtors (AR)');
   });
 
@@ -128,8 +135,8 @@ describe('Reports dashboard clarity pass', () => {
 
   it('customer debt helper clarifies current-state balance', () => {
     const dashboard = readSource('app/(protected)/reports/dashboard/TradingDashboardContent.tsx');
-    expect(dashboard).toContain('Current customer credit balance');
-    expect(dashboard).toContain('not just this period');
+    expect(dashboard).toContain('What customers owe overall');
+    expect(dashboard).toContain('Credit sales (unpaid)');
   });
 
   it('supplier payable helper clarifies current-state balance', () => {
@@ -140,7 +147,9 @@ describe('Reports dashboard clarity pass', () => {
 
   it('trust copy in filter info box clarifies sales and receipts distinction', () => {
     const dashboardPage = readSource('app/(protected)/reports/dashboard/page.tsx');
-    expect(dashboardPage).toContain('Sales and receipts may differ');
+    expect(dashboardPage).toContain('Sales revenue');
+    expect(dashboardPage).toContain('Money received');
+    expect(dashboardPage).toContain('business timezone');
     expect(dashboardPage).toContain('current position, not only this period');
   });
 
@@ -160,24 +169,26 @@ describe('Reports dashboard clarity pass', () => {
     expect(dashboard).toContain('/reports/analytics');
   });
 
-  it('report service imports remain unchanged', () => {
+  it('report service imports remain on the shared reporting contract', () => {
     const dashboard = readSource('app/(protected)/reports/dashboard/TradingDashboardContent.tsx');
     const dashboardPage = readSource('app/(protected)/reports/dashboard/page.tsx');
     expect(dashboard).toContain("from '@/lib/reports/financials'");
     expect(dashboard).toContain("from '@/lib/reports/operational-metrics'");
-    expect(dashboardPage).toContain("from '@/lib/reports/date-parsing'");
+    expect(dashboard).toContain("from '@/lib/reports/money-received'");
+    expect(dashboard).toContain("from '@/lib/reports/sales-revenue'");
+    expect(dashboardPage).toContain("from '@/lib/reports/reporting-scope'");
     expect(dashboard).toContain('getIncomeStatement');
     expect(dashboard).toContain('classifyInventoryState');
-    expect(dashboardPage).toContain('resolveReportDateRange');
+    expect(dashboardPage).toContain('resolveReportingScope');
     expect(dashboard).toContain('computeOutstandingBalance');
   });
 
-  it('sales aggregation and calculation logic is unchanged', () => {
+  it('sales aggregation uses shared sales-revenue contract', () => {
     const dashboard = readSource('app/(protected)/reports/dashboard/TradingDashboardContent.tsx');
-    expect(dashboard).toContain('salesAgg._sum.totalPence');
+    expect(dashboard).toContain('salesRevenue.salesRevenuePence');
     expect(dashboard).toContain('outstandingAR');
     expect(dashboard).toContain('outstandingAP');
-    expect(dashboard).toContain('paymentsByMethod');
+    expect(dashboard).toContain('moneyReceived.byMethod');
     expect(dashboard).toContain('totalGrossMargin');
     expect(dashboard).toContain('income.otherExpenses');
   });

--- a/lib/reports/dashboard-clarity.test.ts
+++ b/lib/reports/dashboard-clarity.test.ts
@@ -70,6 +70,8 @@ describe('Reports dashboard clarity pass', () => {
     expect(dashboard).toContain('Money received');
     expect(dashboard).toContain('Received at sale');
     expect(dashboard).toContain('Later credit collected');
+    expect(dashboard).toContain('Historical — not classified');
+    expect(dashboard).toContain('unknownHistoricalOriginPence');
     expect(dashboard).toContain('moneyReceivedHref');
     expect(dashboard).not.toContain('Payment Receipts Split');
     // Weekly Digest retains prior clarity label until a separate pass.

--- a/lib/reports/home-performance-kpis.test.ts
+++ b/lib/reports/home-performance-kpis.test.ts
@@ -1,11 +1,13 @@
 /**
- * Parity: Home performance summary today revenue/tx vs getTodayKPIs fields
- * used historically by Owner Home.
+ * Parity: Home performance summary today revenue/tx vs shared sales-revenue contract.
  */
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
+    business: {
+      findUnique: vi.fn(),
+    },
     salesInvoice: {
       aggregate: vi.fn(),
       findMany: vi.fn(),
@@ -20,10 +22,8 @@ vi.mock('@/lib/prisma', () => ({
   },
 }));
 
-vi.mock('@/lib/reports/sqlite-report-date-normalization', () => ({
-  ensureSqliteReportDateColumnsNormalized: vi.fn().mockResolvedValue(undefined),
-  isSqliteRuntime: vi.fn().mockReturnValue(false),
-  isDateWithinRange: vi.fn(),
+vi.mock('@/lib/reports/sales-revenue', () => ({
+  getSalesRevenueSummary: vi.fn(),
 }));
 
 describe('getHomePerformanceSummary parity with Home KPI fields', () => {
@@ -31,32 +31,38 @@ describe('getHomePerformanceSummary parity with Home KPI fields', () => {
     vi.clearAllMocks();
   });
 
-  it('returns today revenue/tx matching getTodayKPIs aggregate shape', async () => {
+  it('returns today revenue/tx from shared sales-revenue contract and Today drill-down href', async () => {
     const { prisma } = await import('@/lib/prisma');
+    const { getSalesRevenueSummary } = await import('@/lib/reports/sales-revenue');
     const { getHomePerformanceSummary } = await import('@/lib/reports/home-performance-kpis');
 
-    vi.mocked(prisma.salesInvoice.aggregate)
-      .mockResolvedValueOnce({
-        _sum: { totalPence: 12_238_50 },
-        _count: { id: 114 },
-        _avg: {},
-        _min: {},
-        _max: {},
-      } as never)
-      .mockResolvedValueOnce({
-        _sum: { totalPence: 9_593_00 },
-        _count: { id: 85 },
-        _avg: {},
-        _min: {},
-        _max: {},
-      } as never);
+    vi.mocked(prisma.business.findUnique).mockResolvedValueOnce({
+      timezone: 'Africa/Accra',
+    } as never);
+
+    vi.mocked(getSalesRevenueSummary).mockResolvedValueOnce({
+      salesRevenuePence: 12_238_50,
+      transactionCount: 114,
+      creditSalesOutstandingPence: 0,
+    });
+
+    vi.mocked(prisma.salesInvoice.aggregate).mockResolvedValueOnce({
+      _sum: { totalPence: 9_593_00 },
+      _count: { id: 85 },
+      _avg: {},
+      _min: {},
+      _max: {},
+    } as never);
 
     vi.mocked(prisma.shift.findMany).mockResolvedValueOnce([
       { expectedCashPence: 8_919_00 },
     ] as never);
     vi.mocked(prisma.product.count).mockResolvedValueOnce(1250);
 
-    const summary = await getHomePerformanceSummary('biz-1');
+    const summary = await getHomePerformanceSummary(
+      'biz-1',
+      new Date('2026-08-07T10:00:00.000Z'),
+    );
 
     expect(summary.todayRevenuePence).toBe(12_238_50);
     expect(summary.todayTransactionCount).toBe(114);
@@ -65,12 +71,17 @@ describe('getHomePerformanceSummary parity with Home KPI fields', () => {
     expect(summary.expectedCashPence).toBe(8_919_00);
     expect(summary.openShiftCount).toBe(1);
     expect(summary.productCount).toBe(1250);
+    expect(summary.timeZone).toBe('Africa/Accra');
+    expect(summary.todayScope.periodKey).toBe('today');
+    expect(summary.tradingReportHref).toContain('period=today');
+    expect(summary.tradingReportHref).toContain('storeId=ALL');
 
-    // Today aggregate must not include DEMO_DAY exclusion (match getTodayKPIs).
-    const todayCall = vi.mocked(prisma.salesInvoice.aggregate).mock.calls[0]?.[0] as {
-      where: Record<string, unknown>;
-    };
-    expect(todayCall.where).not.toHaveProperty('OR');
-    expect(todayCall.where.paymentStatus).toEqual({ notIn: ['RETURNED', 'VOID'] });
+    expect(getSalesRevenueSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        businessId: 'biz-1',
+        periodKey: 'today',
+        storeId: 'ALL',
+      }),
+    );
   });
 });

--- a/lib/reports/home-performance-kpis.ts
+++ b/lib/reports/home-performance-kpis.ts
@@ -1,20 +1,26 @@
 /**
- * Slim Owner Home performance summary — revenue, transactions, expected cash,
+ * Slim Owner Home performance summary — sales revenue, transactions, expected cash,
  * yesterday comparison, product count. Does NOT load Command Center payloads.
  *
- * Today revenue/tx match getTodayKPIs (RETURNED/VOID excluded; DEMO_DAY not filtered).
- * Yesterday matches historical getReadiness aggregate (also excludes DEMO_DAY).
+ * Today sales revenue uses the shared sales-revenue contract (RETURNED/VOID excluded).
+ * Period bounds use the business timezone (inclusive start / exclusive end).
  * Expected cash uses open-shift sum semantics via resolveReadinessExpectedCashPence.
  */
 import { prisma } from '@/lib/prisma';
-import {
-  ensureSqliteReportDateColumnsNormalized,
-  isDateWithinRange,
-  isSqliteRuntime,
-} from '@/lib/reports/sqlite-report-date-normalization';
 import { resolveReadinessExpectedCashPence } from '@/lib/reports/home-expected-cash';
 import { measureHomePerf } from '@/lib/performance/home-perf-instrumentation';
 import { assertHomeLoaderAllowed } from '@/lib/owner-home/force-fail';
+import {
+  getBusinessDayBounds,
+  resolveBusinessTimeZone,
+} from '@/lib/notifications/utils';
+import {
+  resolveReportingScope,
+  tradingReportHref,
+  type ReportingScope,
+} from '@/lib/reports/reporting-scope';
+import { getSalesRevenueSummary } from '@/lib/reports/sales-revenue';
+import { REPORTING_EXCLUDED_SALE_STATUSES } from '@/lib/reports/reporting-scope';
 
 export type HomePerformanceSummary = {
   todayRevenuePence: number;
@@ -24,146 +30,106 @@ export type HomePerformanceSummary = {
   expectedCashPence: number;
   openShiftCount: number;
   productCount: number;
+  timeZone: string;
+  todayScope: Pick<ReportingScope, 'periodKey' | 'fromInputValue' | 'toInputValue' | 'storeId'>;
+  tradingReportHref: string;
 };
 
-function dayBounds(now: Date) {
-  const todayStart = new Date(now);
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date(now);
-  todayEnd.setHours(23, 59, 59, 999);
-  const yesterdayStart = new Date(todayStart);
-  yesterdayStart.setDate(yesterdayStart.getDate() - 1);
-  const yesterdayEnd = new Date(todayEnd);
-  yesterdayEnd.setDate(yesterdayEnd.getDate() - 1);
-  return { todayStart, todayEnd, yesterdayStart, yesterdayEnd };
-}
-
-/** Match getTodayKPIs today sales filter. */
-const TODAY_SALE_WHERE = {
-  paymentStatus: { notIn: ['RETURNED', 'VOID'] as ('RETURNED' | 'VOID')[] },
-};
-
-/** Match getReadiness yesterday aggregate. */
-const YESTERDAY_SALE_WHERE = {
-  paymentStatus: { notIn: ['RETURNED', 'VOID'] as ('RETURNED' | 'VOID')[] },
-  OR: [{ qaTag: null }, { qaTag: { not: 'DEMO_DAY' } }],
-};
-
-async function getHomePerformanceSummarySqlite(
-  businessId: string,
-  now: Date
-): Promise<HomePerformanceSummary> {
-  const { todayStart, todayEnd, yesterdayStart, yesterdayEnd } = dayBounds(now);
-
-  const [salesRows, openShifts, productCount] = await Promise.all([
-    prisma.salesInvoice.findMany({
-      where: {
-        businessId,
-        paymentStatus: { notIn: ['RETURNED', 'VOID'] },
-        createdAt: { gte: yesterdayStart, lte: todayEnd },
-      },
-      select: { totalPence: true, createdAt: true, paymentStatus: true, qaTag: true },
-    }),
-    prisma.shift.findMany({
-      where: {
-        status: 'OPEN',
-        closedAt: null,
-        till: { store: { businessId } },
-      },
-      select: { expectedCashPence: true },
-    }),
-    prisma.product.count({ where: { businessId } }),
-  ]);
-
-  const todayRows = salesRows.filter((row) =>
-    isDateWithinRange(row.createdAt, todayStart, todayEnd)
-  );
-  const yesterdayRows = salesRows.filter(
-    (row) =>
-      isDateWithinRange(row.createdAt, yesterdayStart, yesterdayEnd) &&
-      (row.qaTag == null || row.qaTag !== 'DEMO_DAY')
-  );
-
-  const expectedCashPence = await resolveReadinessExpectedCashPence({
-    openShiftExpectedCashPence: openShifts.map((s) => s.expectedCashPence),
+async function loadBusinessTimeZone(businessId: string): Promise<string> {
+  const business = await prisma.business.findUnique({
+    where: { id: businessId },
+    select: { timezone: true },
   });
-
-  return {
-    todayRevenuePence: todayRows.reduce((s, r) => s + r.totalPence, 0),
-    todayTransactionCount: todayRows.length,
-    yesterdayRevenuePence: yesterdayRows.reduce((s, r) => s + r.totalPence, 0),
-    yesterdayTransactionCount: yesterdayRows.length,
-    expectedCashPence,
-    openShiftCount: openShifts.length,
-    productCount,
-  };
-}
-
-async function getHomePerformanceSummaryPostgres(
-  businessId: string,
-  now: Date
-): Promise<HomePerformanceSummary> {
-  const { todayStart, todayEnd, yesterdayStart, yesterdayEnd } = dayBounds(now);
-
-  const [todayAgg, yesterdayAgg, openShifts, productCount] = await Promise.all([
-    prisma.salesInvoice.aggregate({
-      where: {
-        businessId,
-        createdAt: { gte: todayStart, lte: todayEnd },
-        ...TODAY_SALE_WHERE,
-      },
-      _sum: { totalPence: true },
-      _count: { id: true },
-    }),
-    prisma.salesInvoice.aggregate({
-      where: {
-        businessId,
-        createdAt: { gte: yesterdayStart, lte: yesterdayEnd },
-        ...YESTERDAY_SALE_WHERE,
-      },
-      _sum: { totalPence: true },
-      _count: { id: true },
-    }),
-    prisma.shift.findMany({
-      where: {
-        status: 'OPEN',
-        closedAt: null,
-        till: { store: { businessId } },
-      },
-      select: { expectedCashPence: true },
-    }),
-    prisma.product.count({ where: { businessId } }),
-  ]);
-
-  const expectedCashPence = await resolveReadinessExpectedCashPence({
-    openShiftExpectedCashPence: openShifts.map((s) => s.expectedCashPence),
-  });
-
-  return {
-    todayRevenuePence: todayAgg._sum.totalPence ?? 0,
-    todayTransactionCount: todayAgg._count.id,
-    yesterdayRevenuePence: yesterdayAgg._sum.totalPence ?? 0,
-    yesterdayTransactionCount: yesterdayAgg._count.id,
-    expectedCashPence,
-    openShiftCount: openShifts.length,
-    productCount,
-  };
+  return resolveBusinessTimeZone(business?.timezone);
 }
 
 export async function getHomePerformanceSummary(
-  businessId: string
+  businessId: string,
+  now = new Date(),
 ): Promise<HomePerformanceSummary> {
   return measureHomePerf('home.performance-summary', async () => {
     assertHomeLoaderAllowed('performance');
-    try {
-      await ensureSqliteReportDateColumnsNormalized();
-    } catch {
-      // Same resilience as getTodayKPIs — continue with best-effort dates.
-    }
-    const now = new Date();
-    if (isSqliteRuntime()) {
-      return getHomePerformanceSummarySqlite(businessId, now);
-    }
-    return getHomePerformanceSummaryPostgres(businessId, now);
+
+    const timeZone = await loadBusinessTimeZone(businessId);
+    const todayScope = resolveReportingScope({
+      businessId,
+      timeZone,
+      params: { period: 'today', storeId: 'ALL' },
+      defaultPeriod: 'today',
+      allowedStoreIds: [],
+      now,
+    });
+
+    const yesterdayProbe = new Date(todayScope.startInclusive.getTime() - 1);
+    const yesterdayDay = getBusinessDayBounds(yesterdayProbe, timeZone);
+    const yesterdayKey = [
+      yesterdayDay.localDate.year,
+      String(yesterdayDay.localDate.month).padStart(2, '0'),
+      String(yesterdayDay.localDate.day).padStart(2, '0'),
+    ].join('-');
+    const yesterdayScope = resolveReportingScope({
+      businessId,
+      timeZone,
+      params: {
+        period: 'custom',
+        from: yesterdayKey,
+        to: yesterdayKey,
+        storeId: 'ALL',
+      },
+      defaultPeriod: 'today',
+      allowedStoreIds: [],
+      now: yesterdayProbe,
+    });
+
+    // Yesterday historically also excluded DEMO_DAY tags (getReadiness parity).
+    const [todaySummary, yesterdayAgg, openShifts, productCount] = await Promise.all([
+      getSalesRevenueSummary(todayScope),
+      prisma.salesInvoice.aggregate({
+        where: {
+          businessId,
+          createdAt: {
+            gte: yesterdayScope.startInclusive,
+            lt: yesterdayScope.endExclusive,
+          },
+          paymentStatus: { notIn: [...REPORTING_EXCLUDED_SALE_STATUSES] },
+          OR: [{ qaTag: null }, { qaTag: { not: 'DEMO_DAY' } }],
+        },
+        _sum: { totalPence: true },
+        _count: { id: true },
+      }),
+      prisma.shift.findMany({
+        where: {
+          status: 'OPEN',
+          closedAt: null,
+          till: { store: { businessId } },
+        },
+        select: { expectedCashPence: true },
+      }),
+      prisma.product.count({ where: { businessId } }),
+    ]);
+
+    const expectedCashPence = await resolveReadinessExpectedCashPence({
+      openShiftExpectedCashPence: openShifts.map((s) => s.expectedCashPence),
+    });
+
+    const hrefScope = {
+      periodKey: todayScope.periodKey,
+      fromInputValue: todayScope.fromInputValue,
+      toInputValue: todayScope.toInputValue,
+      storeId: todayScope.storeId,
+    };
+
+    return {
+      todayRevenuePence: todaySummary.salesRevenuePence,
+      todayTransactionCount: todaySummary.transactionCount,
+      yesterdayRevenuePence: yesterdayAgg._sum.totalPence ?? 0,
+      yesterdayTransactionCount: yesterdayAgg._count.id,
+      expectedCashPence,
+      openShiftCount: openShifts.length,
+      productCount,
+      timeZone,
+      todayScope: hrefScope,
+      tradingReportHref: tradingReportHref(hrefScope),
+    };
   });
 }

--- a/lib/reports/mobile-dashboard-consistency.test.ts
+++ b/lib/reports/mobile-dashboard-consistency.test.ts
@@ -17,7 +17,10 @@ describe('Mobile dashboard sales consistency', () => {
     expect(navKpis).toContain('txCount: summary.todayTransactionCount');
     expect(navKpis).not.toContain('getTodayKPIs');
 
-    expect(homeSummary).toContain('paymentStatus: { notIn: [\'RETURNED\', \'VOID\']');
+    expect(homeSummary).toContain('REPORTING_EXCLUDED_SALE_STATUSES');
+    expect(homeSummary).toContain('getSalesRevenueSummary');
+    expect(homeSummary).toContain('tradingReportHref');
+    expect(homeSummary).toContain("period: 'today'");
     expect(onboarding).toContain("import { getTodayKPIs } from '@/lib/reports/today-kpis'");
     expect(onboarding).toContain('getTodayKPIs(business.id)');
     expect(onboarding).toContain('todayRevenuePence: todayKpis?.totalSalesPence ?? 0');

--- a/lib/reports/money-received-classify.ts
+++ b/lib/reports/money-received-classify.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure receipt classification helpers (no Prisma import).
+ *
+ * Classification rule (no schema field; reconstructible from existing data):
+ *
+ *   Checkout creates nested SalesPayment rows in the same write as the
+ *   SalesInvoice, so payment.receivedAt aligns with invoice.createdAt
+ *   (typically the same second). Later credit collections via
+ *   recordCustomerPayment create additional SalesPayment rows afterwards.
+ *
+ *   RECEIVED_AT_SALE — positive payment where
+ *     receivedAt - invoice.createdAt <= SALE_RECEIPT_GRACE_MS (5 minutes).
+ *     Grace covers MoMo attach / clock skew inside the checkout path.
+ *
+ *   LATER_CREDIT_COLLECTION — positive payment outside that window.
+ *
+ *   Refunds/reversals use amountPence < 0 (amend/return flows) and are
+ *   exposed with paymentState REVERSAL; they reduce net money received.
+ *
+ * Limitation (documented residual): a same-session credit collection within
+ * 5 minutes of the original sale may classify as RECEIVED_AT_SALE. Without a
+ * payment-source column this cannot be eliminated; do not invent certainty.
+ */
+
+export type ReceiptClassification = 'RECEIVED_AT_SALE' | 'LATER_CREDIT_COLLECTION';
+export type ReceiptPaymentState = 'CONFIRMED' | 'REVERSAL' | 'OTHER';
+
+/** Max delta between invoice.createdAt and payment.receivedAt for sale-time. */
+export const SALE_RECEIPT_GRACE_MS = 5 * 60 * 1000;
+
+export const RECEIPT_CLASSIFICATION_LABELS: Record<ReceiptClassification, string> = {
+  RECEIVED_AT_SALE: 'Received at sale',
+  LATER_CREDIT_COLLECTION: 'Later credit collection',
+};
+
+export function classifySalesPaymentReceipt(input: {
+  amountPence: number;
+  receivedAt: Date;
+  invoiceCreatedAt: Date;
+}): { classification: ReceiptClassification; paymentState: ReceiptPaymentState } {
+  const paymentState: ReceiptPaymentState =
+    input.amountPence < 0 ? 'REVERSAL' : input.amountPence > 0 ? 'CONFIRMED' : 'OTHER';
+
+  const deltaMs = input.receivedAt.getTime() - input.invoiceCreatedAt.getTime();
+  const classification: ReceiptClassification =
+    deltaMs <= SALE_RECEIPT_GRACE_MS ? 'RECEIVED_AT_SALE' : 'LATER_CREDIT_COLLECTION';
+
+  return { classification, paymentState };
+}

--- a/lib/reports/money-received-classify.ts
+++ b/lib/reports/money-received-classify.ts
@@ -1,49 +1,36 @@
 /**
- * Pure receipt classification helpers (no Prisma import).
+ * Pure receipt classification helpers for reporting (no Prisma import).
  *
- * Classification rule (no schema field; reconstructible from existing data):
+ * Authoritative source: SalesPayment.receiptOrigin (PR #85 contract).
+ * Reads go through resolveReceiptOrigin — historical NULL → UNCLASSIFIED.
  *
- *   Checkout creates nested SalesPayment rows in the same write as the
- *   SalesInvoice, so payment.receivedAt aligns with invoice.createdAt
- *   (typically the same second). Later credit collections via
- *   recordCustomerPayment create additional SalesPayment rows afterwards.
- *
- *   RECEIVED_AT_SALE — positive payment where
- *     receivedAt - invoice.createdAt <= SALE_RECEIPT_GRACE_MS (5 minutes).
- *     Grace covers MoMo attach / clock skew inside the checkout path.
- *
- *   LATER_CREDIT_COLLECTION — positive payment outside that window.
- *
- *   Refunds/reversals use amountPence < 0 (amend/return flows) and are
- *   exposed with paymentState REVERSAL; they reduce net money received.
- *
- * Limitation (documented residual): a same-session credit collection within
- * 5 minutes of the original sale may classify as RECEIVED_AT_SALE. Without a
- * payment-source column this cannot be eliminated; do not invent certainty.
+ * Do not infer origin from timestamps, payment method, drawer, or journals.
+ * Do not treat UNCLASSIFIED / NULL as RECEIVED_AT_SALE or LATER_CREDIT_COLLECTION.
  */
 
-export type ReceiptClassification = 'RECEIVED_AT_SALE' | 'LATER_CREDIT_COLLECTION';
-export type ReceiptPaymentState = 'CONFIRMED' | 'REVERSAL' | 'OTHER';
+import {
+  resolveReceiptOrigin,
+  type ReceiptOrigin,
+} from '@/lib/payments/receipt-origin';
 
-/** Max delta between invoice.createdAt and payment.receivedAt for sale-time. */
-export const SALE_RECEIPT_GRACE_MS = 5 * 60 * 1000;
+export type ReceiptClassification = ReceiptOrigin;
+export type ReceiptPaymentState = 'CONFIRMED' | 'REVERSAL' | 'OTHER';
 
 export const RECEIPT_CLASSIFICATION_LABELS: Record<ReceiptClassification, string> = {
   RECEIVED_AT_SALE: 'Received at sale',
   LATER_CREDIT_COLLECTION: 'Later credit collection',
+  UNCLASSIFIED: 'Historical — not classified',
 };
 
 export function classifySalesPaymentReceipt(input: {
   amountPence: number;
-  receivedAt: Date;
-  invoiceCreatedAt: Date;
+  receiptOrigin: string | null | undefined;
 }): { classification: ReceiptClassification; paymentState: ReceiptPaymentState } {
   const paymentState: ReceiptPaymentState =
     input.amountPence < 0 ? 'REVERSAL' : input.amountPence > 0 ? 'CONFIRMED' : 'OTHER';
 
-  const deltaMs = input.receivedAt.getTime() - input.invoiceCreatedAt.getTime();
-  const classification: ReceiptClassification =
-    deltaMs <= SALE_RECEIPT_GRACE_MS ? 'RECEIVED_AT_SALE' : 'LATER_CREDIT_COLLECTION';
-
-  return { classification, paymentState };
+  return {
+    classification: resolveReceiptOrigin(input.receiptOrigin),
+    paymentState,
+  };
 }

--- a/lib/reports/money-received-method.test.ts
+++ b/lib/reports/money-received-method.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseReceiptMethodParam,
+  RECEIPT_METHOD_LABELS,
+  resolveReceiptMethodBucket,
+  sumMoneyReceivedByMethod,
+  UNKNOWN_RECEIPT_METHOD,
+} from '@/lib/reports/money-received';
+
+describe('money received method buckets', () => {
+  it('resolves only exact supported methods; everything else is UNKNOWN', () => {
+    expect(resolveReceiptMethodBucket('CASH')).toBe('CASH');
+    expect(resolveReceiptMethodBucket('CARD')).toBe('CARD');
+    expect(resolveReceiptMethodBucket('TRANSFER')).toBe('TRANSFER');
+    expect(resolveReceiptMethodBucket('MOBILE_MONEY')).toBe('MOBILE_MONEY');
+
+    expect(resolveReceiptMethodBucket('cash')).toBe(UNKNOWN_RECEIPT_METHOD);
+    expect(resolveReceiptMethodBucket('CHEQUE')).toBe(UNKNOWN_RECEIPT_METHOD);
+    expect(resolveReceiptMethodBucket('')).toBe(UNKNOWN_RECEIPT_METHOD);
+    expect(resolveReceiptMethodBucket('   ')).toBe(UNKNOWN_RECEIPT_METHOD);
+    expect(resolveReceiptMethodBucket(null)).toBe(UNKNOWN_RECEIPT_METHOD);
+    expect(resolveReceiptMethodBucket(undefined)).toBe(UNKNOWN_RECEIPT_METHOD);
+    expect(resolveReceiptMethodBucket('CRYPTO_FUTURE')).toBe(UNKNOWN_RECEIPT_METHOD);
+  });
+
+  it('labels UNKNOWN as Unknown/Other and reconciles amount identity helper', () => {
+    expect(RECEIPT_METHOD_LABELS.UNKNOWN).toBe('Unknown/Other');
+    expect(
+      sumMoneyReceivedByMethod({
+        CASH: 100,
+        CARD: 200,
+        TRANSFER: 50,
+        MOBILE_MONEY: 75,
+        UNKNOWN: 25,
+      }),
+    ).toBe(450);
+  });
+
+  it('parses UNKNOWN filter without accepting free-text unsupported methods as known', () => {
+    expect(parseReceiptMethodParam('UNKNOWN')).toBe('UNKNOWN');
+    expect(parseReceiptMethodParam('CASH')).toBe('CASH');
+    expect(parseReceiptMethodParam('cheque')).toBeNull();
+    expect(parseReceiptMethodParam('cash')).toBeNull();
+    expect(parseReceiptMethodParam('')).toBeNull();
+  });
+});

--- a/lib/reports/money-received-scale.pg.test.ts
+++ b/lib/reports/money-received-scale.pg.test.ts
@@ -166,8 +166,16 @@ describePg('money received complete DB aggregation (Postgres scale)', () => {
       summary.byMethod.CASH
         + summary.byMethod.CARD
         + summary.byMethod.TRANSFER
-        + summary.byMethod.MOBILE_MONEY,
+        + summary.byMethod.MOBILE_MONEY
+        + summary.byMethod.UNKNOWN,
     ).toBe(summary.totalPence);
+    expect(
+      summary.byMethodCount.CASH
+        + summary.byMethodCount.CARD
+        + summary.byMethodCount.TRANSFER
+        + summary.byMethodCount.MOBILE_MONEY
+        + summary.byMethodCount.UNKNOWN,
+    ).toBe(summary.totalCount);
     expect(
       summary.receivedAtSalePence
         + summary.laterCreditCollectionPence
@@ -259,8 +267,16 @@ describePg('money received complete DB aggregation (Postgres scale)', () => {
       summary.byMethod.CASH
         + summary.byMethod.CARD
         + summary.byMethod.TRANSFER
-        + summary.byMethod.MOBILE_MONEY,
+        + summary.byMethod.MOBILE_MONEY
+        + summary.byMethod.UNKNOWN,
     ).toBe(summary.totalPence);
+    expect(
+      summary.byMethodCount.CASH
+        + summary.byMethodCount.CARD
+        + summary.byMethodCount.TRANSFER
+        + summary.byMethodCount.MOBILE_MONEY
+        + summary.byMethodCount.UNKNOWN,
+    ).toBe(summary.totalCount);
     expect(
       summary.receivedAtSalePence
         + summary.laterCreditCollectionPence

--- a/lib/reports/money-received-scale.pg.test.ts
+++ b/lib/reports/money-received-scale.pg.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Postgres scale + aggregation completeness for Money received summary.
+ *
+ * Proves getMoneyReceivedSummary does not truncate at the legacy 20_000 row cap:
+ * receipt #20,001 (and larger sets) must change totals.
+ *
+ * Requires DATABASE_URL (Postgres). Skipped otherwise.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
+import { LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP } from '@/lib/reports/money-received';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const databaseUrl = process.env.DATABASE_URL;
+const canRun = !!databaseUrl && isPostgresDatabaseUrl(databaseUrl);
+const describePg = canRun ? describe : describe.skip;
+
+describePg('money received complete DB aggregation (Postgres scale)', () => {
+  let prisma: PrismaClient;
+  let getMoneyReceivedSummary: typeof import('@/lib/reports/money-received').getMoneyReceivedSummary;
+  let resolveReportingScope: typeof import('@/lib/reports/reporting-scope').resolveReportingScope;
+
+  const suffix = `scale-${Date.now()}`;
+  let businessId = '';
+  let storeId = '';
+  let tillId = '';
+  let cashierId = '';
+  let invoiceId = '';
+  const saleAt = new Date('2026-08-07T10:00:00.000Z');
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = databaseUrl!;
+    const g = globalThis as unknown as { prisma?: PrismaClient };
+    if (g.prisma) {
+      await g.prisma.$disconnect().catch(() => {});
+      g.prisma = undefined;
+    }
+    vi.resetModules();
+
+    const money = await import('@/lib/reports/money-received');
+    const scope = await import('@/lib/reports/reporting-scope');
+    getMoneyReceivedSummary = money.getMoneyReceivedSummary;
+    resolveReportingScope = scope.resolveReportingScope;
+
+    prisma = new PrismaClient();
+    await prisma.$connect();
+
+    const business = await prisma.business.create({
+      data: { name: `Scale ${suffix}`, currency: 'GHS', timezone: 'Africa/Accra' },
+    });
+    businessId = business.id;
+    const store = await prisma.store.create({
+      data: { businessId, name: `Store ${suffix}` },
+    });
+    storeId = store.id;
+    const cashier = await prisma.user.create({
+      data: {
+        businessId,
+        email: `${suffix}@example.com`,
+        name: 'Cashier',
+        role: 'CASHIER',
+        passwordHash: 'x',
+      },
+    });
+    cashierId = cashier.id;
+    const till = await prisma.till.create({
+      data: { storeId, name: `Till ${suffix}` },
+    });
+    tillId = till.id;
+
+    const invoice = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        tillId,
+        cashierUserId: cashierId,
+        paymentStatus: 'PAID',
+        subtotalPence: 1,
+        vatPence: 0,
+        totalPence: 1,
+        createdAt: saleAt,
+      },
+    });
+    invoiceId = invoice.id;
+  }, 60_000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await prisma.salesPayment.deleteMany({
+      where: { salesInvoice: { businessId } },
+    }).catch(() => {});
+    await prisma.salesInvoice.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.till.deleteMany({ where: { store: { businessId } } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.store.deleteMany({ where: { businessId } }).catch(() => {});
+    await prisma.business.deleteMany({ where: { id: businessId } }).catch(() => {});
+    await prisma.$disconnect().catch(() => {});
+  });
+
+  function scopeForDay() {
+    return resolveReportingScope({
+      businessId,
+      timeZone: 'Africa/Accra',
+      params: { period: 'custom', from: '2026-08-07', to: '2026-08-07', storeId: 'ALL' },
+      allowedStoreIds: [storeId],
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+  }
+
+  async function seedPayments(count: number, amountPence: number, origin: string | null) {
+    // Bulk insert via generate_series — avoids loading payment rows into Node.
+    await prisma.$executeRaw`
+      INSERT INTO "SalesPayment" (
+        id, "salesInvoiceId", method, "amountPence", "receivedAt", status, "receiptOrigin"
+      )
+      SELECT
+        ${`sc-${suffix}-`} || lpad(g::text, 8, '0'),
+        ${invoiceId},
+        'CASH',
+        ${amountPence},
+        ${saleAt},
+        'CONFIRMED',
+        ${origin}
+      FROM generate_series(1, ${count}) AS g
+      ON CONFLICT (id) DO NOTHING
+    `;
+  }
+
+  async function clearPayments() {
+    await prisma.salesPayment.deleteMany({ where: { salesInvoiceId: invoiceId } });
+  }
+
+  it('source no longer uses the legacy take:20_000 summary cap', () => {
+    const src = readFileSync(join(process.cwd(), 'lib/reports/money-received.ts'), 'utf8');
+    expect(src).toContain('LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP');
+    expect(LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP).toBe(20_000);
+    // Aggregation path must not reintroduce a capped findMany.
+    expect(src).not.toMatch(/take:\s*20_000/);
+    expect(src).not.toMatch(/take:\s*LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP/);
+    expect(src).toMatch(/\$queryRaw/);
+  });
+
+  it('includes receipt 20,001 — legacy cap would omit it and understate total', async () => {
+    await clearPayments();
+    const n = LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP + 1; // 20_001
+    const started = Date.now();
+    const memBefore = process.memoryUsage().heapUsed;
+
+    await seedPayments(n, 1, 'RECEIVED_AT_SALE');
+    const seedMs = Date.now() - started;
+
+    const t0 = Date.now();
+    const summary = await getMoneyReceivedSummary(scopeForDay());
+    const queryMs = Date.now() - t0;
+    const memAfter = process.memoryUsage().heapUsed;
+
+    // Legacy take:20_000 ordered by receivedAt/id would drop the last row → total 20_000.
+    expect(summary.totalCount).toBe(n);
+    expect(summary.totalPence).toBe(n);
+    expect(summary.receivedAtSalePence).toBe(n);
+    expect(summary.receivedAtSaleCount).toBe(n);
+    expect(summary.byMethod.CASH).toBe(n);
+    expect(
+      summary.byMethod.CASH
+        + summary.byMethod.CARD
+        + summary.byMethod.TRANSFER
+        + summary.byMethod.MOBILE_MONEY,
+    ).toBe(summary.totalPence);
+    expect(
+      summary.receivedAtSalePence
+        + summary.laterCreditCollectionPence
+        + summary.unknownHistoricalOriginPence,
+    ).toBe(summary.totalPence);
+    expect(
+      summary.receivedAtSaleCount
+        + summary.laterCreditCollectionCount
+        + summary.unknownHistoricalOriginCount,
+    ).toBe(summary.totalCount);
+
+    // Performance observation (not a hard SLA): one aggregate query, not N+1 / load-all.
+    expect(queryMs).toBeLessThan(30_000);
+    // eslint-disable-next-line no-console
+    console.log(
+      JSON.stringify({
+        dataset: n,
+        seedMs,
+        queryMs,
+        heapDeltaMb: Math.round(((memAfter - memBefore) / 1024 / 1024) * 10) / 10,
+      }),
+    );
+
+    // EXPLAIN — confirm aggregate plan (no evidence of app-side full materialisation).
+    const plan = await prisma.$queryRaw<Array<{ 'QUERY PLAN': string }>>`
+      EXPLAIN
+      SELECT COALESCE(SUM(sp."amountPence"), 0)
+      FROM "SalesPayment" sp
+      INNER JOIN "SalesInvoice" si ON si.id = sp."salesInvoiceId"
+      WHERE sp."receivedAt" >= ${saleAt}
+        AND sp."receivedAt" < ${new Date('2026-08-08T00:00:00.000Z')}
+        AND sp.status NOT IN ('FAILED', 'CANCELLED', 'VOID')
+        AND si."businessId" = ${businessId}
+        AND si."paymentStatus" NOT IN ('RETURNED', 'VOID')
+    `;
+    const planText = plan.map((p) => p['QUERY PLAN']).join('\n');
+    expect(planText.length).toBeGreaterThan(20);
+    // eslint-disable-next-line no-console
+    console.log('EXPLAIN_SNIPPET', planText.slice(0, 500));
+  }, 180_000);
+
+  it('reconciles 20,000 exact-boundary and mixed origin 50,000+ sets', async () => {
+    await clearPayments();
+    await seedPayments(LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP, 1, 'RECEIVED_AT_SALE');
+    let summary = await getMoneyReceivedSummary(scopeForDay());
+    expect(summary.totalCount).toBe(LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP);
+    expect(summary.totalPence).toBe(LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP);
+
+    await clearPayments();
+    const large = 50_000;
+    // Mix origins: 40k at-sale, 5k later, 5k NULL unknown
+    await prisma.$executeRaw`
+      INSERT INTO "SalesPayment" (
+        id, "salesInvoiceId", method, "amountPence", "receivedAt", status, "receiptOrigin"
+      )
+      SELECT
+        ${`sc2-${suffix}-`} || lpad(g::text, 8, '0'),
+        ${invoiceId},
+        CASE
+          WHEN g <= 20000 THEN 'CASH'
+          WHEN g <= 35000 THEN 'MOBILE_MONEY'
+          WHEN g <= 45000 THEN 'CARD'
+          ELSE 'TRANSFER'
+        END,
+        1,
+        ${saleAt},
+        'CONFIRMED',
+        CASE
+          WHEN g <= 40000 THEN 'RECEIVED_AT_SALE'
+          WHEN g <= 45000 THEN 'LATER_CREDIT_COLLECTION'
+          ELSE NULL
+        END
+      FROM generate_series(1, ${large}) AS g
+    `;
+
+    const t0 = Date.now();
+    summary = await getMoneyReceivedSummary(scopeForDay());
+    const queryMs = Date.now() - t0;
+
+    expect(summary.totalCount).toBe(large);
+    expect(summary.totalPence).toBe(large);
+    expect(summary.receivedAtSalePence).toBe(40_000);
+    expect(summary.laterCreditCollectionPence).toBe(5_000);
+    expect(summary.unknownHistoricalOriginPence).toBe(5_000);
+    expect(summary.receivedAtSaleCount).toBe(40_000);
+    expect(summary.laterCreditCollectionCount).toBe(5_000);
+    expect(summary.unknownHistoricalOriginCount).toBe(5_000);
+    expect(
+      summary.byMethod.CASH
+        + summary.byMethod.CARD
+        + summary.byMethod.TRANSFER
+        + summary.byMethod.MOBILE_MONEY,
+    ).toBe(summary.totalPence);
+    expect(
+      summary.receivedAtSalePence
+        + summary.laterCreditCollectionPence
+        + summary.unknownHistoricalOriginPence,
+    ).toBe(summary.totalPence);
+    expect(
+      summary.receivedAtSaleCount
+        + summary.laterCreditCollectionCount
+        + summary.unknownHistoricalOriginCount,
+    ).toBe(summary.totalCount);
+    expect(queryMs).toBeLessThan(60_000);
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify({ dataset: large, queryMs }));
+  }, 300_000);
+
+  it('keeps signed reversal in origin bucket without double-counting total', async () => {
+    await clearPayments();
+    await prisma.salesPayment.createMany({
+      data: [
+        {
+          id: `rev-pos-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'CASH',
+          amountPence: 5000,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'RECEIVED_AT_SALE',
+        },
+        {
+          id: `rev-neg-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'CASH',
+          amountPence: -1500,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'UNCLASSIFIED',
+        },
+      ],
+    });
+    const summary = await getMoneyReceivedSummary(scopeForDay());
+    expect(summary.totalPence).toBe(3500);
+    expect(summary.receivedAtSalePence).toBe(5000);
+    expect(summary.unknownHistoricalOriginPence).toBe(-1500);
+    expect(summary.reversalPence).toBe(-1500);
+    expect(
+      summary.receivedAtSalePence
+        + summary.laterCreditCollectionPence
+        + summary.unknownHistoricalOriginPence,
+    ).toBe(summary.totalPence);
+  });
+});

--- a/lib/reports/money-received-store-scope.pg.test.ts
+++ b/lib/reports/money-received-store-scope.pg.test.ts
@@ -1,0 +1,244 @@
+/**
+ * PostgreSQL: invalid/inaccessible storeId must not broaden Money received
+ * summary or list to ALL-store data.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
+
+const databaseUrl = process.env.DATABASE_URL;
+const canRun = !!databaseUrl && isPostgresDatabaseUrl(databaseUrl);
+const describePg = canRun ? describe : describe.skip;
+
+describePg('money received store-scope fail-closed (Postgres)', () => {
+  let prisma: PrismaClient;
+  let getMoneyReceivedSummary: typeof import('@/lib/reports/money-received').getMoneyReceivedSummary;
+  let listMoneyReceivedPayments: typeof import('@/lib/reports/money-received').listMoneyReceivedPayments;
+  let resolveReportingScope: typeof import('@/lib/reports/reporting-scope').resolveReportingScope;
+  let ReportingScopeStoreError: typeof import('@/lib/reports/reporting-scope').ReportingScopeStoreError;
+
+  const suffix = `store-fc-${Date.now()}`;
+  let businessId = '';
+  let otherBusinessId = '';
+  let storeA = '';
+  let storeB = '';
+  let otherStoreId = '';
+  const saleAt = new Date('2026-08-07T10:00:00.000Z');
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = databaseUrl!;
+    const g = globalThis as unknown as { prisma?: PrismaClient };
+    if (g.prisma) {
+      await g.prisma.$disconnect().catch(() => {});
+      g.prisma = undefined;
+    }
+    vi.resetModules();
+
+    const money = await import('@/lib/reports/money-received');
+    const scope = await import('@/lib/reports/reporting-scope');
+    getMoneyReceivedSummary = money.getMoneyReceivedSummary;
+    listMoneyReceivedPayments = money.listMoneyReceivedPayments;
+    resolveReportingScope = scope.resolveReportingScope;
+    ReportingScopeStoreError = scope.ReportingScopeStoreError;
+
+    prisma = new PrismaClient();
+    await prisma.$connect();
+
+    const business = await prisma.business.create({
+      data: { name: `StoreFC ${suffix}`, currency: 'GHS', timezone: 'Africa/Accra' },
+    });
+    businessId = business.id;
+    const other = await prisma.business.create({
+      data: { name: `StoreFC Other ${suffix}`, currency: 'GHS', timezone: 'Africa/Accra' },
+    });
+    otherBusinessId = other.id;
+
+    const a = await prisma.store.create({ data: { businessId, name: `A ${suffix}` } });
+    const b = await prisma.store.create({ data: { businessId, name: `B ${suffix}` } });
+    storeA = a.id;
+    storeB = b.id;
+    const otherStore = await prisma.store.create({
+      data: { businessId: otherBusinessId, name: `Foreign ${suffix}` },
+    });
+    otherStoreId = otherStore.id;
+
+    const cashier = await prisma.user.create({
+      data: {
+        businessId,
+        email: `${suffix}@example.com`,
+        name: 'Cashier',
+        role: 'CASHIER',
+        passwordHash: 'x',
+      },
+    });
+    const otherCashier = await prisma.user.create({
+      data: {
+        businessId: otherBusinessId,
+        email: `o-${suffix}@example.com`,
+        name: 'Other',
+        role: 'OWNER',
+        passwordHash: 'x',
+      },
+    });
+
+    const tillA = await prisma.till.create({ data: { storeId: storeA, name: `TillA ${suffix}` } });
+    const tillB = await prisma.till.create({ data: { storeId: storeB, name: `TillB ${suffix}` } });
+    const tillOther = await prisma.till.create({
+      data: { storeId: otherStoreId, name: `TillF ${suffix}` },
+    });
+
+    const invA = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId: storeA,
+        tillId: tillA.id,
+        cashierUserId: cashier.id,
+        paymentStatus: 'PAID',
+        subtotalPence: 1000,
+        vatPence: 0,
+        totalPence: 1000,
+        createdAt: saleAt,
+      },
+    });
+    const invB = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId: storeB,
+        tillId: tillB.id,
+        cashierUserId: cashier.id,
+        paymentStatus: 'PAID',
+        subtotalPence: 2000,
+        vatPence: 0,
+        totalPence: 2000,
+        createdAt: saleAt,
+      },
+    });
+    await prisma.salesPayment.createMany({
+      data: [
+        {
+          salesInvoiceId: invA.id,
+          method: 'CASH',
+          amountPence: 1000,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'RECEIVED_AT_SALE',
+        },
+        {
+          salesInvoiceId: invB.id,
+          method: 'CARD',
+          amountPence: 2000,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'RECEIVED_AT_SALE',
+        },
+      ],
+    });
+
+    await prisma.salesInvoice.create({
+      data: {
+        businessId: otherBusinessId,
+        storeId: otherStoreId,
+        tillId: tillOther.id,
+        cashierUserId: otherCashier.id,
+        paymentStatus: 'PAID',
+        subtotalPence: 99999,
+        vatPence: 0,
+        totalPence: 99999,
+        createdAt: saleAt,
+        payments: {
+          create: {
+            method: 'CASH',
+            amountPence: 99999,
+            receivedAt: saleAt,
+            status: 'CONFIRMED',
+            receiptOrigin: 'RECEIVED_AT_SALE',
+          },
+        },
+      },
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await prisma.salesPayment.deleteMany({
+      where: { salesInvoice: { businessId: { in: [businessId, otherBusinessId] } } },
+    }).catch(() => {});
+    await prisma.salesInvoice.deleteMany({
+      where: { businessId: { in: [businessId, otherBusinessId] } },
+    }).catch(() => {});
+    await prisma.till.deleteMany({
+      where: { store: { businessId: { in: [businessId, otherBusinessId] } } },
+    }).catch(() => {});
+    await prisma.user.deleteMany({
+      where: { businessId: { in: [businessId, otherBusinessId] } },
+    }).catch(() => {});
+    await prisma.store.deleteMany({
+      where: { businessId: { in: [businessId, otherBusinessId] } },
+    }).catch(() => {});
+    await prisma.business.deleteMany({
+      where: { id: { in: [businessId, otherBusinessId] } },
+    }).catch(() => {});
+    await prisma.$disconnect().catch(() => {});
+  });
+
+  function scope(storeId?: string) {
+    return resolveReportingScope({
+      businessId,
+      timeZone: 'Africa/Accra',
+      params: {
+        period: 'custom',
+        from: '2026-08-07',
+        to: '2026-08-07',
+        ...(storeId === undefined ? {} : { storeId }),
+      },
+      allowedStoreIds: [storeA, storeB],
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+  }
+
+  it('omitted and ALL return all accessible stores only; never foreign tenant', async () => {
+    const omitted = await getMoneyReceivedSummary(scope());
+    const all = await getMoneyReceivedSummary(scope('ALL'));
+    expect(omitted.totalPence).toBe(3000);
+    expect(all.totalPence).toBe(3000);
+    expect(omitted.totalCount).toBe(2);
+    expect(all.byMethod.UNKNOWN).toBe(0);
+  });
+
+  it('valid accessible stores isolate amounts; second store differs', async () => {
+    const a = await getMoneyReceivedSummary(scope(storeA));
+    const b = await getMoneyReceivedSummary(scope(storeB));
+    expect(a.totalPence).toBe(1000);
+    expect(b.totalPence).toBe(2000);
+    expect(a.byMethod.CASH).toBe(1000);
+    expect(b.byMethod.CARD).toBe(2000);
+
+    const listA = await listMoneyReceivedPayments({ scope: scope(storeA), page: 1, pageSize: 50 });
+    expect(listA.totalCount).toBe(1);
+    expect(listA.rows.every((r) => r.storeId === storeA)).toBe(true);
+  });
+
+  it('unknown, blank, whitespace and foreign store fail closed before any query', async () => {
+    for (const bad of ['store-missing', '', '   ', otherStoreId]) {
+      expect(() => scope(bad)).toThrow(ReportingScopeStoreError);
+    }
+  });
+
+  it('summary and list stay consistent; pagination cannot bypass store isolation', async () => {
+    const s = scope(storeA);
+    const summary = await getMoneyReceivedSummary(s);
+    const page1 = await listMoneyReceivedPayments({ scope: s, page: 1, pageSize: 1 });
+    const page2 = await listMoneyReceivedPayments({ scope: s, page: 2, pageSize: 1 });
+    expect(page1.totalCount).toBe(summary.totalCount);
+    expect(page2.totalCount).toBe(summary.totalCount);
+    expect(page1.rows.every((r) => r.storeId === storeA)).toBe(true);
+    expect(page2.rows.every((r) => r.storeId === storeA)).toBe(true);
+    expect(summary.totalPence).toBe(
+      summary.byMethod.CASH
+        + summary.byMethod.CARD
+        + summary.byMethod.TRANSFER
+        + summary.byMethod.MOBILE_MONEY
+        + summary.byMethod.UNKNOWN,
+    );
+  });
+});

--- a/lib/reports/money-received-unknown-method.pg.test.ts
+++ b/lib/reports/money-received-unknown-method.pg.test.ts
@@ -1,0 +1,358 @@
+/**
+ * PostgreSQL regression: unrecognised SalesPayment.method values must land in UNKNOWN
+ * and keep amount/count reconciliation identities.
+ *
+ * Requires DATABASE_URL (Postgres). Skipped otherwise.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
+import {
+  RECEIPT_METHOD_LABELS,
+  sumMoneyReceivedByMethod,
+  UNKNOWN_RECEIPT_METHOD,
+} from '@/lib/reports/money-received';
+
+const databaseUrl = process.env.DATABASE_URL;
+const canRun = !!databaseUrl && isPostgresDatabaseUrl(databaseUrl);
+const describePg = canRun ? describe : describe.skip;
+
+describePg('money received unknown payment-method reconciliation (Postgres)', () => {
+  let prisma: PrismaClient;
+  let getMoneyReceivedSummary: typeof import('@/lib/reports/money-received').getMoneyReceivedSummary;
+  let listMoneyReceivedPayments: typeof import('@/lib/reports/money-received').listMoneyReceivedPayments;
+  let resolveReportingScope: typeof import('@/lib/reports/reporting-scope').resolveReportingScope;
+
+  const suffix = `unkm-${Date.now()}`;
+  let businessId = '';
+  let otherBusinessId = '';
+  let storeId = '';
+  let otherStoreId = '';
+  let tillId = '';
+  let cashierId = '';
+  let invoiceId = '';
+  const saleAt = new Date('2026-08-07T10:00:00.000Z');
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = databaseUrl!;
+    const g = globalThis as unknown as { prisma?: PrismaClient };
+    if (g.prisma) {
+      await g.prisma.$disconnect().catch(() => {});
+      g.prisma = undefined;
+    }
+    vi.resetModules();
+
+    const money = await import('@/lib/reports/money-received');
+    const scope = await import('@/lib/reports/reporting-scope');
+    getMoneyReceivedSummary = money.getMoneyReceivedSummary;
+    listMoneyReceivedPayments = money.listMoneyReceivedPayments;
+    resolveReportingScope = scope.resolveReportingScope;
+
+    prisma = new PrismaClient();
+    await prisma.$connect();
+
+    const business = await prisma.business.create({
+      data: { name: `UnkM ${suffix}`, currency: 'GHS', timezone: 'Africa/Accra' },
+    });
+    businessId = business.id;
+    const other = await prisma.business.create({
+      data: { name: `UnkM Other ${suffix}`, currency: 'GHS', timezone: 'Africa/Accra' },
+    });
+    otherBusinessId = other.id;
+
+    const store = await prisma.store.create({ data: { businessId, name: `Store ${suffix}` } });
+    storeId = store.id;
+    const otherStore = await prisma.store.create({
+      data: { businessId: otherBusinessId, name: `Other ${suffix}` },
+    });
+    otherStoreId = otherStore.id;
+
+    const cashier = await prisma.user.create({
+      data: {
+        businessId,
+        email: `${suffix}@example.com`,
+        name: 'Cashier',
+        role: 'CASHIER',
+        passwordHash: 'x',
+      },
+    });
+    cashierId = cashier.id;
+    const otherCashier = await prisma.user.create({
+      data: {
+        businessId: otherBusinessId,
+        email: `o-${suffix}@example.com`,
+        name: 'Other',
+        role: 'OWNER',
+        passwordHash: 'x',
+      },
+    });
+
+    const till = await prisma.till.create({ data: { storeId, name: `Till ${suffix}` } });
+    tillId = till.id;
+    const otherTill = await prisma.till.create({
+      data: { storeId: otherStoreId, name: `Other till ${suffix}` },
+    });
+
+    const invoice = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        tillId,
+        cashierUserId: cashierId,
+        paymentStatus: 'PAID',
+        subtotalPence: 10000,
+        vatPence: 0,
+        totalPence: 10000,
+        createdAt: saleAt,
+      },
+    });
+    invoiceId = invoice.id;
+
+    // Recognised + unrecognised (exact match only — wrong case is UNKNOWN).
+    await prisma.salesPayment.createMany({
+      data: [
+        {
+          id: `um-cash-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'CASH',
+          amountPence: 1000,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'RECEIVED_AT_SALE',
+        },
+        {
+          id: `um-card-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'CARD',
+          amountPence: 2000,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'RECEIVED_AT_SALE',
+        },
+        {
+          id: `um-xfer-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'TRANSFER',
+          amountPence: 500,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'RECEIVED_AT_SALE',
+        },
+        {
+          id: `um-momo-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'MOBILE_MONEY',
+          amountPence: 700,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'LATER_CREDIT_COLLECTION',
+        },
+        {
+          id: `um-cheque-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'CHEQUE',
+          amountPence: 300,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'RECEIVED_AT_SALE',
+        },
+        {
+          id: `um-blank-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: '',
+          amountPence: 110,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'UNCLASSIFIED',
+        },
+        {
+          id: `um-ws-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: '   ',
+          amountPence: 90,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: null,
+        },
+        {
+          id: `um-case-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'cash',
+          amountPence: 40,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'RECEIVED_AT_SALE',
+        },
+        {
+          id: `um-legacy-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'CRYPTO_FUTURE',
+          amountPence: 25,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'RECEIVED_AT_SALE',
+        },
+        {
+          id: `um-neg-${suffix}`,
+          salesInvoiceId: invoiceId,
+          method: 'CHEQUE',
+          amountPence: -15,
+          receivedAt: saleAt,
+          status: 'CONFIRMED',
+          receiptOrigin: 'UNCLASSIFIED',
+        },
+      ],
+    });
+
+    // Foreign tenant payment must never enter totals.
+    await prisma.salesInvoice.create({
+      data: {
+        businessId: otherBusinessId,
+        storeId: otherStoreId,
+        tillId: otherTill.id,
+        cashierUserId: otherCashier.id,
+        paymentStatus: 'PAID',
+        subtotalPence: 99999,
+        vatPence: 0,
+        totalPence: 99999,
+        createdAt: saleAt,
+        payments: {
+          create: {
+            method: 'CHEQUE',
+            amountPence: 99999,
+            receivedAt: saleAt,
+            status: 'CONFIRMED',
+            receiptOrigin: 'RECEIVED_AT_SALE',
+          },
+        },
+      },
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await prisma.salesPayment.deleteMany({
+      where: { salesInvoice: { businessId: { in: [businessId, otherBusinessId] } } },
+    }).catch(() => {});
+    await prisma.salesInvoice.deleteMany({
+      where: { businessId: { in: [businessId, otherBusinessId] } },
+    }).catch(() => {});
+    await prisma.till.deleteMany({
+      where: { store: { businessId: { in: [businessId, otherBusinessId] } } },
+    }).catch(() => {});
+    await prisma.user.deleteMany({
+      where: { businessId: { in: [businessId, otherBusinessId] } },
+    }).catch(() => {});
+    await prisma.store.deleteMany({
+      where: { businessId: { in: [businessId, otherBusinessId] } },
+    }).catch(() => {});
+    await prisma.business.deleteMany({
+      where: { id: { in: [businessId, otherBusinessId] } },
+    }).catch(() => {});
+    await prisma.$disconnect().catch(() => {});
+  });
+
+  function dayScope(store: string = 'ALL') {
+    return resolveReportingScope({
+      businessId,
+      timeZone: 'Africa/Accra',
+      params: { period: 'custom', from: '2026-08-07', to: '2026-08-07', storeId: store },
+      allowedStoreIds: [storeId],
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+  }
+
+  it('places every unrecognised method in UNKNOWN and reconciles amount + count', async () => {
+    const summary = await getMoneyReceivedSummary(dayScope());
+
+    // Known exact matches only
+    expect(summary.byMethod.CASH).toBe(1000);
+    expect(summary.byMethod.CARD).toBe(2000);
+    expect(summary.byMethod.TRANSFER).toBe(500);
+    expect(summary.byMethod.MOBILE_MONEY).toBe(700);
+
+    // CHEQUE(300) + blank(110) + whitespace(90) + cash(40) + CRYPTO(25) + CHEQUE(-15)
+    expect(summary.byMethod.UNKNOWN).toBe(300 + 110 + 90 + 40 + 25 - 15);
+    expect(summary.byMethodCount.UNKNOWN).toBe(6);
+
+    expect(sumMoneyReceivedByMethod(summary.byMethod)).toBe(summary.totalPence);
+    expect(
+      summary.byMethodCount.CASH
+        + summary.byMethodCount.CARD
+        + summary.byMethodCount.TRANSFER
+        + summary.byMethodCount.MOBILE_MONEY
+        + summary.byMethodCount.UNKNOWN,
+    ).toBe(summary.totalCount);
+
+    expect(
+      summary.receivedAtSalePence
+        + summary.laterCreditCollectionPence
+        + summary.unknownHistoricalOriginPence,
+    ).toBe(summary.totalPence);
+    expect(
+      summary.receivedAtSaleCount
+        + summary.laterCreditCollectionCount
+        + summary.unknownHistoricalOriginCount,
+    ).toBe(summary.totalCount);
+
+    // Foreign CHEQUE excluded
+    expect(summary.totalPence).toBe(1000 + 2000 + 500 + 700 + 550);
+    expect(summary.totalCount).toBe(10);
+    expect(RECEIPT_METHOD_LABELS[UNKNOWN_RECEIPT_METHOD]).toBe('Unknown/Other');
+  });
+
+  it('UNKNOWN method filter returns only unrecognised rows and preserves known filters', async () => {
+    const scope = dayScope();
+    const unknownListed = await listMoneyReceivedPayments({
+      scope,
+      method: 'UNKNOWN',
+      page: 1,
+      pageSize: 50,
+    });
+    expect(unknownListed.totalCount).toBe(6);
+    expect(unknownListed.rows.every((r) => r.methodBucket === 'UNKNOWN')).toBe(true);
+    expect(unknownListed.rows.every((r) => r.methodLabel === 'Unknown/Other')).toBe(true);
+    expect(unknownListed.rows.some((r) => r.method === 'CHEQUE')).toBe(true);
+    expect(unknownListed.rows.some((r) => r.method === 'cash')).toBe(true);
+    expect(unknownListed.rows.every((r) => r.method !== 'CASH')).toBe(true);
+
+    const cashListed = await listMoneyReceivedPayments({
+      scope,
+      method: 'CASH',
+      page: 1,
+      pageSize: 50,
+    });
+    expect(cashListed.totalCount).toBe(1);
+    expect(cashListed.rows[0]?.method).toBe('CASH');
+    expect(cashListed.rows[0]?.amountPence).toBe(1000);
+  });
+
+  it('pagination does not change authorised totals', async () => {
+    const scope = dayScope();
+    const summary = await getMoneyReceivedSummary(scope);
+    const page1 = await listMoneyReceivedPayments({ scope, page: 1, pageSize: 3 });
+    const page2 = await listMoneyReceivedPayments({ scope, page: 2, pageSize: 3 });
+    expect(page1.totalCount).toBe(summary.totalCount);
+    expect(page2.totalCount).toBe(summary.totalCount);
+    expect(page1.pageSize).toBe(3);
+    expect(page1.rows.length + page2.rows.length).toBeLessThanOrEqual(6);
+  });
+
+  it('store filter and cross-tenant scope fail closed', async () => {
+    const ownStore = await getMoneyReceivedSummary(dayScope(storeId));
+    expect(ownStore.totalCount).toBe(10);
+
+    // Inaccessible / foreign store id must not broaden scope (resolveReportingScope fail-closed).
+    const blocked = resolveReportingScope({
+      businessId,
+      timeZone: 'Africa/Accra',
+      params: { period: 'custom', from: '2026-08-07', to: '2026-08-07', storeId: otherStoreId },
+      allowedStoreIds: [storeId],
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+    // When store is not allowed, scope typically falls back to ALL or rejects — assert no foreign leak.
+    const summary = await getMoneyReceivedSummary(blocked);
+    expect(summary.totalPence).toBeLessThan(99999);
+    expect(summary.byMethod.UNKNOWN).toBeLessThan(99999);
+  });
+});

--- a/lib/reports/money-received-unknown-method.pg.test.ts
+++ b/lib/reports/money-received-unknown-method.pg.test.ts
@@ -342,17 +342,14 @@ describePg('money received unknown payment-method reconciliation (Postgres)', ()
     const ownStore = await getMoneyReceivedSummary(dayScope(storeId));
     expect(ownStore.totalCount).toBe(10);
 
-    // Inaccessible / foreign store id must not broaden scope (resolveReportingScope fail-closed).
-    const blocked = resolveReportingScope({
-      businessId,
-      timeZone: 'Africa/Accra',
-      params: { period: 'custom', from: '2026-08-07', to: '2026-08-07', storeId: otherStoreId },
-      allowedStoreIds: [storeId],
-      now: new Date('2026-08-07T12:00:00.000Z'),
-    });
-    // When store is not allowed, scope typically falls back to ALL or rejects — assert no foreign leak.
-    const summary = await getMoneyReceivedSummary(blocked);
-    expect(summary.totalPence).toBeLessThan(99999);
-    expect(summary.byMethod.UNKNOWN).toBeLessThan(99999);
+    expect(() =>
+      resolveReportingScope({
+        businessId,
+        timeZone: 'Africa/Accra',
+        params: { period: 'custom', from: '2026-08-07', to: '2026-08-07', storeId: otherStoreId },
+        allowedStoreIds: [storeId],
+        now: new Date('2026-08-07T12:00:00.000Z'),
+      }),
+    ).toThrow(/invalid|inaccessible|store/i);
   });
 });

--- a/lib/reports/money-received.pg.test.ts
+++ b/lib/reports/money-received.pg.test.ts
@@ -259,8 +259,15 @@ describePg('money received reconciliation (Postgres)', () => {
     expect(receipts.receivedAtSalePence).toBe(13000);
     expect(receipts.laterCreditCollectionPence).toBe(0);
     expect(receipts.unknownHistoricalOriginPence).toBe(0);
-    expect(receipts.byMethod.CASH + receipts.byMethod.CARD + receipts.byMethod.TRANSFER + receipts.byMethod.MOBILE_MONEY)
+    expect(receipts.byMethod.CASH + receipts.byMethod.CARD + receipts.byMethod.TRANSFER + receipts.byMethod.MOBILE_MONEY + receipts.byMethod.UNKNOWN)
       .toBe(receipts.totalPence);
+    expect(
+      receipts.byMethodCount.CASH
+        + receipts.byMethodCount.CARD
+        + receipts.byMethodCount.TRANSFER
+        + receipts.byMethodCount.MOBILE_MONEY
+        + receipts.byMethodCount.UNKNOWN,
+    ).toBe(receipts.totalCount);
     expect(
       receipts.receivedAtSalePence
         + receipts.laterCreditCollectionPence

--- a/lib/reports/money-received.pg.test.ts
+++ b/lib/reports/money-received.pg.test.ts
@@ -115,7 +115,6 @@ describePg('money received reconciliation (Postgres)', () => {
     customerId = customer.id;
 
     const saleAt = new Date('2026-08-07T10:00:00.000Z');
-    const laterAt = new Date('2026-08-08T11:00:00.000Z');
 
     // Cash sale GH₵40
     const cashSale = await prisma.salesInvoice.create({

--- a/lib/reports/money-received.pg.test.ts
+++ b/lib/reports/money-received.pg.test.ts
@@ -135,6 +135,7 @@ describePg('money received reconciliation (Postgres)', () => {
             amountPence: 4000,
             receivedAt: saleAt,
             status: 'CONFIRMED',
+            receiptOrigin: 'RECEIVED_AT_SALE',
           },
         },
       },
@@ -159,6 +160,7 @@ describePg('money received reconciliation (Postgres)', () => {
             amountPence: 6000,
             receivedAt: new Date(saleAt.getTime() + 1_000),
             status: 'CONFIRMED',
+            receiptOrigin: 'RECEIVED_AT_SALE',
           },
         },
       },
@@ -185,12 +187,14 @@ describePg('money received reconciliation (Postgres)', () => {
               amountPence: 3000,
               receivedAt: saleAt,
               status: 'CONFIRMED',
+              receiptOrigin: 'RECEIVED_AT_SALE',
             },
             {
               method: 'MOBILE_MONEY',
               amountPence: 7000,
               receivedAt: laterAt,
               status: 'CONFIRMED',
+              receiptOrigin: 'LATER_CREDIT_COLLECTION',
             },
           ],
         },
@@ -220,6 +224,7 @@ describePg('money received reconciliation (Postgres)', () => {
             amountPence: 9999,
             receivedAt: saleAt,
             status: 'CONFIRMED',
+            receiptOrigin: 'RECEIVED_AT_SALE',
           },
         },
       },
@@ -266,6 +271,13 @@ describePg('money received reconciliation (Postgres)', () => {
     expect(receipts.byMethod.MOBILE_MONEY).toBe(6000);
     expect(receipts.receivedAtSalePence).toBe(13000);
     expect(receipts.laterCreditCollectionPence).toBe(0);
+    expect(receipts.unknownHistoricalOriginPence).toBe(0);
+    expect(
+      receipts.receivedAtSalePence
+        + receipts.laterCreditCollectionPence
+        + receipts.unknownHistoricalOriginPence
+        + receipts.reversalPence,
+    ).toBe(receipts.totalPence);
     expect(revenue.creditSalesOutstandingPence).toBe(7000);
   });
 
@@ -326,5 +338,142 @@ describePg('money received reconciliation (Postgres)', () => {
     expect(missing).toBeNull();
     void cashSaleId;
     void tillId;
+  });
+
+  it('keeps historical NULL origins unclassified and does not use five-minute proximity', async () => {
+    const nearSale = new Date('2026-08-07T10:02:00.000Z'); // within old 5-minute window
+    const invoice = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        tillId,
+        cashierUserId: cashierId,
+        paymentStatus: 'PAID',
+        subtotalPence: 2500,
+        vatPence: 0,
+        totalPence: 2500,
+        createdAt: new Date('2026-08-07T10:00:00.000Z'),
+        payments: {
+          create: {
+            method: 'CARD',
+            amountPence: 2500,
+            receivedAt: nearSale,
+            status: 'CONFIRMED',
+            receiptOrigin: null,
+          },
+        },
+      },
+    });
+
+    // Explicit later collection within five minutes of invoice create — must stay later.
+    const explicitLater = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        tillId,
+        cashierUserId: cashierId,
+        paymentStatus: 'PART_PAID',
+        subtotalPence: 8000,
+        vatPence: 0,
+        totalPence: 8000,
+        createdAt: new Date('2026-08-07T10:00:00.000Z'),
+        payments: {
+          create: {
+            method: 'CASH',
+            amountPence: 1500,
+            receivedAt: nearSale,
+            status: 'CONFIRMED',
+            receiptOrigin: 'LATER_CREDIT_COLLECTION',
+          },
+        },
+      },
+    });
+
+    // Explicit at-sale far after invoice create — must stay at-sale.
+    const lateButAtSale = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        tillId,
+        cashierUserId: cashierId,
+        paymentStatus: 'PAID',
+        subtotalPence: 1100,
+        vatPence: 0,
+        totalPence: 1100,
+        createdAt: new Date('2026-08-07T10:00:00.000Z'),
+        payments: {
+          create: {
+            method: 'TRANSFER',
+            amountPence: 1100,
+            receivedAt: new Date('2026-08-07T12:00:00.000Z'),
+            status: 'CONFIRMED',
+            receiptOrigin: 'RECEIVED_AT_SALE',
+          },
+        },
+      },
+    });
+
+    const scope = resolveReportingScope({
+      businessId,
+      timeZone: 'Africa/Accra',
+      params: { period: 'custom', from: '2026-08-07', to: '2026-08-07', storeId: 'ALL' },
+      allowedStoreIds: [storeId],
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+    const receipts = await getMoneyReceivedSummary(scope);
+    expect(receipts.unknownHistoricalOriginPence).toBeGreaterThanOrEqual(2500);
+    expect(
+      receipts.receivedAtSalePence
+        + receipts.laterCreditCollectionPence
+        + receipts.unknownHistoricalOriginPence
+        + receipts.reversalPence,
+    ).toBe(receipts.totalPence);
+
+    const unknownListed = await listMoneyReceivedPayments({
+      scope,
+      origin: 'UNCLASSIFIED',
+      page: 1,
+      pageSize: 50,
+    });
+    expect(unknownListed.rows.some((r) => r.invoiceId === invoice.id)).toBe(true);
+    expect(unknownListed.rows.every((r) => r.classification === 'UNCLASSIFIED')).toBe(true);
+
+    const laterListed = await listMoneyReceivedPayments({
+      scope,
+      origin: 'LATER_CREDIT_COLLECTION',
+      page: 1,
+      pageSize: 50,
+    });
+    expect(laterListed.rows.some((r) => r.invoiceId === explicitLater.id && r.amountPence === 1500)).toBe(true);
+
+    const atSaleListed = await listMoneyReceivedPayments({
+      scope,
+      origin: 'RECEIVED_AT_SALE',
+      method: 'TRANSFER',
+      page: 1,
+      pageSize: 50,
+    });
+    expect(atSaleListed.rows.some((r) => r.invoiceId === lateButAtSale.id)).toBe(true);
+  });
+
+  it('paginates without changing authorised totals', async () => {
+    const scope = resolveReportingScope({
+      businessId,
+      timeZone: 'Africa/Accra',
+      params: { period: 'custom', from: '2026-08-07', to: '2026-08-07', storeId: 'ALL' },
+      allowedStoreIds: [storeId],
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+    const summary = await getMoneyReceivedSummary(scope);
+    const page1 = await listMoneyReceivedPayments({ scope, page: 1, pageSize: 2 });
+    const page2 = await listMoneyReceivedPayments({ scope, page: 2, pageSize: 2 });
+    expect(page1.totalCount).toBe(page2.totalCount);
+    expect(page1.pageSize).toBe(2);
+    expect(page1.rows.length).toBeLessThanOrEqual(2);
+    const pageSum =
+      [...page1.rows, ...page2.rows].reduce((s, r) => s + r.amountPence, 0);
+    // Totals come from complete scope, not the current page alone.
+    expect(summary.totalPence).toBeGreaterThanOrEqual(pageSum);
+    expect(page1.totalCount).toBeGreaterThan(2);
   });
 });

--- a/lib/reports/money-received.pg.test.ts
+++ b/lib/reports/money-received.pg.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Postgres integration: money-received aggregates and payment-record drill-down.
+ *
+ * Requires DATABASE_URL (Postgres). Skipped otherwise.
+ *
+ *   set DATABASE_URL=postgres://...
+ *   npx vitest run lib/reports/money-received.pg.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { isPostgresDatabaseUrl } from '@/lib/database-runtime';
+
+const databaseUrl = process.env.DATABASE_URL;
+const canRun = !!databaseUrl && isPostgresDatabaseUrl(databaseUrl);
+const describePg = canRun ? describe : describe.skip;
+
+describePg('money received reconciliation (Postgres)', () => {
+  let prisma: PrismaClient;
+  let getMoneyReceivedSummary: typeof import('@/lib/reports/money-received').getMoneyReceivedSummary;
+  let listMoneyReceivedPayments: typeof import('@/lib/reports/money-received').listMoneyReceivedPayments;
+  let getSalesRevenueSummary: typeof import('@/lib/reports/sales-revenue').getSalesRevenueSummary;
+  let resolveReportingScope: typeof import('@/lib/reports/reporting-scope').resolveReportingScope;
+  let findTenantSalesPayment: typeof import('@/lib/reports/money-received').findTenantSalesPayment;
+
+  const suffix = `recv-${Date.now()}`;
+  let businessId = '';
+  let otherBusinessId = '';
+  let storeId = '';
+  let tillId = '';
+  let cashierId = '';
+  let customerId = '';
+  let cashSaleId = '';
+  let momoSaleId = '';
+  let creditSaleId = '';
+  let laterMomoPaymentId = '';
+  let foreignPaymentId = '';
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = databaseUrl!;
+    const g = globalThis as unknown as { prisma?: PrismaClient };
+    if (g.prisma) {
+      await g.prisma.$disconnect().catch(() => {});
+      g.prisma = undefined;
+    }
+    vi.resetModules();
+
+    const money = await import('@/lib/reports/money-received');
+    const sales = await import('@/lib/reports/sales-revenue');
+    const scope = await import('@/lib/reports/reporting-scope');
+    getMoneyReceivedSummary = money.getMoneyReceivedSummary;
+    listMoneyReceivedPayments = money.listMoneyReceivedPayments;
+    findTenantSalesPayment = money.findTenantSalesPayment;
+    getSalesRevenueSummary = sales.getSalesRevenueSummary;
+    resolveReportingScope = scope.resolveReportingScope;
+
+    prisma = new PrismaClient();
+    await prisma.$connect();
+
+    const business = await prisma.business.create({
+      data: {
+        name: `Recv ${suffix}`,
+        currency: 'GHS',
+        timezone: 'Africa/Accra',
+      },
+    });
+    businessId = business.id;
+
+    const other = await prisma.business.create({
+      data: { name: `Other ${suffix}`, currency: 'GHS', timezone: 'Africa/Accra' },
+    });
+    otherBusinessId = other.id;
+
+    const store = await prisma.store.create({
+      data: { businessId, name: `Store ${suffix}` },
+    });
+    storeId = store.id;
+
+    const otherStore = await prisma.store.create({
+      data: { businessId: otherBusinessId, name: `Other store ${suffix}` },
+    });
+
+    const cashier = await prisma.user.create({
+      data: {
+        businessId,
+        email: `${suffix}@example.com`,
+        name: 'Cashier',
+        role: 'CASHIER',
+        passwordHash: 'x',
+      },
+    });
+    cashierId = cashier.id;
+
+    const otherCashier = await prisma.user.create({
+      data: {
+        businessId: otherBusinessId,
+        email: `other-${suffix}@example.com`,
+        name: 'Other',
+        role: 'OWNER',
+        passwordHash: 'x',
+      },
+    });
+
+    const till = await prisma.till.create({
+      data: { storeId, name: `Till ${suffix}` },
+    });
+    tillId = till.id;
+
+    const otherTill = await prisma.till.create({
+      data: { storeId: otherStore.id, name: `Other till ${suffix}` },
+    });
+
+    const customer = await prisma.customer.create({
+      data: { businessId, storeId, name: `Cust ${suffix}` },
+    });
+    customerId = customer.id;
+
+    const saleAt = new Date('2026-08-07T10:00:00.000Z');
+    const laterAt = new Date('2026-08-08T11:00:00.000Z');
+
+    // Cash sale GH₵40
+    const cashSale = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        tillId,
+        cashierUserId: cashierId,
+        paymentStatus: 'PAID',
+        subtotalPence: 4000,
+        vatPence: 0,
+        totalPence: 4000,
+        createdAt: saleAt,
+        payments: {
+          create: {
+            method: 'CASH',
+            amountPence: 4000,
+            receivedAt: saleAt,
+            status: 'CONFIRMED',
+          },
+        },
+      },
+    });
+    cashSaleId = cashSale.id;
+
+    // MoMo sale GH₵60
+    const momoSale = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        tillId,
+        cashierUserId: cashierId,
+        paymentStatus: 'PAID',
+        subtotalPence: 6000,
+        vatPence: 0,
+        totalPence: 6000,
+        createdAt: saleAt,
+        payments: {
+          create: {
+            method: 'MOBILE_MONEY',
+            amountPence: 6000,
+            receivedAt: new Date(saleAt.getTime() + 1_000),
+            status: 'CONFIRMED',
+          },
+        },
+      },
+    });
+    momoSaleId = momoSale.id;
+
+    // Credit sale GH₵100 with GH₵30 cash at sale, GH₵70 later MoMo
+    const creditSale = await prisma.salesInvoice.create({
+      data: {
+        businessId,
+        storeId,
+        tillId,
+        cashierUserId: cashierId,
+        customerId,
+        paymentStatus: 'PART_PAID',
+        subtotalPence: 10000,
+        vatPence: 0,
+        totalPence: 10000,
+        createdAt: saleAt,
+        payments: {
+          create: [
+            {
+              method: 'CASH',
+              amountPence: 3000,
+              receivedAt: saleAt,
+              status: 'CONFIRMED',
+            },
+            {
+              method: 'MOBILE_MONEY',
+              amountPence: 7000,
+              receivedAt: laterAt,
+              status: 'CONFIRMED',
+            },
+          ],
+        },
+      },
+    });
+    creditSaleId = creditSale.id;
+    const laterPayment = await prisma.salesPayment.findFirst({
+      where: { salesInvoiceId: creditSaleId, amountPence: 7000 },
+    });
+    laterMomoPaymentId = laterPayment!.id;
+
+    // Foreign-tenant payment
+    const foreignSale = await prisma.salesInvoice.create({
+      data: {
+        businessId: otherBusinessId,
+        storeId: otherStore.id,
+        tillId: otherTill.id,
+        cashierUserId: otherCashier.id,
+        paymentStatus: 'PAID',
+        subtotalPence: 9999,
+        vatPence: 0,
+        totalPence: 9999,
+        createdAt: saleAt,
+        payments: {
+          create: {
+            method: 'MOBILE_MONEY',
+            amountPence: 9999,
+            receivedAt: saleAt,
+            status: 'CONFIRMED',
+          },
+        },
+      },
+    });
+    const foreignPayment = await prisma.salesPayment.findFirst({
+      where: { salesInvoiceId: foreignSale.id },
+    });
+    foreignPaymentId = foreignPayment!.id;
+  }, 60_000);
+
+  afterAll(async () => {
+    if (!prisma) return;
+    await prisma.salesPayment.deleteMany({
+      where: { salesInvoice: { businessId: { in: [businessId, otherBusinessId] } } },
+    }).catch(() => {});
+    await prisma.salesInvoice.deleteMany({
+      where: { businessId: { in: [businessId, otherBusinessId] } },
+    }).catch(() => {});
+    await prisma.customer.deleteMany({ where: { businessId: { in: [businessId, otherBusinessId] } } }).catch(() => {});
+    await prisma.till.deleteMany({ where: { store: { businessId: { in: [businessId, otherBusinessId] } } } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { businessId: { in: [businessId, otherBusinessId] } } }).catch(() => {});
+    await prisma.store.deleteMany({ where: { businessId: { in: [businessId, otherBusinessId] } } }).catch(() => {});
+    await prisma.business.deleteMany({ where: { id: { in: [businessId, otherBusinessId] } } }).catch(() => {});
+    await prisma.$disconnect().catch(() => {});
+  });
+
+  it('reconciles sales revenue and money received for the sale day', async () => {
+    const scope = resolveReportingScope({
+      businessId,
+      timeZone: 'Africa/Accra',
+      params: { period: 'custom', from: '2026-08-07', to: '2026-08-07', storeId: 'ALL' },
+      allowedStoreIds: [storeId],
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+
+    const revenue = await getSalesRevenueSummary(scope);
+    const receipts = await getMoneyReceivedSummary(scope);
+
+    // Cash 40 + MoMo 60 + Credit 100 = 200 sales revenue
+    expect(revenue.salesRevenuePence).toBe(20000);
+    // Sale-day receipts: 40 + 60 + 30 = 130 (later MoMo not yet)
+    expect(receipts.totalPence).toBe(13000);
+    expect(receipts.byMethod.CASH).toBe(7000);
+    expect(receipts.byMethod.MOBILE_MONEY).toBe(6000);
+    expect(receipts.receivedAtSalePence).toBe(13000);
+    expect(receipts.laterCreditCollectionPence).toBe(0);
+    expect(revenue.creditSalesOutstandingPence).toBe(7000);
+  });
+
+  it('attributes later MoMo collection to collection date without inflating revenue', async () => {
+    const scope = resolveReportingScope({
+      businessId,
+      timeZone: 'Africa/Accra',
+      params: { period: 'custom', from: '2026-08-08', to: '2026-08-08', storeId: 'ALL' },
+      allowedStoreIds: [storeId],
+      now: new Date('2026-08-08T12:00:00.000Z'),
+    });
+
+    const revenue = await getSalesRevenueSummary(scope);
+    const receipts = await getMoneyReceivedSummary(scope);
+    expect(revenue.salesRevenuePence).toBe(0);
+    expect(receipts.byMethod.MOBILE_MONEY).toBe(7000);
+    expect(receipts.laterCreditCollectionPence).toBe(7000);
+    expect(receipts.receivedAtSalePence).toBe(0);
+
+    const listed = await listMoneyReceivedPayments({
+      scope,
+      method: 'MOBILE_MONEY',
+      page: 1,
+      pageSize: 25,
+    });
+    expect(listed.totalCount).toBe(1);
+    expect(listed.rows[0]?.paymentId).toBe(laterMomoPaymentId);
+    expect(listed.rows[0]?.classification).toBe('LATER_CREDIT_COLLECTION');
+    expect(listed.rows[0]?.amountPence).toBe(7000);
+    expect(listed.rows[0]?.invoiceId).toBe(creditSaleId);
+  });
+
+  it('MoMo drill-down on sale day shows only MoMo component amounts', async () => {
+    const scope = resolveReportingScope({
+      businessId,
+      timeZone: 'Africa/Accra',
+      params: { period: 'custom', from: '2026-08-07', to: '2026-08-07', storeId: 'ALL' },
+      allowedStoreIds: [storeId],
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+    const listed = await listMoneyReceivedPayments({
+      scope,
+      method: 'MOBILE_MONEY',
+      page: 1,
+    });
+    expect(listed.rows).toHaveLength(1);
+    expect(listed.rows[0]?.amountPence).toBe(6000);
+    expect(listed.rows[0]?.invoiceId).toBe(momoSaleId);
+    expect(listed.rows[0]?.classification).toBe('RECEIVED_AT_SALE');
+  });
+
+  it('hides foreign-tenant payment ids', async () => {
+    const own = await findTenantSalesPayment({ businessId, paymentId: laterMomoPaymentId });
+    const foreign = await findTenantSalesPayment({ businessId, paymentId: foreignPaymentId });
+    const missing = await findTenantSalesPayment({ businessId, paymentId: 'does-not-exist' });
+    expect(own?.id).toBe(laterMomoPaymentId);
+    expect(foreign).toBeNull();
+    expect(missing).toBeNull();
+    void cashSaleId;
+    void tillId;
+  });
+});

--- a/lib/reports/money-received.pg.test.ts
+++ b/lib/reports/money-received.pg.test.ts
@@ -167,7 +167,7 @@ describePg('money received reconciliation (Postgres)', () => {
     });
     momoSaleId = momoSale.id;
 
-    // Credit sale GH₵100 with GH₵30 cash at sale, GH₵70 later MoMo
+    // Credit sale GH₵100 with GH₵30 cash at sale; GH₵70 later MoMo added in collection test.
     const creditSale = await prisma.salesInvoice.create({
       data: {
         businessId,
@@ -181,30 +181,18 @@ describePg('money received reconciliation (Postgres)', () => {
         totalPence: 10000,
         createdAt: saleAt,
         payments: {
-          create: [
-            {
-              method: 'CASH',
-              amountPence: 3000,
-              receivedAt: saleAt,
-              status: 'CONFIRMED',
-              receiptOrigin: 'RECEIVED_AT_SALE',
-            },
-            {
-              method: 'MOBILE_MONEY',
-              amountPence: 7000,
-              receivedAt: laterAt,
-              status: 'CONFIRMED',
-              receiptOrigin: 'LATER_CREDIT_COLLECTION',
-            },
-          ],
+          create: {
+            method: 'CASH',
+            amountPence: 3000,
+            receivedAt: saleAt,
+            status: 'CONFIRMED',
+            receiptOrigin: 'RECEIVED_AT_SALE',
+          },
         },
       },
     });
     creditSaleId = creditSale.id;
-    const laterPayment = await prisma.salesPayment.findFirst({
-      where: { salesInvoiceId: creditSaleId, amountPence: 7000 },
-    });
-    laterMomoPaymentId = laterPayment!.id;
+    laterMomoPaymentId = '';
 
     // Foreign-tenant payment
     const foreignSale = await prisma.salesInvoice.create({
@@ -282,6 +270,23 @@ describePg('money received reconciliation (Postgres)', () => {
   });
 
   it('attributes later MoMo collection to collection date without inflating revenue', async () => {
+    const laterAt = new Date('2026-08-08T11:00:00.000Z');
+    const laterPayment = await prisma.salesPayment.create({
+      data: {
+        salesInvoiceId: creditSaleId,
+        method: 'MOBILE_MONEY',
+        amountPence: 7000,
+        receivedAt: laterAt,
+        status: 'CONFIRMED',
+        receiptOrigin: 'LATER_CREDIT_COLLECTION',
+      },
+    });
+    laterMomoPaymentId = laterPayment.id;
+    await prisma.salesInvoice.update({
+      where: { id: creditSaleId },
+      data: { paymentStatus: 'PAID' },
+    });
+
     const scope = resolveReportingScope({
       businessId,
       timeZone: 'Africa/Accra',

--- a/lib/reports/money-received.pg.test.ts
+++ b/lib/reports/money-received.pg.test.ts
@@ -259,12 +259,18 @@ describePg('money received reconciliation (Postgres)', () => {
     expect(receipts.receivedAtSalePence).toBe(13000);
     expect(receipts.laterCreditCollectionPence).toBe(0);
     expect(receipts.unknownHistoricalOriginPence).toBe(0);
+    expect(receipts.byMethod.CASH + receipts.byMethod.CARD + receipts.byMethod.TRANSFER + receipts.byMethod.MOBILE_MONEY)
+      .toBe(receipts.totalPence);
     expect(
       receipts.receivedAtSalePence
         + receipts.laterCreditCollectionPence
-        + receipts.unknownHistoricalOriginPence
-        + receipts.reversalPence,
+        + receipts.unknownHistoricalOriginPence,
     ).toBe(receipts.totalPence);
+    expect(
+      receipts.receivedAtSaleCount
+        + receipts.laterCreditCollectionCount
+        + receipts.unknownHistoricalOriginCount,
+    ).toBe(receipts.totalCount);
     expect(revenue.creditSalesOutstandingPence).toBe(7000);
   });
 
@@ -429,9 +435,13 @@ describePg('money received reconciliation (Postgres)', () => {
     expect(
       receipts.receivedAtSalePence
         + receipts.laterCreditCollectionPence
-        + receipts.unknownHistoricalOriginPence
-        + receipts.reversalPence,
+        + receipts.unknownHistoricalOriginPence,
     ).toBe(receipts.totalPence);
+    expect(
+      receipts.receivedAtSaleCount
+        + receipts.laterCreditCollectionCount
+        + receipts.unknownHistoricalOriginCount,
+    ).toBe(receipts.totalCount);
 
     const unknownListed = await listMoneyReceivedPayments({
       scope,

--- a/lib/reports/money-received.ts
+++ b/lib/reports/money-received.ts
@@ -1,0 +1,265 @@
+import { prisma } from '@/lib/prisma';
+import {
+  REPORTING_EXCLUDED_PAYMENT_STATUSES,
+  REPORTING_EXCLUDED_SALE_STATUSES,
+  reportingTimestampFilter,
+  type ReportingScope,
+} from '@/lib/reports/reporting-scope';
+import {
+  classifySalesPaymentReceipt,
+  RECEIPT_CLASSIFICATION_LABELS,
+  SALE_RECEIPT_GRACE_MS,
+  type ReceiptClassification,
+  type ReceiptPaymentState,
+} from '@/lib/reports/money-received-classify';
+
+export {
+  classifySalesPaymentReceipt,
+  RECEIPT_CLASSIFICATION_LABELS,
+  SALE_RECEIPT_GRACE_MS,
+};
+export type { ReceiptClassification, ReceiptPaymentState };
+
+export const SUPPORTED_RECEIPT_METHODS = ['CASH', 'CARD', 'TRANSFER', 'MOBILE_MONEY'] as const;
+export type ReceiptPaymentMethod = (typeof SUPPORTED_RECEIPT_METHODS)[number];
+
+export const RECEIPT_METHOD_LABELS: Record<ReceiptPaymentMethod, string> = {
+  CASH: 'Physical cash',
+  MOBILE_MONEY: 'Mobile Money (MoMo)',
+  CARD: 'Card',
+  TRANSFER: 'Bank transfer',
+};
+
+export type MoneyReceivedByMethod = Record<ReceiptPaymentMethod, number>;
+
+export type MoneyReceivedSummary = {
+  byMethod: MoneyReceivedByMethod;
+  totalPence: number;
+  receivedAtSalePence: number;
+  laterCreditCollectionPence: number;
+  reversalPence: number;
+};
+
+export type MoneyReceivedRow = {
+  paymentId: string;
+  receivedAt: Date;
+  amountPence: number;
+  method: string;
+  methodLabel: string;
+  classification: ReceiptClassification;
+  classificationLabel: string;
+  paymentState: ReceiptPaymentState;
+  status: string;
+  reference: string | null;
+  network: string | null;
+  payerMsisdn: string | null;
+  provider: string | null;
+  transactionNumber: string | null;
+  invoiceId: string;
+  invoiceTotalPence: number;
+  invoiceCreatedAt: Date;
+  storeId: string;
+  storeName: string;
+  tillId: string;
+  tillName: string;
+  cashierName: string | null;
+  customerName: string | null;
+};
+
+function emptyByMethod(): MoneyReceivedByMethod {
+  return { CASH: 0, CARD: 0, TRANSFER: 0, MOBILE_MONEY: 0 };
+}
+
+function isSupportedMethod(method: string): method is ReceiptPaymentMethod {
+  return (SUPPORTED_RECEIPT_METHODS as readonly string[]).includes(method);
+}
+
+function paymentListWhere(
+  scope: ReportingScope,
+  method?: string | null,
+) {
+  const methodFilter =
+    method && isSupportedMethod(method) ? { method } : {};
+
+  return {
+    receivedAt: reportingTimestampFilter(scope),
+    status: { notIn: [...REPORTING_EXCLUDED_PAYMENT_STATUSES] },
+    ...methodFilter,
+    salesInvoice: {
+      businessId: scope.businessId,
+      ...(scope.storeId === 'ALL' ? {} : { storeId: scope.storeId }),
+      paymentStatus: { notIn: [...REPORTING_EXCLUDED_SALE_STATUSES] },
+    },
+  };
+}
+
+/**
+ * Aggregate money received from payment records for the scope.
+ * Classification totals require loading payment+invoice timestamps (bounded).
+ */
+export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<MoneyReceivedSummary> {
+  const payments = await prisma.salesPayment.findMany({
+    where: paymentListWhere(scope),
+    select: {
+      amountPence: true,
+      method: true,
+      receivedAt: true,
+      salesInvoice: { select: { createdAt: true } },
+    },
+    // Bounded fetch for classification; period aggregates for a retail day stay well under this.
+    take: 20_000,
+    orderBy: [{ receivedAt: 'asc' }, { id: 'asc' }],
+  });
+
+  const byMethod = emptyByMethod();
+  let totalPence = 0;
+  let receivedAtSalePence = 0;
+  let laterCreditCollectionPence = 0;
+  let reversalPence = 0;
+
+  for (const payment of payments) {
+    if (isSupportedMethod(payment.method)) {
+      byMethod[payment.method] += payment.amountPence;
+    }
+    totalPence += payment.amountPence;
+
+    const { classification, paymentState } = classifySalesPaymentReceipt({
+      amountPence: payment.amountPence,
+      receivedAt: payment.receivedAt,
+      invoiceCreatedAt: payment.salesInvoice.createdAt,
+    });
+
+    if (paymentState === 'REVERSAL') {
+      reversalPence += payment.amountPence;
+    } else if (classification === 'RECEIVED_AT_SALE') {
+      receivedAtSalePence += payment.amountPence;
+    } else {
+      laterCreditCollectionPence += payment.amountPence;
+    }
+  }
+
+  return {
+    byMethod,
+    totalPence,
+    receivedAtSalePence,
+    laterCreditCollectionPence,
+    reversalPence,
+  };
+}
+
+export const RECEIPTS_PAGE_SIZE = 25;
+export const RECEIPTS_MAX_PAGE_SIZE = 50;
+
+export async function listMoneyReceivedPayments(input: {
+  scope: ReportingScope;
+  method?: string | null;
+  page?: number;
+  pageSize?: number;
+}): Promise<{
+  rows: MoneyReceivedRow[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}> {
+  const pageSize = Math.min(
+    Math.max(input.pageSize ?? RECEIPTS_PAGE_SIZE, 1),
+    RECEIPTS_MAX_PAGE_SIZE,
+  );
+  const requestedPage = Math.max(input.page ?? 1, 1);
+  const where = paymentListWhere(input.scope, input.method);
+
+  const totalCount = await prisma.salesPayment.count({ where });
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const page = Math.min(requestedPage, totalPages);
+
+  const payments = await prisma.salesPayment.findMany({
+    where,
+    orderBy: [{ receivedAt: 'desc' }, { id: 'desc' }],
+    skip: (page - 1) * pageSize,
+    take: pageSize,
+    select: {
+      id: true,
+      method: true,
+      amountPence: true,
+      receivedAt: true,
+      reference: true,
+      network: true,
+      payerMsisdn: true,
+      provider: true,
+      status: true,
+      salesInvoice: {
+        select: {
+          id: true,
+          transactionNumber: true,
+          totalPence: true,
+          createdAt: true,
+          storeId: true,
+          tillId: true,
+          store: { select: { name: true } },
+          till: { select: { name: true } },
+          cashierUser: { select: { name: true } },
+          customer: { select: { name: true } },
+        },
+      },
+    },
+  });
+
+  const rows: MoneyReceivedRow[] = payments.map((payment) => {
+    const { classification, paymentState } = classifySalesPaymentReceipt({
+      amountPence: payment.amountPence,
+      receivedAt: payment.receivedAt,
+      invoiceCreatedAt: payment.salesInvoice.createdAt,
+    });
+    const method = payment.method;
+    return {
+      paymentId: payment.id,
+      receivedAt: payment.receivedAt,
+      amountPence: payment.amountPence,
+      method,
+      methodLabel: isSupportedMethod(method)
+        ? RECEIPT_METHOD_LABELS[method]
+        : method,
+      classification,
+      classificationLabel: RECEIPT_CLASSIFICATION_LABELS[classification],
+      paymentState,
+      status: payment.status,
+      reference: payment.reference,
+      network: payment.network,
+      payerMsisdn: payment.payerMsisdn,
+      provider: payment.provider,
+      transactionNumber: payment.salesInvoice.transactionNumber,
+      invoiceId: payment.salesInvoice.id,
+      invoiceTotalPence: payment.salesInvoice.totalPence,
+      invoiceCreatedAt: payment.salesInvoice.createdAt,
+      storeId: payment.salesInvoice.storeId,
+      storeName: payment.salesInvoice.store.name,
+      tillId: payment.salesInvoice.tillId,
+      tillName: payment.salesInvoice.till.name,
+      cashierName: payment.salesInvoice.cashierUser?.name ?? null,
+      customerName: payment.salesInvoice.customer?.name ?? null,
+    };
+  });
+
+  return { rows, totalCount, page, pageSize, totalPages };
+}
+
+/** Tenant-safe payment lookup — returns null for foreign or missing ids. */
+export async function findTenantSalesPayment(input: {
+  businessId: string;
+  paymentId: string;
+}) {
+  return prisma.salesPayment.findFirst({
+    where: {
+      id: input.paymentId,
+      salesInvoice: { businessId: input.businessId },
+    },
+    select: { id: true },
+  });
+}
+
+export function parseReceiptMethodParam(value: string | undefined | null): ReceiptPaymentMethod | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return isSupportedMethod(trimmed) ? trimmed : null;
+}

--- a/lib/reports/money-received.ts
+++ b/lib/reports/money-received.ts
@@ -29,14 +29,25 @@ export type { ReceiptClassification, ReceiptPaymentState };
  */
 export const LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP = 20_000;
 
+/** Exact stored values recognised by the Money received contract (case-sensitive). */
 export const SUPPORTED_RECEIPT_METHODS = ['CASH', 'CARD', 'TRANSFER', 'MOBILE_MONEY'] as const;
 export type ReceiptPaymentMethod = (typeof SUPPORTED_RECEIPT_METHODS)[number];
 
-export const RECEIPT_METHOD_LABELS: Record<ReceiptPaymentMethod, string> = {
+/** Filter / bucket key for every stored method that is not an exact supported value. */
+export const UNKNOWN_RECEIPT_METHOD = 'UNKNOWN' as const;
+export type ReceiptMethodBucket = ReceiptPaymentMethod | typeof UNKNOWN_RECEIPT_METHOD;
+
+export const RECEIPT_METHOD_BUCKETS = [
+  ...SUPPORTED_RECEIPT_METHODS,
+  UNKNOWN_RECEIPT_METHOD,
+] as const satisfies readonly ReceiptMethodBucket[];
+
+export const RECEIPT_METHOD_LABELS: Record<ReceiptMethodBucket, string> = {
   CASH: 'Physical cash',
   MOBILE_MONEY: 'Mobile Money (MoMo)',
   CARD: 'Card',
   TRANSFER: 'Bank transfer',
+  UNKNOWN: 'Unknown/Other',
 };
 
 export const SUPPORTED_RECEIPT_ORIGINS = [
@@ -45,10 +56,11 @@ export const SUPPORTED_RECEIPT_ORIGINS = [
   'UNCLASSIFIED',
 ] as const satisfies readonly ReceiptOrigin[];
 
-export type MoneyReceivedByMethod = Record<ReceiptPaymentMethod, number>;
+export type MoneyReceivedByMethod = Record<ReceiptMethodBucket, number>;
 
 export type MoneyReceivedSummary = {
   byMethod: MoneyReceivedByMethod;
+  byMethodCount: MoneyReceivedByMethod;
   totalPence: number;
   totalCount: number;
   receivedAtSalePence: number;
@@ -68,6 +80,7 @@ export type MoneyReceivedRow = {
   amountPence: number;
   method: string;
   methodLabel: string;
+  methodBucket: ReceiptMethodBucket;
   classification: ReceiptClassification;
   classificationLabel: string;
   paymentState: ReceiptPaymentState;
@@ -88,11 +101,28 @@ export type MoneyReceivedRow = {
 };
 
 function emptyByMethod(): MoneyReceivedByMethod {
-  return { CASH: 0, CARD: 0, TRANSFER: 0, MOBILE_MONEY: 0 };
+  return { CASH: 0, CARD: 0, TRANSFER: 0, MOBILE_MONEY: 0, UNKNOWN: 0 };
 }
 
-function isSupportedMethod(method: string): method is ReceiptPaymentMethod {
+export function isSupportedMethod(method: string): method is ReceiptPaymentMethod {
   return (SUPPORTED_RECEIPT_METHODS as readonly string[]).includes(method);
+}
+
+export function resolveReceiptMethodBucket(
+  method: string | null | undefined,
+): ReceiptMethodBucket {
+  if (method != null && isSupportedMethod(method)) return method;
+  return UNKNOWN_RECEIPT_METHOD;
+}
+
+export function sumMoneyReceivedByMethod(byMethod: MoneyReceivedByMethod): number {
+  return (
+    byMethod.CASH
+    + byMethod.CARD
+    + byMethod.TRANSFER
+    + byMethod.MOBILE_MONEY
+    + byMethod.UNKNOWN
+  );
 }
 
 function toNumber(value: bigint | number | null | undefined): number {
@@ -110,18 +140,25 @@ function originFilter(origin?: ReceiptOrigin | null) {
   return { receiptOrigin: origin };
 }
 
+function methodFilter(method?: ReceiptMethodBucket | null) {
+  if (!method) return {};
+  if (method === UNKNOWN_RECEIPT_METHOD) {
+    // SalesPayment.method is a required string; unsupported/blank/wrong-case values
+    // are exactly those not in the supported set (exact match).
+    return { method: { notIn: [...SUPPORTED_RECEIPT_METHODS] } };
+  }
+  return { method };
+}
+
 function paymentListWhere(
   scope: ReportingScope,
-  method?: string | null,
+  method?: ReceiptMethodBucket | null,
   origin?: ReceiptOrigin | null,
 ) {
-  const methodFilter =
-    method && isSupportedMethod(method) ? { method } : {};
-
   return {
     receivedAt: reportingTimestampFilter(scope),
     status: { notIn: [...REPORTING_EXCLUDED_PAYMENT_STATUSES] },
-    ...methodFilter,
+    ...methodFilter(method),
     ...originFilter(origin),
     salesInvoice: {
       businessId: scope.businessId,
@@ -138,6 +175,12 @@ type AggregateRow = {
   card_pence: bigint;
   transfer_pence: bigint;
   momo_pence: bigint;
+  unknown_method_pence: bigint;
+  cash_count: bigint;
+  card_count: bigint;
+  transfer_count: bigint;
+  momo_count: bigint;
+  unknown_method_count: bigint;
   at_sale_pence: bigint;
   later_pence: bigint;
   unknown_pence: bigint;
@@ -152,12 +195,14 @@ type AggregateRow = {
  *
  * Complete database aggregation — never load matching payments into app memory.
  *
- * Origin buckets use persisted receiptOrigin only (NULL / invalid → unknown).
+ * Method buckets: exact CASH/CARD/TRANSFER/MOBILE_MONEY only; every other stored
+ * value (blank, whitespace, wrong case, legacy/future) → UNKNOWN.
+ *
  * Identities:
- *   totalPence = Σ supported method groups (+ any unsupported method amounts still in total)
+ *   totalPence = CASH + CARD + TRANSFER + MOBILE_MONEY + UNKNOWN
+ *   totalCount = Σ method counts
  *   totalPence = receivedAtSale + laterCredit + unknownHistorical
- *   totalCount = receivedAtSaleCount + laterCreditCount + unknownCount
- * Signed reversals remain in their origin bucket and are also surfaced as reversalPence.
+ *   totalCount = Σ origin counts
  */
 export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<MoneyReceivedSummary> {
   const storeClause =
@@ -173,6 +218,24 @@ export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<Mo
       COALESCE(SUM(CASE WHEN sp.method = 'CARD' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS card_pence,
       COALESCE(SUM(CASE WHEN sp.method = 'TRANSFER' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS transfer_pence,
       COALESCE(SUM(CASE WHEN sp.method = 'MOBILE_MONEY' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS momo_pence,
+      COALESCE(SUM(
+        CASE
+          WHEN sp.method IS NULL OR sp.method NOT IN ('CASH', 'CARD', 'TRANSFER', 'MOBILE_MONEY')
+          THEN sp."amountPence"
+          ELSE 0
+        END
+      ), 0)::bigint AS unknown_method_pence,
+      COALESCE(SUM(CASE WHEN sp.method = 'CASH' THEN 1 ELSE 0 END), 0)::bigint AS cash_count,
+      COALESCE(SUM(CASE WHEN sp.method = 'CARD' THEN 1 ELSE 0 END), 0)::bigint AS card_count,
+      COALESCE(SUM(CASE WHEN sp.method = 'TRANSFER' THEN 1 ELSE 0 END), 0)::bigint AS transfer_count,
+      COALESCE(SUM(CASE WHEN sp.method = 'MOBILE_MONEY' THEN 1 ELSE 0 END), 0)::bigint AS momo_count,
+      COALESCE(SUM(
+        CASE
+          WHEN sp.method IS NULL OR sp.method NOT IN ('CASH', 'CARD', 'TRANSFER', 'MOBILE_MONEY')
+          THEN 1
+          ELSE 0
+        END
+      ), 0)::bigint AS unknown_method_count,
       COALESCE(SUM(CASE WHEN sp."receiptOrigin" = 'RECEIVED_AT_SALE' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS at_sale_pence,
       COALESCE(SUM(CASE WHEN sp."receiptOrigin" = 'LATER_CREDIT_COLLECTION' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS later_pence,
       COALESCE(SUM(
@@ -214,9 +277,18 @@ export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<Mo
   byMethod.CARD = toNumber(row?.card_pence);
   byMethod.TRANSFER = toNumber(row?.transfer_pence);
   byMethod.MOBILE_MONEY = toNumber(row?.momo_pence);
+  byMethod.UNKNOWN = toNumber(row?.unknown_method_pence);
+
+  const byMethodCount = emptyByMethod();
+  byMethodCount.CASH = toNumber(row?.cash_count);
+  byMethodCount.CARD = toNumber(row?.card_count);
+  byMethodCount.TRANSFER = toNumber(row?.transfer_count);
+  byMethodCount.MOBILE_MONEY = toNumber(row?.momo_count);
+  byMethodCount.UNKNOWN = toNumber(row?.unknown_method_count);
 
   return {
     byMethod,
+    byMethodCount,
     totalPence: toNumber(row?.total_pence),
     totalCount: toNumber(row?.total_count),
     receivedAtSalePence: toNumber(row?.at_sale_pence),
@@ -234,7 +306,7 @@ export const RECEIPTS_MAX_PAGE_SIZE = 50;
 
 export async function listMoneyReceivedPayments(input: {
   scope: ReportingScope;
-  method?: string | null;
+  method?: ReceiptMethodBucket | null;
   origin?: ReceiptOrigin | null;
   page?: number;
   pageSize?: number;
@@ -293,15 +365,14 @@ export async function listMoneyReceivedPayments(input: {
       amountPence: payment.amountPence,
       receiptOrigin: payment.receiptOrigin,
     });
-    const method = payment.method;
+    const methodBucket = resolveReceiptMethodBucket(payment.method);
     return {
       paymentId: payment.id,
       receivedAt: payment.receivedAt,
       amountPence: payment.amountPence,
-      method,
-      methodLabel: isSupportedMethod(method)
-        ? RECEIPT_METHOD_LABELS[method]
-        : method,
+      method: payment.method,
+      methodBucket,
+      methodLabel: RECEIPT_METHOD_LABELS[methodBucket],
       classification,
       classificationLabel: RECEIPT_CLASSIFICATION_LABELS[classification],
       paymentState,
@@ -339,9 +410,12 @@ export async function findTenantSalesPayment(input: {
   });
 }
 
-export function parseReceiptMethodParam(value: string | undefined | null): ReceiptPaymentMethod | null {
+export function parseReceiptMethodParam(
+  value: string | undefined | null,
+): ReceiptMethodBucket | null {
   const trimmed = value?.trim();
   if (!trimmed) return null;
+  if (trimmed === UNKNOWN_RECEIPT_METHOD) return UNKNOWN_RECEIPT_METHOD;
   return isSupportedMethod(trimmed) ? trimmed : null;
 }
 

--- a/lib/reports/money-received.ts
+++ b/lib/reports/money-received.ts
@@ -8,15 +8,17 @@ import {
 import {
   classifySalesPaymentReceipt,
   RECEIPT_CLASSIFICATION_LABELS,
-  SALE_RECEIPT_GRACE_MS,
   type ReceiptClassification,
   type ReceiptPaymentState,
 } from '@/lib/reports/money-received-classify';
+import {
+  isReceiptOrigin,
+  type ReceiptOrigin,
+} from '@/lib/payments/receipt-origin';
 
 export {
   classifySalesPaymentReceipt,
   RECEIPT_CLASSIFICATION_LABELS,
-  SALE_RECEIPT_GRACE_MS,
 };
 export type { ReceiptClassification, ReceiptPaymentState };
 
@@ -30,6 +32,12 @@ export const RECEIPT_METHOD_LABELS: Record<ReceiptPaymentMethod, string> = {
   TRANSFER: 'Bank transfer',
 };
 
+export const SUPPORTED_RECEIPT_ORIGINS = [
+  'RECEIVED_AT_SALE',
+  'LATER_CREDIT_COLLECTION',
+  'UNCLASSIFIED',
+] as const satisfies readonly ReceiptOrigin[];
+
 export type MoneyReceivedByMethod = Record<ReceiptPaymentMethod, number>;
 
 export type MoneyReceivedSummary = {
@@ -37,6 +45,8 @@ export type MoneyReceivedSummary = {
   totalPence: number;
   receivedAtSalePence: number;
   laterCreditCollectionPence: number;
+  /** Historical NULL / explicit UNCLASSIFIED — never inferred as a known origin. */
+  unknownHistoricalOriginPence: number;
   reversalPence: number;
 };
 
@@ -74,9 +84,20 @@ function isSupportedMethod(method: string): method is ReceiptPaymentMethod {
   return (SUPPORTED_RECEIPT_METHODS as readonly string[]).includes(method);
 }
 
+function originFilter(origin?: ReceiptOrigin | null) {
+  if (!origin) return {};
+  if (origin === 'UNCLASSIFIED') {
+    return {
+      OR: [{ receiptOrigin: null }, { receiptOrigin: 'UNCLASSIFIED' }],
+    };
+  }
+  return { receiptOrigin: origin };
+}
+
 function paymentListWhere(
   scope: ReportingScope,
   method?: string | null,
+  origin?: ReceiptOrigin | null,
 ) {
   const methodFilter =
     method && isSupportedMethod(method) ? { method } : {};
@@ -85,6 +106,7 @@ function paymentListWhere(
     receivedAt: reportingTimestampFilter(scope),
     status: { notIn: [...REPORTING_EXCLUDED_PAYMENT_STATUSES] },
     ...methodFilter,
+    ...originFilter(origin),
     salesInvoice: {
       businessId: scope.businessId,
       ...(scope.storeId === 'ALL' ? {} : { storeId: scope.storeId }),
@@ -95,7 +117,10 @@ function paymentListWhere(
 
 /**
  * Aggregate money received from payment records for the scope.
- * Classification totals require loading payment+invoice timestamps (bounded).
+ *
+ * Origin buckets use persisted receiptOrigin only.
+ * Identity (non-forced):
+ *   totalPence = receivedAtSale + laterCredit + unknownHistorical + reversal
  */
 export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<MoneyReceivedSummary> {
   const payments = await prisma.salesPayment.findMany({
@@ -103,10 +128,9 @@ export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<Mo
     select: {
       amountPence: true,
       method: true,
-      receivedAt: true,
-      salesInvoice: { select: { createdAt: true } },
+      receiptOrigin: true,
     },
-    // Bounded fetch for classification; period aggregates for a retail day stay well under this.
+    // Bounded fetch for origin buckets; retail-day aggregates stay well under this.
     take: 20_000,
     orderBy: [{ receivedAt: 'asc' }, { id: 'asc' }],
   });
@@ -115,6 +139,7 @@ export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<Mo
   let totalPence = 0;
   let receivedAtSalePence = 0;
   let laterCreditCollectionPence = 0;
+  let unknownHistoricalOriginPence = 0;
   let reversalPence = 0;
 
   for (const payment of payments) {
@@ -125,16 +150,17 @@ export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<Mo
 
     const { classification, paymentState } = classifySalesPaymentReceipt({
       amountPence: payment.amountPence,
-      receivedAt: payment.receivedAt,
-      invoiceCreatedAt: payment.salesInvoice.createdAt,
+      receiptOrigin: payment.receiptOrigin,
     });
 
     if (paymentState === 'REVERSAL') {
       reversalPence += payment.amountPence;
     } else if (classification === 'RECEIVED_AT_SALE') {
       receivedAtSalePence += payment.amountPence;
-    } else {
+    } else if (classification === 'LATER_CREDIT_COLLECTION') {
       laterCreditCollectionPence += payment.amountPence;
+    } else {
+      unknownHistoricalOriginPence += payment.amountPence;
     }
   }
 
@@ -143,6 +169,7 @@ export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<Mo
     totalPence,
     receivedAtSalePence,
     laterCreditCollectionPence,
+    unknownHistoricalOriginPence,
     reversalPence,
   };
 }
@@ -153,6 +180,7 @@ export const RECEIPTS_MAX_PAGE_SIZE = 50;
 export async function listMoneyReceivedPayments(input: {
   scope: ReportingScope;
   method?: string | null;
+  origin?: ReceiptOrigin | null;
   page?: number;
   pageSize?: number;
 }): Promise<{
@@ -167,7 +195,7 @@ export async function listMoneyReceivedPayments(input: {
     RECEIPTS_MAX_PAGE_SIZE,
   );
   const requestedPage = Math.max(input.page ?? 1, 1);
-  const where = paymentListWhere(input.scope, input.method);
+  const where = paymentListWhere(input.scope, input.method, input.origin);
 
   const totalCount = await prisma.salesPayment.count({ where });
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
@@ -188,6 +216,7 @@ export async function listMoneyReceivedPayments(input: {
       payerMsisdn: true,
       provider: true,
       status: true,
+      receiptOrigin: true,
       salesInvoice: {
         select: {
           id: true,
@@ -208,8 +237,7 @@ export async function listMoneyReceivedPayments(input: {
   const rows: MoneyReceivedRow[] = payments.map((payment) => {
     const { classification, paymentState } = classifySalesPaymentReceipt({
       amountPence: payment.amountPence,
-      receivedAt: payment.receivedAt,
-      invoiceCreatedAt: payment.salesInvoice.createdAt,
+      receiptOrigin: payment.receiptOrigin,
     });
     const method = payment.method;
     return {
@@ -262,4 +290,10 @@ export function parseReceiptMethodParam(value: string | undefined | null): Recei
   const trimmed = value?.trim();
   if (!trimmed) return null;
   return isSupportedMethod(trimmed) ? trimmed : null;
+}
+
+export function parseReceiptOriginParam(value: string | undefined | null): ReceiptOrigin | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return isReceiptOrigin(trimmed) ? trimmed : null;
 }

--- a/lib/reports/money-received.ts
+++ b/lib/reports/money-received.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import {
   REPORTING_EXCLUDED_PAYMENT_STATUSES,
@@ -22,6 +23,12 @@ export {
 };
 export type { ReceiptClassification, ReceiptPaymentState };
 
+/**
+ * Historical defective in-memory summary cap. Must never be used for aggregation.
+ * Kept only so tests can prove we did not raise or reintroduce a row-cap workaround.
+ */
+export const LEGACY_MONEY_RECEIVED_SUMMARY_ROW_CAP = 20_000;
+
 export const SUPPORTED_RECEIPT_METHODS = ['CASH', 'CARD', 'TRANSFER', 'MOBILE_MONEY'] as const;
 export type ReceiptPaymentMethod = (typeof SUPPORTED_RECEIPT_METHODS)[number];
 
@@ -43,11 +50,16 @@ export type MoneyReceivedByMethod = Record<ReceiptPaymentMethod, number>;
 export type MoneyReceivedSummary = {
   byMethod: MoneyReceivedByMethod;
   totalPence: number;
+  totalCount: number;
   receivedAtSalePence: number;
   laterCreditCollectionPence: number;
   /** Historical NULL / explicit UNCLASSIFIED — never inferred as a known origin. */
   unknownHistoricalOriginPence: number;
+  /** Sum of negative payment amounts (display / audit); already included in origin buckets. */
   reversalPence: number;
+  receivedAtSaleCount: number;
+  laterCreditCollectionCount: number;
+  unknownHistoricalOriginCount: number;
 };
 
 export type MoneyReceivedRow = {
@@ -62,7 +74,6 @@ export type MoneyReceivedRow = {
   status: string;
   reference: string | null;
   network: string | null;
-  payerMsisdn: string | null;
   provider: string | null;
   transactionNumber: string | null;
   invoiceId: string;
@@ -82,6 +93,11 @@ function emptyByMethod(): MoneyReceivedByMethod {
 
 function isSupportedMethod(method: string): method is ReceiptPaymentMethod {
   return (SUPPORTED_RECEIPT_METHODS as readonly string[]).includes(method);
+}
+
+function toNumber(value: bigint | number | null | undefined): number {
+  if (value == null) return 0;
+  return typeof value === 'bigint' ? Number(value) : value;
 }
 
 function originFilter(origin?: ReceiptOrigin | null) {
@@ -115,62 +131,101 @@ function paymentListWhere(
   };
 }
 
+type AggregateRow = {
+  total_pence: bigint;
+  total_count: bigint;
+  cash_pence: bigint;
+  card_pence: bigint;
+  transfer_pence: bigint;
+  momo_pence: bigint;
+  at_sale_pence: bigint;
+  later_pence: bigint;
+  unknown_pence: bigint;
+  reversal_pence: bigint;
+  at_sale_count: bigint;
+  later_count: bigint;
+  unknown_count: bigint;
+};
+
 /**
  * Aggregate money received from payment records for the scope.
  *
- * Origin buckets use persisted receiptOrigin only.
- * Identity (non-forced):
- *   totalPence = receivedAtSale + laterCredit + unknownHistorical + reversal
+ * Complete database aggregation — never load matching payments into app memory.
+ *
+ * Origin buckets use persisted receiptOrigin only (NULL / invalid → unknown).
+ * Identities:
+ *   totalPence = Σ supported method groups (+ any unsupported method amounts still in total)
+ *   totalPence = receivedAtSale + laterCredit + unknownHistorical
+ *   totalCount = receivedAtSaleCount + laterCreditCount + unknownCount
+ * Signed reversals remain in their origin bucket and are also surfaced as reversalPence.
  */
 export async function getMoneyReceivedSummary(scope: ReportingScope): Promise<MoneyReceivedSummary> {
-  const payments = await prisma.salesPayment.findMany({
-    where: paymentListWhere(scope),
-    select: {
-      amountPence: true,
-      method: true,
-      receiptOrigin: true,
-    },
-    // Bounded fetch for origin buckets; retail-day aggregates stay well under this.
-    take: 20_000,
-    orderBy: [{ receivedAt: 'asc' }, { id: 'asc' }],
-  });
+  const storeClause =
+    scope.storeId === 'ALL'
+      ? Prisma.empty
+      : Prisma.sql`AND si."storeId" = ${scope.storeId}`;
 
+  const rows = await prisma.$queryRaw<AggregateRow[]>`
+    SELECT
+      COALESCE(SUM(sp."amountPence"), 0)::bigint AS total_pence,
+      COUNT(*)::bigint AS total_count,
+      COALESCE(SUM(CASE WHEN sp.method = 'CASH' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS cash_pence,
+      COALESCE(SUM(CASE WHEN sp.method = 'CARD' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS card_pence,
+      COALESCE(SUM(CASE WHEN sp.method = 'TRANSFER' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS transfer_pence,
+      COALESCE(SUM(CASE WHEN sp.method = 'MOBILE_MONEY' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS momo_pence,
+      COALESCE(SUM(CASE WHEN sp."receiptOrigin" = 'RECEIVED_AT_SALE' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS at_sale_pence,
+      COALESCE(SUM(CASE WHEN sp."receiptOrigin" = 'LATER_CREDIT_COLLECTION' THEN sp."amountPence" ELSE 0 END), 0)::bigint AS later_pence,
+      COALESCE(SUM(
+        CASE
+          WHEN sp."receiptOrigin" IS NULL
+            OR sp."receiptOrigin" = ''
+            OR sp."receiptOrigin" = 'UNCLASSIFIED'
+            OR sp."receiptOrigin" NOT IN ('RECEIVED_AT_SALE', 'LATER_CREDIT_COLLECTION', 'UNCLASSIFIED')
+          THEN sp."amountPence"
+          ELSE 0
+        END
+      ), 0)::bigint AS unknown_pence,
+      COALESCE(SUM(CASE WHEN sp."amountPence" < 0 THEN sp."amountPence" ELSE 0 END), 0)::bigint AS reversal_pence,
+      COALESCE(SUM(CASE WHEN sp."receiptOrigin" = 'RECEIVED_AT_SALE' THEN 1 ELSE 0 END), 0)::bigint AS at_sale_count,
+      COALESCE(SUM(CASE WHEN sp."receiptOrigin" = 'LATER_CREDIT_COLLECTION' THEN 1 ELSE 0 END), 0)::bigint AS later_count,
+      COALESCE(SUM(
+        CASE
+          WHEN sp."receiptOrigin" IS NULL
+            OR sp."receiptOrigin" = ''
+            OR sp."receiptOrigin" = 'UNCLASSIFIED'
+            OR sp."receiptOrigin" NOT IN ('RECEIVED_AT_SALE', 'LATER_CREDIT_COLLECTION', 'UNCLASSIFIED')
+          THEN 1
+          ELSE 0
+        END
+      ), 0)::bigint AS unknown_count
+    FROM "SalesPayment" sp
+    INNER JOIN "SalesInvoice" si ON si.id = sp."salesInvoiceId"
+    WHERE sp."receivedAt" >= ${scope.startInclusive}
+      AND sp."receivedAt" < ${scope.endExclusive}
+      AND sp.status NOT IN (${Prisma.join([...REPORTING_EXCLUDED_PAYMENT_STATUSES])})
+      AND si."businessId" = ${scope.businessId}
+      AND si."paymentStatus" NOT IN (${Prisma.join([...REPORTING_EXCLUDED_SALE_STATUSES])})
+      ${storeClause}
+  `;
+
+  const row = rows[0];
   const byMethod = emptyByMethod();
-  let totalPence = 0;
-  let receivedAtSalePence = 0;
-  let laterCreditCollectionPence = 0;
-  let unknownHistoricalOriginPence = 0;
-  let reversalPence = 0;
-
-  for (const payment of payments) {
-    if (isSupportedMethod(payment.method)) {
-      byMethod[payment.method] += payment.amountPence;
-    }
-    totalPence += payment.amountPence;
-
-    const { classification, paymentState } = classifySalesPaymentReceipt({
-      amountPence: payment.amountPence,
-      receiptOrigin: payment.receiptOrigin,
-    });
-
-    if (paymentState === 'REVERSAL') {
-      reversalPence += payment.amountPence;
-    } else if (classification === 'RECEIVED_AT_SALE') {
-      receivedAtSalePence += payment.amountPence;
-    } else if (classification === 'LATER_CREDIT_COLLECTION') {
-      laterCreditCollectionPence += payment.amountPence;
-    } else {
-      unknownHistoricalOriginPence += payment.amountPence;
-    }
-  }
+  byMethod.CASH = toNumber(row?.cash_pence);
+  byMethod.CARD = toNumber(row?.card_pence);
+  byMethod.TRANSFER = toNumber(row?.transfer_pence);
+  byMethod.MOBILE_MONEY = toNumber(row?.momo_pence);
 
   return {
     byMethod,
-    totalPence,
-    receivedAtSalePence,
-    laterCreditCollectionPence,
-    unknownHistoricalOriginPence,
-    reversalPence,
+    totalPence: toNumber(row?.total_pence),
+    totalCount: toNumber(row?.total_count),
+    receivedAtSalePence: toNumber(row?.at_sale_pence),
+    laterCreditCollectionPence: toNumber(row?.later_pence),
+    unknownHistoricalOriginPence: toNumber(row?.unknown_pence),
+    reversalPence: toNumber(row?.reversal_pence),
+    receivedAtSaleCount: toNumber(row?.at_sale_count),
+    laterCreditCollectionCount: toNumber(row?.later_count),
+    unknownHistoricalOriginCount: toNumber(row?.unknown_count),
   };
 }
 
@@ -213,7 +268,6 @@ export async function listMoneyReceivedPayments(input: {
       receivedAt: true,
       reference: true,
       network: true,
-      payerMsisdn: true,
       provider: true,
       status: true,
       receiptOrigin: true,
@@ -254,7 +308,6 @@ export async function listMoneyReceivedPayments(input: {
       status: payment.status,
       reference: payment.reference,
       network: payment.network,
-      payerMsisdn: payment.payerMsisdn,
       provider: payment.provider,
       transactionNumber: payment.salesInvoice.transactionNumber,
       invoiceId: payment.salesInvoice.id,

--- a/lib/reports/report-streaming.test.ts
+++ b/lib/reports/report-streaming.test.ts
@@ -39,9 +39,11 @@ describe('Phase 2b report streaming', () => {
     expect(dashboardPage).not.toContain('_getTradingDashboardSnapshot');
     expect(dashboardContent).toContain('_getTradingDashboardSnapshot');
     expect(dashboardContent).toContain('getCachedTradingDashboardSnapshot');
-    expect(dashboardPage).toMatch(/startIso=\{start\.toISOString\(\)\}/);
-    expect(dashboardPage).toMatch(/endIso=\{end\.toISOString\(\)\}/);
+    expect(dashboardPage).toMatch(/startIso=\{scope\.startInclusive\.toISOString\(\)\}/);
+    expect(dashboardPage).toMatch(/endIso=\{scope\.endExclusive\.toISOString\(\)\}/);
     expect(dashboardPage).toMatch(/selectedStoreId=\{selectedStoreId\}/);
+    expect(dashboardPage).toContain('resolveReportingScope');
+    expect(dashboardPage).toContain('periodKey={scope.periodKey}');
   });
 
   it('owner page streams snapshot body behind Suspense', () => {

--- a/lib/reports/reporting-contract.test.ts
+++ b/lib/reports/reporting-contract.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Reporting scope, sales-revenue / money-received contract, and classification tests.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildReportingScopeSearchParams,
+  isReportingScopeToday,
+  resolveReportingScope,
+  tradingReportHref,
+} from '@/lib/reports/reporting-scope';
+import {
+  classifySalesPaymentReceipt,
+  SALE_RECEIPT_GRACE_MS,
+} from '@/lib/reports/money-received-classify';
+import {
+  getBusinessCalendarDayBounds,
+  getBusinessDayBounds,
+  parseBusinessLocalDateKey,
+} from '@/lib/notifications/utils';
+
+describe('resolveReportingScope — business timezone Today', () => {
+  it('uses Africa/Accra calendar day with inclusive start and exclusive end', () => {
+    // 2026-04-01 00:30 Accra = still 2026-03-31 23:30 UTC previous day in UK winter? Accra=GMT.
+    const now = new Date('2026-04-01T15:30:00.000Z');
+    const scope = resolveReportingScope({
+      businessId: 'biz-1',
+      timeZone: 'Africa/Accra',
+      params: { period: 'today', storeId: 'ALL' },
+      defaultPeriod: '7d',
+      allowedStoreIds: ['store-a'],
+      now,
+    });
+
+    expect(scope.periodKey).toBe('today');
+    expect(scope.fromInputValue).toBe('2026-04-01');
+    expect(scope.toInputValue).toBe('2026-04-01');
+    expect(scope.startInclusive.toISOString()).toBe('2026-04-01T00:00:00.000Z');
+    expect(scope.endExclusive.toISOString()).toBe('2026-04-02T00:00:00.000Z');
+    expect(isReportingScopeToday(scope, now)).toBe(true);
+  });
+
+  it('does not fall back to 7d when period=today is supplied (Home drill-down)', () => {
+    const now = new Date('2026-08-07T10:00:00.000Z');
+    const scope = resolveReportingScope({
+      businessId: 'biz-1',
+      timeZone: 'Africa/Accra',
+      params: {
+        period: 'today',
+        from: '2026-08-07',
+        to: '2026-08-07',
+        storeId: 'ALL',
+      },
+      defaultPeriod: '7d',
+      allowedStoreIds: [],
+      now,
+    });
+    expect(scope.periodKey).toBe('today');
+    expect(scope.fromInputValue).toBe('2026-08-07');
+    expect(tradingReportHref(scope)).toContain('period=today');
+    expect(tradingReportHref(scope)).not.toMatch(/period=7d/);
+  });
+
+  it('defaults bare Trading Report to rolling 7 local days', () => {
+    const now = new Date('2026-08-07T10:00:00.000Z');
+    const scope = resolveReportingScope({
+      businessId: 'biz-1',
+      timeZone: 'Africa/Accra',
+      params: {},
+      defaultPeriod: '7d',
+      allowedStoreIds: [],
+      now,
+    });
+    expect(scope.periodKey).toBe('7d');
+    expect(scope.fromInputValue).toBe('2026-08-01');
+    expect(scope.toInputValue).toBe('2026-08-07');
+  });
+
+  it('rejects foreign storeId and falls back to ALL', () => {
+    const scope = resolveReportingScope({
+      businessId: 'biz-1',
+      timeZone: 'Africa/Accra',
+      params: { period: 'today', storeId: 'foreign-store' },
+      allowedStoreIds: ['store-a'],
+      now: new Date('2026-08-07T10:00:00.000Z'),
+    });
+    expect(scope.storeId).toBe('ALL');
+  });
+
+  it('preserves authorised branch selection', () => {
+    const scope = resolveReportingScope({
+      businessId: 'biz-1',
+      timeZone: 'Africa/Accra',
+      params: { period: 'today', storeId: 'store-a' },
+      allowedStoreIds: ['store-a', 'store-b'],
+      now: new Date('2026-08-07T10:00:00.000Z'),
+    });
+    expect(scope.storeId).toBe('store-a');
+    expect(buildReportingScopeSearchParams(scope).get('storeId')).toBe('store-a');
+  });
+
+  it('handles UK DST spring-forward local midnight for Europe/London', () => {
+    // 2026-03-29 is UK spring-forward (01:00 → 02:00). Local 29 Mar still exists.
+    const now = new Date('2026-03-29T12:00:00.000Z');
+    const scope = resolveReportingScope({
+      businessId: 'biz-1',
+      timeZone: 'Europe/London',
+      params: { period: 'today' },
+      allowedStoreIds: [],
+      now,
+    });
+    expect(scope.fromInputValue).toBe('2026-03-29');
+    expect(scope.startInclusive < scope.endExclusive).toBe(true);
+    // Exclusive end should be local midnight 30 Mar BST (UTC+1) = 2026-03-29T23:00:00.000Z
+    expect(scope.endExclusive.toISOString()).toBe('2026-03-29T23:00:00.000Z');
+  });
+
+  it('handles UK DST autumn boundary for Europe/London', () => {
+    const now = new Date('2026-10-25T12:00:00.000Z');
+    const scope = resolveReportingScope({
+      businessId: 'biz-1',
+      timeZone: 'Europe/London',
+      params: { period: 'today' },
+      allowedStoreIds: [],
+      now,
+    });
+    expect(scope.fromInputValue).toBe('2026-10-25');
+    expect(scope.startInclusive.toISOString()).toBe('2026-10-24T23:00:00.000Z');
+  });
+});
+
+describe('business calendar day helpers', () => {
+  it('parses YYYY-MM-DD and rejects impossible dates', () => {
+    expect(parseBusinessLocalDateKey('2026-02-28')).toEqual({ year: 2026, month: 2, day: 28 });
+    expect(parseBusinessLocalDateKey('2026-02-31')).toBeNull();
+    expect(parseBusinessLocalDateKey('not-a-date')).toBeNull();
+  });
+
+  it('places 23:59 Accra inside Today and 00:00 next day outside', () => {
+    const bounds = getBusinessDayBounds(new Date('2026-08-07T12:00:00.000Z'), 'Africa/Accra');
+    const late = new Date('2026-08-07T23:59:59.000Z');
+    const next = new Date('2026-08-08T00:00:00.000Z');
+    expect(late >= bounds.dayStart && late < bounds.dayEndExclusive).toBe(true);
+    expect(next >= bounds.dayEndExclusive).toBe(true);
+  });
+
+  it('builds calendar bounds for an explicit local date', () => {
+    const bounds = getBusinessCalendarDayBounds({ year: 2026, month: 8, day: 7 }, 'Africa/Accra');
+    expect(bounds.dayStart.toISOString()).toBe('2026-08-07T00:00:00.000Z');
+    expect(bounds.dayEndExclusive.toISOString()).toBe('2026-08-08T00:00:00.000Z');
+  });
+});
+
+describe('classifySalesPaymentReceipt', () => {
+  const saleAt = new Date('2026-08-07T10:00:00.000Z');
+
+  it('classifies checkout-aligned payments as RECEIVED_AT_SALE', () => {
+    const result = classifySalesPaymentReceipt({
+      amountPence: 5000,
+      receivedAt: new Date(saleAt.getTime() + 2_000),
+      invoiceCreatedAt: saleAt,
+    });
+    expect(result.classification).toBe('RECEIVED_AT_SALE');
+    expect(result.paymentState).toBe('CONFIRMED');
+  });
+
+  it('classifies later collections beyond grace as LATER_CREDIT_COLLECTION', () => {
+    const result = classifySalesPaymentReceipt({
+      amountPence: 7000,
+      receivedAt: new Date(saleAt.getTime() + SALE_RECEIPT_GRACE_MS + 1),
+      invoiceCreatedAt: saleAt,
+    });
+    expect(result.classification).toBe('LATER_CREDIT_COLLECTION');
+  });
+
+  it('marks negative amounts as REVERSAL while still classifying timing', () => {
+    const result = classifySalesPaymentReceipt({
+      amountPence: -2000,
+      receivedAt: new Date(saleAt.getTime() + 60_000),
+      invoiceCreatedAt: saleAt,
+    });
+    expect(result.paymentState).toBe('REVERSAL');
+    expect(result.classification).toBe('RECEIVED_AT_SALE');
+  });
+});
+
+describe('Home navigation contract helpers', () => {
+  it('builds Trading Report deep links that preserve period and branch', () => {
+    const href = tradingReportHref({
+      periodKey: 'today',
+      fromInputValue: '2026-08-07',
+      toInputValue: '2026-08-07',
+      storeId: 'ALL',
+    });
+    expect(href).toBe(
+      '/reports/dashboard?period=today&from=2026-08-07&to=2026-08-07&storeId=ALL',
+    );
+  });
+});

--- a/lib/reports/reporting-contract.test.ts
+++ b/lib/reports/reporting-contract.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from 'vitest';
 import {
   buildReportingScopeSearchParams,
   isReportingScopeToday,
+  ReportingScopeStoreError,
+  resolveAuthorisedStoreId,
   resolveReportingScope,
   tradingReportHref,
 } from '@/lib/reports/reporting-scope';
@@ -76,15 +78,79 @@ describe('resolveReportingScope — business timezone Today', () => {
     expect(scope.toInputValue).toBe('2026-08-07');
   });
 
-  it('rejects foreign storeId and falls back to ALL', () => {
-    const scope = resolveReportingScope({
+  it('PRE-FIX DEFECT: inaccessible storeId must not silently broaden to ALL', () => {
+    // This asserts the required fail-closed contract. On the defective head it
+    // failed because resolveReportingScope fell back to storeId=ALL.
+    expect(() =>
+      resolveReportingScope({
+        businessId: 'biz-1',
+        timeZone: 'Africa/Accra',
+        params: { period: 'today', storeId: 'foreign-store' },
+        allowedStoreIds: ['store-a'],
+        now: new Date('2026-08-07T10:00:00.000Z'),
+      }),
+    ).toThrow(ReportingScopeStoreError);
+
+    const broadened = (() => {
+      try {
+        return resolveReportingScope({
+          businessId: 'biz-1',
+          timeZone: 'Africa/Accra',
+          params: { period: 'today', storeId: 'foreign-store' },
+          allowedStoreIds: ['store-a'],
+          now: new Date('2026-08-07T10:00:00.000Z'),
+        }).storeId;
+      } catch {
+        return null;
+      }
+    })();
+    expect(broadened).not.toBe('ALL');
+  });
+
+  it('omitted storeId defaults to ALL; explicit ALL stays ALL', () => {
+    const omitted = resolveReportingScope({
       businessId: 'biz-1',
       timeZone: 'Africa/Accra',
-      params: { period: 'today', storeId: 'foreign-store' },
+      params: { period: 'today' },
+      allowedStoreIds: ['store-a', 'store-b'],
+      now: new Date('2026-08-07T10:00:00.000Z'),
+    });
+    expect(omitted.storeId).toBe('ALL');
+
+    const explicitAll = resolveReportingScope({
+      businessId: 'biz-1',
+      timeZone: 'Africa/Accra',
+      params: { period: 'today', storeId: 'ALL' },
       allowedStoreIds: ['store-a'],
       now: new Date('2026-08-07T10:00:00.000Z'),
     });
-    expect(scope.storeId).toBe('ALL');
+    expect(explicitAll.storeId).toBe('ALL');
+  });
+
+  it('accepts each accessible store and rejects blank, whitespace, unknown and foreign', () => {
+    expect(
+      resolveAuthorisedStoreId({ storeId: 'store-a', allowedStoreIds: ['store-a', 'store-b'] }),
+    ).toBe('store-a');
+    expect(
+      resolveAuthorisedStoreId({ storeId: 'store-b', allowedStoreIds: ['store-a', 'store-b'] }),
+    ).toBe('store-b');
+
+    expect(() =>
+      resolveAuthorisedStoreId({ storeId: '', allowedStoreIds: ['store-a'] }),
+    ).toThrow(ReportingScopeStoreError);
+    expect(() =>
+      resolveAuthorisedStoreId({ storeId: '   ', allowedStoreIds: ['store-a'] }),
+    ).toThrow(ReportingScopeStoreError);
+    expect(() =>
+      resolveAuthorisedStoreId({ storeId: 'store-missing', allowedStoreIds: ['store-a'] }),
+    ).toThrow(ReportingScopeStoreError);
+    expect(() =>
+      resolveAuthorisedStoreId({ storeId: 'foreign-store', allowedStoreIds: ['store-a'] }),
+    ).toThrow(ReportingScopeStoreError);
+    // Deleted/inactive: not present in allowedStoreIds for this business.
+    expect(() =>
+      resolveAuthorisedStoreId({ storeId: 'store-deleted', allowedStoreIds: ['store-a'] }),
+    ).toThrow(ReportingScopeStoreError);
   });
 
   it('preserves authorised branch selection', () => {

--- a/lib/reports/reporting-contract.test.ts
+++ b/lib/reports/reporting-contract.test.ts
@@ -10,8 +10,9 @@ import {
 } from '@/lib/reports/reporting-scope';
 import {
   classifySalesPaymentReceipt,
-  SALE_RECEIPT_GRACE_MS,
+  RECEIPT_CLASSIFICATION_LABELS,
 } from '@/lib/reports/money-received-classify';
+import { RECEIPT_ORIGIN } from '@/lib/payments/receipt-origin';
 import {
   getBusinessCalendarDayBounds,
   getBusinessDayBounds,
@@ -151,35 +152,50 @@ describe('business calendar day helpers', () => {
 });
 
 describe('classifySalesPaymentReceipt', () => {
-  const saleAt = new Date('2026-08-07T10:00:00.000Z');
-
-  it('classifies checkout-aligned payments as RECEIVED_AT_SALE', () => {
+  it('uses persisted RECEIVED_AT_SALE without timestamps', () => {
     const result = classifySalesPaymentReceipt({
       amountPence: 5000,
-      receivedAt: new Date(saleAt.getTime() + 2_000),
-      invoiceCreatedAt: saleAt,
+      receiptOrigin: RECEIPT_ORIGIN.RECEIVED_AT_SALE,
     });
     expect(result.classification).toBe('RECEIVED_AT_SALE');
     expect(result.paymentState).toBe('CONFIRMED');
+    expect(RECEIPT_CLASSIFICATION_LABELS.RECEIVED_AT_SALE).toBe('Received at sale');
   });
 
-  it('classifies later collections beyond grace as LATER_CREDIT_COLLECTION', () => {
+  it('uses persisted LATER_CREDIT_COLLECTION even within five minutes of a sale', () => {
     const result = classifySalesPaymentReceipt({
       amountPence: 7000,
-      receivedAt: new Date(saleAt.getTime() + SALE_RECEIPT_GRACE_MS + 1),
-      invoiceCreatedAt: saleAt,
+      receiptOrigin: RECEIPT_ORIGIN.LATER_CREDIT_COLLECTION,
     });
     expect(result.classification).toBe('LATER_CREDIT_COLLECTION');
   });
 
-  it('marks negative amounts as REVERSAL while still classifying timing', () => {
+  it('maps historical NULL to UNCLASSIFIED and never invents sale-time meaning', () => {
+    const result = classifySalesPaymentReceipt({
+      amountPence: 1000,
+      receiptOrigin: null,
+    });
+    expect(result.classification).toBe('UNCLASSIFIED');
+    expect(RECEIPT_CLASSIFICATION_LABELS.UNCLASSIFIED).toBe('Historical — not classified');
+  });
+
+  it('does not infer origin from payment timing fields (none accepted)', () => {
+    const result = classifySalesPaymentReceipt({
+      amountPence: 9000,
+      receiptOrigin: RECEIPT_ORIGIN.RECEIVED_AT_SALE,
+    });
+    // Explicit at-sale origin wins even if a caller might also know timestamps.
+    expect(result.classification).toBe('RECEIVED_AT_SALE');
+    expect(result).not.toHaveProperty('deltaMs');
+  });
+
+  it('marks negative amounts as REVERSAL while preserving persisted origin', () => {
     const result = classifySalesPaymentReceipt({
       amountPence: -2000,
-      receivedAt: new Date(saleAt.getTime() + 60_000),
-      invoiceCreatedAt: saleAt,
+      receiptOrigin: RECEIPT_ORIGIN.UNCLASSIFIED,
     });
     expect(result.paymentState).toBe('REVERSAL');
-    expect(result.classification).toBe('RECEIVED_AT_SALE');
+    expect(result.classification).toBe('UNCLASSIFIED');
   });
 });
 

--- a/lib/reports/reporting-scope.ts
+++ b/lib/reports/reporting-scope.ts
@@ -199,8 +199,15 @@ export function tradingReportHref(
 export function moneyReceivedHref(
   scope: Pick<ReportingScope, 'periodKey' | 'fromInputValue' | 'toInputValue' | 'storeId'>,
   method?: string,
+  origin?: string,
 ): string {
-  const params = buildReportingScopeSearchParams(scope, method ? { method } : undefined);
+  const extras: Record<string, string> = {};
+  if (method) extras.method = method;
+  if (origin) extras.origin = origin;
+  const params = buildReportingScopeSearchParams(
+    scope,
+    Object.keys(extras).length ? extras : undefined,
+  );
   return `/reports/receipts?${params.toString()}`;
 }
 

--- a/lib/reports/reporting-scope.ts
+++ b/lib/reports/reporting-scope.ts
@@ -46,6 +46,54 @@ export type ReportingScopeParams = {
   storeId?: string;
 };
 
+/**
+ * Thrown when a storeId query param is supplied but is blank, malformed,
+ * unknown, deleted, or otherwise inaccessible. Callers must fail closed
+ * (typically `notFound()` / 4xx) — never broaden to ALL-store data.
+ */
+export class ReportingScopeStoreError extends Error {
+  readonly code = 'INVALID_STORE_SCOPE' as const;
+
+  constructor(message = 'Invalid or inaccessible reporting store scope') {
+    super(message);
+    this.name = 'ReportingScopeStoreError';
+  }
+}
+
+export function isReportingScopeStoreError(error: unknown): error is ReportingScopeStoreError {
+  return error instanceof ReportingScopeStoreError;
+}
+
+/**
+ * Resolve an authorised store scope.
+ *
+ * - Omitted storeId → ALL (established default)
+ * - Explicit ALL → ALL
+ * - Valid accessible store → that store
+ * - Blank, whitespace, unknown, deleted, or inaccessible → throw ReportingScopeStoreError
+ */
+export function resolveAuthorisedStoreId(input: {
+  storeId?: string | null;
+  allowedStoreIds: readonly string[];
+}): 'ALL' | string {
+  if (input.storeId === undefined || input.storeId === null) {
+    return 'ALL';
+  }
+
+  // Param was supplied (including empty string) — blank/whitespace fail closed.
+  const trimmed = input.storeId.trim();
+  if (trimmed === '') {
+    throw new ReportingScopeStoreError('Blank reporting store scope is not authorised');
+  }
+  if (trimmed === 'ALL') {
+    return 'ALL';
+  }
+  if (input.allowedStoreIds.includes(trimmed)) {
+    return trimmed;
+  }
+  throw new ReportingScopeStoreError('Invalid or inaccessible reporting store scope');
+}
+
 function addLocalDays(parts: LocalDateParts, days: number): LocalDateParts {
   const probe = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days));
   return {
@@ -84,6 +132,9 @@ function compareLocalDates(a: LocalDateParts, b: LocalDateParts): number {
  * Resolve Home / Trading Report scope from URL params.
  * Malformed dates fall back safely to the default period (7d for bare Trading
  * Report; callers that need Today pass period=today explicitly).
+ *
+ * Store scope is fail-closed: an explicitly supplied invalid/inaccessible
+ * storeId throws ReportingScopeStoreError (never silently broadens to ALL).
  */
 export function resolveReportingScope(input: {
   businessId: string;
@@ -91,7 +142,7 @@ export function resolveReportingScope(input: {
   params?: ReportingScopeParams;
   /** Default when period/from/to are absent. Trading Report uses 7d. */
   defaultPeriod?: ReportingPeriodKey;
-  /** Allowed store ids for this business; unknown storeId → ALL. */
+  /** Allowed store ids for this authenticated business context. */
   allowedStoreIds: string[];
   now?: Date;
 }): ReportingScope {
@@ -148,13 +199,10 @@ export function resolveReportingScope(input: {
 
   const { startInclusive, endExclusive } = rangeForLocalDates(fromParts, toParts, timeZone);
 
-  const requestedStore = input.params?.storeId?.trim();
-  const storeId =
-    requestedStore
-    && requestedStore !== 'ALL'
-    && input.allowedStoreIds.includes(requestedStore)
-      ? requestedStore
-      : 'ALL';
+  const storeId = resolveAuthorisedStoreId({
+    storeId: input.params?.storeId,
+    allowedStoreIds: input.allowedStoreIds,
+  });
 
   return {
     businessId: input.businessId,

--- a/lib/reports/reporting-scope.ts
+++ b/lib/reports/reporting-scope.ts
@@ -1,0 +1,226 @@
+/**
+ * Shared reporting period / branch scope for Home Revenue and Trading Report.
+ *
+ * Boundaries are always:
+ *   startInclusive <= timestamp < endExclusive
+ * in the business-configured timezone (never server-local or browser TZ).
+ *
+ * Preserved week rule: rolling last 7 local calendar days inclusive of today
+ * (today and the prior 6 days) — same window historically used as the Trading
+ * Report default when no Home drill-down params are supplied.
+ */
+import {
+  formatBusinessLocalDateKey,
+  getBusinessCalendarDayBounds,
+  getBusinessDayBounds,
+  parseBusinessLocalDateKey,
+  resolveBusinessTimeZone,
+  type LocalDateParts,
+} from '@/lib/notifications/utils';
+
+export const REPORTING_EXCLUDED_SALE_STATUSES = ['RETURNED', 'VOID'] as const;
+
+export const REPORTING_EXCLUDED_PAYMENT_STATUSES = ['FAILED', 'CANCELLED', 'VOID'] as const;
+
+export type ReportingPeriodKey = 'today' | '7d' | 'custom';
+
+export type ReportingScope = {
+  businessId: string;
+  timeZone: string;
+  periodKey: ReportingPeriodKey;
+  /** Inclusive UTC instant for the start of the selected local range. */
+  startInclusive: Date;
+  /** Exclusive UTC instant for the end of the selected local range. */
+  endExclusive: Date;
+  /** Local YYYY-MM-DD (business TZ) for date inputs / deep links. */
+  fromInputValue: string;
+  toInputValue: string;
+  /** Validated store id or ALL. */
+  storeId: 'ALL' | string;
+};
+
+export type ReportingScopeParams = {
+  period?: string;
+  from?: string;
+  to?: string;
+  storeId?: string;
+};
+
+function addLocalDays(parts: LocalDateParts, days: number): LocalDateParts {
+  const probe = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days));
+  return {
+    year: probe.getUTCFullYear(),
+    month: probe.getUTCMonth() + 1,
+    day: probe.getUTCDate(),
+  };
+}
+
+function localDateKey(parts: LocalDateParts): string {
+  return [
+    parts.year,
+    String(parts.month).padStart(2, '0'),
+    String(parts.day).padStart(2, '0'),
+  ].join('-');
+}
+
+function rangeForLocalDates(
+  fromLocal: LocalDateParts,
+  toLocal: LocalDateParts,
+  timeZone: string,
+): { startInclusive: Date; endExclusive: Date } {
+  const start = getBusinessCalendarDayBounds(fromLocal, timeZone);
+  const end = getBusinessCalendarDayBounds(toLocal, timeZone);
+  return {
+    startInclusive: start.dayStart,
+    endExclusive: end.dayEndExclusive,
+  };
+}
+
+function compareLocalDates(a: LocalDateParts, b: LocalDateParts): number {
+  return localDateKey(a).localeCompare(localDateKey(b));
+}
+
+/**
+ * Resolve Home / Trading Report scope from URL params.
+ * Malformed dates fall back safely to the default period (7d for bare Trading
+ * Report; callers that need Today pass period=today explicitly).
+ */
+export function resolveReportingScope(input: {
+  businessId: string;
+  timeZone?: string | null;
+  params?: ReportingScopeParams;
+  /** Default when period/from/to are absent. Trading Report uses 7d. */
+  defaultPeriod?: ReportingPeriodKey;
+  /** Allowed store ids for this business; unknown storeId → ALL. */
+  allowedStoreIds: string[];
+  now?: Date;
+}): ReportingScope {
+  const timeZone = resolveBusinessTimeZone(input.timeZone);
+  const now = input.now ?? new Date();
+  const todayBounds = getBusinessDayBounds(now, timeZone);
+  const todayLocal = todayBounds.localDate;
+  const defaultPeriod = input.defaultPeriod ?? '7d';
+
+  const rawPeriod = (input.params?.period ?? '').trim().toLowerCase();
+  const fromLocal = parseBusinessLocalDateKey(input.params?.from);
+  const toLocal = parseBusinessLocalDateKey(input.params?.to);
+
+  let periodKey: ReportingPeriodKey = defaultPeriod;
+  let fromParts = todayLocal;
+  let toParts = todayLocal;
+
+  if (rawPeriod === 'today') {
+    periodKey = 'today';
+    fromParts = todayLocal;
+    toParts = todayLocal;
+  } else if (rawPeriod === '7d' || rawPeriod === '7') {
+    periodKey = '7d';
+    fromParts = addLocalDays(todayLocal, -6);
+    toParts = todayLocal;
+  } else if (fromLocal && toLocal) {
+    periodKey = 'custom';
+    if (compareLocalDates(fromLocal, toLocal) <= 0) {
+      fromParts = fromLocal;
+      toParts = toLocal;
+    } else {
+      fromParts = toLocal;
+      toParts = fromLocal;
+    }
+  } else if (rawPeriod === 'custom' && fromLocal && toLocal) {
+    periodKey = 'custom';
+    fromParts = compareLocalDates(fromLocal, toLocal) <= 0 ? fromLocal : toLocal;
+    toParts = compareLocalDates(fromLocal, toLocal) <= 0 ? toLocal : fromLocal;
+  } else if (defaultPeriod === 'today') {
+    periodKey = 'today';
+    fromParts = todayLocal;
+    toParts = todayLocal;
+  } else {
+    periodKey = '7d';
+    fromParts = addLocalDays(todayLocal, -6);
+    toParts = todayLocal;
+  }
+
+  // When period=today but stale from/to disagree, honour period=today.
+  if (periodKey === 'today') {
+    fromParts = todayLocal;
+    toParts = todayLocal;
+  }
+
+  const { startInclusive, endExclusive } = rangeForLocalDates(fromParts, toParts, timeZone);
+
+  const requestedStore = input.params?.storeId?.trim();
+  const storeId =
+    requestedStore
+    && requestedStore !== 'ALL'
+    && input.allowedStoreIds.includes(requestedStore)
+      ? requestedStore
+      : 'ALL';
+
+  return {
+    businessId: input.businessId,
+    timeZone,
+    periodKey,
+    startInclusive,
+    endExclusive,
+    fromInputValue: localDateKey(fromParts),
+    toInputValue: localDateKey(toParts),
+    storeId,
+  };
+}
+
+/** Build a deep-link query string for Trading Report / Money received. */
+export function buildReportingScopeSearchParams(
+  scope: Pick<ReportingScope, 'periodKey' | 'fromInputValue' | 'toInputValue' | 'storeId'>,
+  extra?: Record<string, string | undefined>,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('period', scope.periodKey);
+  params.set('from', scope.fromInputValue);
+  params.set('to', scope.toInputValue);
+  if (scope.storeId && scope.storeId !== 'ALL') {
+    params.set('storeId', scope.storeId);
+  } else {
+    params.set('storeId', 'ALL');
+  }
+  if (extra) {
+    for (const [key, value] of Object.entries(extra)) {
+      if (value != null && value !== '') params.set(key, value);
+    }
+  }
+  return params;
+}
+
+export function tradingReportHref(
+  scope: Pick<ReportingScope, 'periodKey' | 'fromInputValue' | 'toInputValue' | 'storeId'>,
+): string {
+  return `/reports/dashboard?${buildReportingScopeSearchParams(scope).toString()}`;
+}
+
+export function moneyReceivedHref(
+  scope: Pick<ReportingScope, 'periodKey' | 'fromInputValue' | 'toInputValue' | 'storeId'>,
+  method?: string,
+): string {
+  const params = buildReportingScopeSearchParams(scope, method ? { method } : undefined);
+  return `/reports/receipts?${params.toString()}`;
+}
+
+/** Prisma-friendly createdAt / receivedAt filter for inclusive/exclusive bounds. */
+export function reportingTimestampFilter(scope: Pick<ReportingScope, 'startInclusive' | 'endExclusive'>) {
+  return {
+    gte: scope.startInclusive,
+    lt: scope.endExclusive,
+  };
+}
+
+export function salesInvoiceStoreFilter(storeId: ReportingScope['storeId']) {
+  return storeId === 'ALL' ? {} : { storeId };
+}
+
+/** True when the scope is exactly the business-local current day. */
+export function isReportingScopeToday(scope: ReportingScope, now = new Date()): boolean {
+  const todayKey = formatBusinessLocalDateKey(now, scope.timeZone);
+  return (
+    scope.periodKey === 'today'
+    || (scope.fromInputValue === todayKey && scope.toInputValue === todayKey)
+  );
+}

--- a/lib/reports/reporting-store-scope-routes.test.ts
+++ b/lib/reports/reporting-store-scope-routes.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Route-level contract: Trading Report / Money received / Cash Drawer fail closed
+ * on invalid store scope (never broaden to ALL via getBusinessStores coalescing).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+
+function read(rel: string) {
+  return readFileSync(join(root, rel), 'utf8');
+}
+
+describe('reporting store-scope fail-closed routes', () => {
+  it('Trading Report resolves raw searchParams.storeId and notFounds on store errors', () => {
+    const page = read('app/(protected)/reports/dashboard/page.tsx');
+    expect(page).toContain('resolveReportingScope(');
+    expect(page).toContain('storeId: searchParams?.storeId');
+    expect(page).not.toContain('rawStoreId ?? searchParams?.storeId ?? \'ALL\'');
+    expect(page).toContain('isReportingScopeStoreError');
+    expect(page).toContain('notFound()');
+    expect(page).toContain("requireBusiness(['MANAGER', 'OWNER'])");
+  });
+
+  it('Money received list uses the same fail-closed scope as summaries', () => {
+    const page = read('app/(protected)/reports/receipts/page.tsx');
+    expect(page).toContain('resolveReportingScope(');
+    expect(page).toContain('listMoneyReceivedPayments');
+    expect(page).toContain('storeId: searchParams?.storeId');
+    expect(page).not.toContain('rawStoreId ?? searchParams?.storeId ?? \'ALL\'');
+    expect(page).toContain('isReportingScopeStoreError');
+    expect(page).toContain('notFound()');
+    expect(page).toContain("requireBusiness(['MANAGER', 'OWNER'])");
+    expect(page).toContain('Math.min(50');
+  });
+
+  it('Cash Drawer uses resolveAuthorisedStoreId fail-closed (not ALL fallback)', () => {
+    const page = read('app/(protected)/reports/cash-drawer/page.tsx');
+    expect(page).toContain('resolveAuthorisedStoreId');
+    expect(page).toContain('isReportingScopeStoreError');
+    expect(page).toContain('notFound()');
+    expect(page).not.toContain("resolveStoreSelection(stores, searchParams?.storeId, 'ALL')");
+  });
+});

--- a/lib/reports/sales-revenue.ts
+++ b/lib/reports/sales-revenue.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared sales-revenue contract for Home and Trading Report.
+ *
+ * Sales revenue = Σ SalesInvoice.totalPence where:
+ *   - businessId from authenticated session
+ *   - createdAt in [startInclusive, endExclusive)
+ *   - paymentStatus not in RETURNED | VOID
+ *   - optional storeId filter
+ *
+ * totalPence already reflects discounts and tax per TillFlow checkout.
+ * Credit (UNPAID / PART_PAID) sales are included in full — unpaid amounts
+ * are not receipts. Later debtor collections do not create new invoices and
+ * therefore do not inflate revenue.
+ */
+import { prisma } from '@/lib/prisma';
+import {
+  REPORTING_EXCLUDED_SALE_STATUSES,
+  reportingTimestampFilter,
+  salesInvoiceStoreFilter,
+  type ReportingScope,
+} from '@/lib/reports/reporting-scope';
+
+export type SalesRevenueSummary = {
+  salesRevenuePence: number;
+  transactionCount: number;
+  /** Invoice total still unpaid within the period (credit component of period sales). */
+  creditSalesOutstandingPence: number;
+};
+
+export function salesRevenueWhere(scope: ReportingScope) {
+  return {
+    businessId: scope.businessId,
+    ...salesInvoiceStoreFilter(scope.storeId),
+    createdAt: reportingTimestampFilter(scope),
+    paymentStatus: { notIn: [...REPORTING_EXCLUDED_SALE_STATUSES] },
+  };
+}
+
+export async function getSalesRevenueSummary(scope: ReportingScope): Promise<SalesRevenueSummary> {
+  const where = salesRevenueWhere(scope);
+
+  const [agg, creditRows] = await Promise.all([
+    prisma.salesInvoice.aggregate({
+      where,
+      _sum: { totalPence: true },
+      _count: { id: true },
+    }),
+    prisma.salesInvoice.findMany({
+      where: {
+        ...where,
+        paymentStatus: { in: ['UNPAID', 'PART_PAID'] },
+      },
+      select: {
+        totalPence: true,
+        payments: {
+          where: { status: { notIn: ['FAILED', 'CANCELLED', 'VOID'] } },
+          select: { amountPence: true },
+        },
+      },
+      take: 5000,
+    }),
+  ]);
+
+  let creditSalesOutstandingPence = 0;
+  for (const invoice of creditRows) {
+    const paid = invoice.payments.reduce((sum, payment) => sum + payment.amountPence, 0);
+    creditSalesOutstandingPence += Math.max(invoice.totalPence - paid, 0);
+  }
+
+  return {
+    salesRevenuePence: agg._sum.totalPence ?? 0,
+    transactionCount: agg._count.id,
+    creditSalesOutstandingPence,
+  };
+}

--- a/lib/services/performance-phase-b.test.ts
+++ b/lib/services/performance-phase-b.test.ts
@@ -151,9 +151,10 @@ describe('Phase B: cache revalidation and dashboard performance hardening', () =
   it('Trading Dashboard keeps force-dynamic on page shell and existing date range resolution', () => {
     const dashboardPage = read('app/(protected)/reports/dashboard/page.tsx');
     expect(dashboardPage).toContain("export const dynamic = 'force-dynamic'");
-    expect(dashboardPage).toContain('resolveReportDateRange(');
-    expect(dashboardPage).toContain('defaultRangeStart');
-    expect(dashboardPage).toContain('todayEnd');
+    expect(dashboardPage).toContain('resolveReportingScope(');
+    expect(dashboardPage).toContain("defaultPeriod: '7d'");
+    expect(dashboardPage).toContain('scope.startInclusive');
+    expect(dashboardPage).toContain('scope.endExclusive');
   });
 
   it('POS cached loaders remain scoped by function arguments and TTLs are unchanged', () => {

--- a/scripts/reporting-option-b-preview-probe.cjs
+++ b/scripts/reporting-option-b-preview-probe.cjs
@@ -176,6 +176,7 @@ async function main() {
     payCreditCash: cuidLike(),
     payLaterMomo: cuidLike(),
     payLaterCash: cuidLike(),
+    payUnknown: cuidLike(),
     foreignPay: cuidLike(),
   };
 
@@ -409,6 +410,17 @@ async function main() {
       receiptOrigin: null,
     });
 
+    // Unsupported method (exact match only) — must land in Unknown/Other.
+    await insertPayment({
+      id: ids.payUnknown,
+      salesInvoiceId: ids.saleCash,
+      method: 'CHEQUE',
+      amountPence: 1500,
+      receivedAt: saleAt,
+      reference: `CHEQUE-REF-${stamp}`,
+      receiptOrigin: 'RECEIVED_AT_SALE',
+    });
+
     await insertSale({
       id: ids.foreignSale,
       businessId: ids.foreignBusiness,
@@ -461,7 +473,8 @@ async function main() {
     assert(/Sales revenue/i.test(tradingText), 'Missing Sales revenue label');
     assert(/Money received/i.test(tradingText), 'Missing Money received label');
     assert(/372\.00/.test(tradingText), 'Trading Sales revenue missing GH₵372.00');
-    assert(/372\.00/.test(tradingText), 'Trading Money received should include GH₵372.00 total receipts');
+    assert(/387\.00/.test(tradingText), 'Trading Money received should include GH₵387.00 (372 + CHEQUE 15)');
+    assert(/Unknown\/Other/i.test(tradingText), 'Missing Unknown/Other method bucket');
     assert(/Historical — not classified|Historical - not classified/i.test(tradingText), 'Missing unknown-origin bucket');
     assert(/Received at sale/i.test(tradingText), 'Missing received-at-sale bucket');
     assert(/Later credit collected/i.test(tradingText), 'Missing later-collection bucket');
@@ -530,6 +543,19 @@ async function main() {
     checks.push({ name: 'cash_drilldown' });
     console.log('PASS Cash payment drill-down');
 
+    await page.goto(
+      `${base}/reports/receipts?period=today&method=UNKNOWN&storeId=ALL`,
+      { waitUntil: 'networkidle', timeout: 90000 }
+    );
+    await page.getByText(/Money received|Unknown/i).first().waitFor({ timeout: 60000 });
+    const unknownText = await page.locator('body').innerText();
+    assert(/Unknown\/Other/i.test(unknownText), 'UNKNOWN filter missing Unknown/Other label');
+    assert(/15\.00/.test(unknownText), 'UNKNOWN filter missing CHEQUE amount');
+    assert(/CHEQUE-REF-/i.test(unknownText), 'UNKNOWN filter missing CHEQUE reference');
+    assert(!/OB-FOREIGN|999\.00/.test(unknownText), 'Foreign tenant leaked into UNKNOWN filter');
+    checks.push({ name: 'unknown_method_filter' });
+    console.log('PASS Unknown/Other method filter');
+
     await page.goto(`${base}/reports/cash-drawer`, {
       waitUntil: 'networkidle',
       timeout: 90000,
@@ -590,7 +616,9 @@ async function main() {
       JSON.stringify(
         {
           tag,
-          expectedRevenuePence: 36000,
+          expectedRevenuePence: 37200,
+          expectedMoneyReceivedPence: 38700,
+          expectedUnknownMethodPence: 1500,
           expectedCashReceiptsPence: 20000,
           expectedMomoReceiptsPence: 16000,
           checks: checks.map((c) => c.name),
@@ -626,6 +654,7 @@ async function main() {
           ids.payCreditCash,
           ids.payLaterMomo,
           ids.payLaterCash,
+          ids.payUnknown,
           ids.foreignPay,
         ],
       ]);

--- a/scripts/reporting-option-b-preview-probe.cjs
+++ b/scripts/reporting-option-b-preview-probe.cjs
@@ -1,0 +1,610 @@
+/**
+ * Preview verification probe for Option B reporting (synthetic Preview data only).
+ *
+ * Loads secrets from tmp/reporting-preview.local.env (do not commit).
+ *
+ * Exit 0 = verified (+ cleanup), 1 = failure, 2 = blocked (missing env)
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const bcrypt = require('bcryptjs');
+const { Client } = require('pg');
+
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  const o = {};
+  for (const raw of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    const m = raw.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    let v = m[2].trim();
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    o[m[1]] = v;
+  }
+  return o;
+}
+
+function fail(code, msg) {
+  console.error(msg);
+  process.exit(code);
+}
+
+function assert(cond, msg) {
+  if (!cond) {
+    const err = new Error(msg);
+    err.exitCode = 1;
+    throw err;
+  }
+}
+
+function cuidLike() {
+  return `c${crypto.randomBytes(12).toString('hex')}`;
+}
+
+async function loginWithPlaywright(base, email, password, bypass) {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  if (bypass) {
+    await context.setExtraHTTPHeaders({
+      'x-vercel-protection-bypass': bypass,
+      'x-vercel-set-bypass-cookie': 'true',
+    });
+  }
+  const page = await context.newPage();
+  const loginUrl = bypass
+    ? `${base}/login?x-vercel-protection-bypass=${encodeURIComponent(bypass)}`
+    : `${base}/login`;
+  await page.goto(loginUrl, { waitUntil: 'domcontentloaded', timeout: 90000 });
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', password);
+  await page.click('button[type="submit"]');
+  await page
+    .waitForURL((url) => !String(url.pathname || '').includes('/login'), {
+      timeout: 90000,
+    })
+    .catch(() => null);
+  const cookies = await context.cookies();
+  const sessionCookies = cookies.filter((c) => c.name.startsWith('pos_session'));
+  if (sessionCookies.length === 0) {
+    const url = page.url();
+    await browser.close();
+    return { ok: false, url };
+  }
+  return { ok: true, context, browser, page };
+}
+
+async function fetchWithBypass(base, pathName, bypass, { redirect = 'manual' } = {}) {
+  const url = new URL(pathName, base);
+  url.searchParams.set('x-vercel-protection-bypass', bypass);
+  let cookie = '';
+  let current = url.toString();
+  for (let i = 0; i < 8; i++) {
+    const res = await fetch(current, {
+      redirect: 'manual',
+      headers: {
+        'x-vercel-protection-bypass': bypass,
+        'x-vercel-set-bypass-cookie': 'true',
+        ...(cookie ? { cookie } : {}),
+      },
+    });
+    const setCookies = res.headers.getSetCookie?.() || [];
+    if (setCookies.length) {
+      const part = setCookies.map((c) => c.split(';')[0]).join('; ');
+      cookie = cookie ? `${cookie}; ${part}` : part;
+    }
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get('location');
+      if (!loc) return { status: res.status, url: current, text: await res.text(), cookie };
+      current = new URL(loc, current).toString();
+      if (redirect === 'manual' && i === 0) {
+        // keep following internally so callers see the app response after bypass cookie
+      }
+      continue;
+    }
+    return { status: res.status, url: current, text: await res.text(), cookie };
+  }
+  throw new Error('bypass fetch redirect count exceeded');
+}
+
+function relHref(base, href) {
+  if (!href) return null;
+  if (href.startsWith('/')) return href;
+  try {
+    const u = new URL(href);
+    return `${u.pathname}${u.search}`;
+  } catch {
+    return href.replace(base, '');
+  }
+}
+
+async function main() {
+  const fileEnv = loadEnvFile(
+    path.join(process.cwd(), 'tmp', 'reporting-preview.local.env')
+  );
+  const base = (
+    process.env.PREVIEW_BASE_URL ||
+    'https://supermarket-pos-git-fix-reporting-812082-joshua-owusus-projects.vercel.app'
+  ).replace(/\/$/, '');
+  const bypass =
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET ||
+    fileEnv.VERCEL_AUTOMATION_BYPASS_SECRET ||
+    '';
+  const dbUrl =
+    process.env.PREVIEW_DATABASE_URL ||
+    fileEnv.POSTGRES_URL_NON_POOLING ||
+    fileEnv.POSTGRES_PRISMA_URL;
+
+  if (!bypass) fail(2, 'BLOCKED: VERCEL_AUTOMATION_BYPASS_SECRET missing');
+  if (!dbUrl) fail(2, 'BLOCKED: Preview database URL missing');
+
+  const stamp = Date.now();
+  const password = `OptBPrev${stamp}!`;
+  const passwordHash = await bcrypt.hash(password, 10);
+  const tag = `OPTION_B_PREVIEW_${stamp}`;
+  const ownerEmail = `owner-optb-${stamp}@tillflow-test.invalid`;
+  const managerEmail = `manager-optb-${stamp}@tillflow-test.invalid`;
+  const cashierEmail = `cashier-optb-${stamp}@tillflow-test.invalid`;
+  const foreignEmail = `foreign-optb-${stamp}@tillflow-test.invalid`;
+
+  const ids = {
+    business: cuidLike(),
+    foreignBusiness: cuidLike(),
+    store: cuidLike(),
+    foreignStore: cuidLike(),
+    till: cuidLike(),
+    foreignTill: cuidLike(),
+    owner: cuidLike(),
+    manager: cuidLike(),
+    cashier: cuidLike(),
+    foreignOwner: cuidLike(),
+    saleCash: cuidLike(),
+    saleMomo: cuidLike(),
+    saleSplit: cuidLike(),
+    saleCredit: cuidLike(),
+    foreignSale: cuidLike(),
+    payCash: cuidLike(),
+    payMomo: cuidLike(),
+    paySplitCash: cuidLike(),
+    paySplitMomo: cuidLike(),
+    payCreditCash: cuidLike(),
+    payLaterMomo: cuidLike(),
+    payLaterCash: cuidLike(),
+    foreignPay: cuidLike(),
+  };
+
+  // Midday Accra-stable timestamps (avoid end-of-day edge flakiness on Preview).
+  const saleAt = new Date();
+  saleAt.setUTCHours(12, 0, 0, 0);
+  const laterAt = new Date(saleAt.getTime() + 2 * 60 * 60 * 1000);
+
+  const db = new Client({ connectionString: dbUrl, ssl: { rejectUnauthorized: false } });
+  let browserHandles = [];
+  const checks = [];
+
+  try {
+    console.log('Preview host:', base.replace(/^https?:\/\//, ''));
+    console.log('Synthetic tag:', tag);
+
+    // Unauthenticated app access (SSO bypassed; app auth required)
+    {
+      const res = await fetchWithBypass(base, '/reports/dashboard?period=today', bypass);
+      const denied =
+        /\/login/i.test(res.url) ||
+        /name=["']email["']|Sign in|Log in/i.test(res.text) ||
+        res.status === 401 ||
+        res.status === 403;
+      assert(denied, `unauth reports should require login, got ${res.status} ${res.url}`);
+      assert(
+        !/Sales revenue|Money received/i.test(res.text) || /\/login/i.test(res.url),
+        'unauth unexpectedly saw Trading Report content'
+      );
+      checks.push({ name: 'unauthenticated_denied', status: res.status, finalUrl: res.url });
+      console.log('PASS unauthenticated denied', res.status, res.url);
+    }
+
+    await db.connect();
+
+    const trialEnds = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000);
+    await db.query(
+      `INSERT INTO "Business" (
+         id, name, currency, timezone, "subscriptionStatus",
+         "trialStartedAt", "trialEndsAt", "updatedAt"
+       ) VALUES ($1,$2,'GHS','Africa/Accra','TRIAL_ACTIVE',NOW(),$3,NOW())`,
+      [ids.business, `Option B Preview ${stamp}`, trialEnds]
+    );
+
+    await db.query(
+      `INSERT INTO "Business" (
+         id, name, currency, timezone, "subscriptionStatus",
+         "trialStartedAt", "trialEndsAt", "updatedAt"
+       ) VALUES ($1,$2,'GHS','Africa/Accra','TRIAL_ACTIVE',NOW(),$3,NOW())`,
+      [ids.foreignBusiness, `Option B Foreign ${stamp}`, trialEnds]
+    );
+
+    await db.query(
+      `INSERT INTO "Store" (id, "businessId", name) VALUES ($1,$2,$3)`,
+      [ids.store, ids.business, 'Main Branch']
+    );
+    await db.query(
+      `INSERT INTO "Store" (id, "businessId", name) VALUES ($1,$2,$3)`,
+      [ids.foreignStore, ids.foreignBusiness, 'Foreign Branch']
+    );
+
+    await db.query(
+      `INSERT INTO "Till" (id, "storeId", name) VALUES ($1,$2,$3)`,
+      [ids.till, ids.store, 'Till 1']
+    );
+    await db.query(
+      `INSERT INTO "Till" (id, "storeId", name) VALUES ($1,$2,$3)`,
+      [ids.foreignTill, ids.foreignStore, 'Foreign Till']
+    );
+
+    for (const [id, email, name, role, businessId] of [
+      [ids.owner, ownerEmail, 'Option B Owner', 'OWNER', ids.business],
+      [ids.manager, managerEmail, 'Option B Manager', 'MANAGER', ids.business],
+      [ids.cashier, cashierEmail, 'Option B Cashier', 'CASHIER', ids.business],
+      [ids.foreignOwner, foreignEmail, 'Option B Foreign', 'OWNER', ids.foreignBusiness],
+    ]) {
+      await db.query(
+        `INSERT INTO "User" (id, "businessId", email, name, "passwordHash", role, active)
+         VALUES ($1,$2,$3,$4,$5,$6,true)`,
+        [id, businessId, email, name, passwordHash, role]
+      );
+    }
+
+    async function insertSale({ id, businessId, storeId, tillId, cashierUserId, paymentStatus, totalPence, createdAt, txn }) {
+      await db.query(
+        `INSERT INTO "SalesInvoice" (
+           id, "businessId", "storeId", "tillId", "cashierUserId", "paymentStatus",
+           "transactionNumber", "subtotalPence", "vatPence", "totalPence", "createdAt"
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,0,$8,$9)`,
+        [id, businessId, storeId, tillId, cashierUserId, paymentStatus, txn, totalPence, createdAt]
+      );
+    }
+
+    async function insertPayment({ id, salesInvoiceId, method, amountPence, receivedAt, reference }) {
+      await db.query(
+        `INSERT INTO "SalesPayment" (
+           id, "salesInvoiceId", method, "amountPence", "receivedAt", reference, status
+         ) VALUES ($1,$2,$3,$4,$5,$6,'CONFIRMED')`,
+        [id, salesInvoiceId, method, amountPence, receivedAt, reference || null]
+      );
+    }
+
+    await insertSale({
+      id: ids.saleCash,
+      businessId: ids.business,
+      storeId: ids.store,
+      tillId: ids.till,
+      cashierUserId: ids.cashier,
+      paymentStatus: 'PAID',
+      totalPence: 10000,
+      createdAt: saleAt,
+      txn: `OB-CASH-${stamp}`,
+    });
+    await insertPayment({
+      id: ids.payCash,
+      salesInvoiceId: ids.saleCash,
+      method: 'CASH',
+      amountPence: 10000,
+      receivedAt: saleAt,
+    });
+
+    await insertSale({
+      id: ids.saleMomo,
+      businessId: ids.business,
+      storeId: ids.store,
+      tillId: ids.till,
+      cashierUserId: ids.cashier,
+      paymentStatus: 'PAID',
+      totalPence: 6000,
+      createdAt: saleAt,
+      txn: `OB-MOMO-${stamp}`,
+    });
+    await insertPayment({
+      id: ids.payMomo,
+      salesInvoiceId: ids.saleMomo,
+      method: 'MOBILE_MONEY',
+      amountPence: 6000,
+      receivedAt: saleAt,
+      reference: `MOMO-REF-${stamp}`,
+    });
+
+    await insertSale({
+      id: ids.saleSplit,
+      businessId: ids.business,
+      storeId: ids.store,
+      tillId: ids.till,
+      cashierUserId: ids.cashier,
+      paymentStatus: 'PAID',
+      totalPence: 10000,
+      createdAt: saleAt,
+      txn: `OB-SPLIT-${stamp}`,
+    });
+    await insertPayment({
+      id: ids.paySplitCash,
+      salesInvoiceId: ids.saleSplit,
+      method: 'CASH',
+      amountPence: 4000,
+      receivedAt: saleAt,
+    });
+    await insertPayment({
+      id: ids.paySplitMomo,
+      salesInvoiceId: ids.saleSplit,
+      method: 'MOBILE_MONEY',
+      amountPence: 6000,
+      receivedAt: saleAt,
+    });
+
+    await insertSale({
+      id: ids.saleCredit,
+      businessId: ids.business,
+      storeId: ids.store,
+      tillId: ids.till,
+      cashierUserId: ids.cashier,
+      paymentStatus: 'PART_PAID',
+      totalPence: 10000,
+      createdAt: saleAt,
+      txn: `OB-CREDIT-${stamp}`,
+    });
+    await insertPayment({
+      id: ids.payCreditCash,
+      salesInvoiceId: ids.saleCredit,
+      method: 'CASH',
+      amountPence: 3000,
+      receivedAt: saleAt,
+    });
+    await insertPayment({
+      id: ids.payLaterMomo,
+      salesInvoiceId: ids.saleCredit,
+      method: 'MOBILE_MONEY',
+      amountPence: 4000,
+      receivedAt: laterAt,
+      reference: `LATER-MOMO-${stamp}`,
+    });
+    await insertPayment({
+      id: ids.payLaterCash,
+      salesInvoiceId: ids.saleCredit,
+      method: 'CASH',
+      amountPence: 3000,
+      receivedAt: laterAt,
+    });
+    await db.query(
+      `UPDATE "SalesInvoice" SET "paymentStatus" = 'PAID' WHERE id = $1`,
+      [ids.saleCredit]
+    );
+
+    await insertSale({
+      id: ids.foreignSale,
+      businessId: ids.foreignBusiness,
+      storeId: ids.foreignStore,
+      tillId: ids.foreignTill,
+      cashierUserId: ids.foreignOwner,
+      paymentStatus: 'PAID',
+      totalPence: 99900,
+      createdAt: saleAt,
+      txn: `OB-FOREIGN-${stamp}`,
+    });
+    await insertPayment({
+      id: ids.foreignPay,
+      salesInvoiceId: ids.foreignSale,
+      method: 'MOBILE_MONEY',
+      amountPence: 99900,
+      receivedAt: saleAt,
+    });
+
+    console.log('PASS seeded synthetic Preview dataset');
+
+    const ownerLogin = await loginWithPlaywright(base, ownerEmail, password, bypass);
+    assert(ownerLogin.ok, `owner login failed url=${ownerLogin.url}`);
+    browserHandles.push(ownerLogin);
+    const page = ownerLogin.page;
+
+    await page.goto(`${base}/`, { waitUntil: 'networkidle', timeout: 90000 });
+    await page.getByText(/Sales revenue/i).first().waitFor({ timeout: 60000 });
+    const revenueLink = await page
+      .locator('a[href*="/reports/dashboard"][href*="period=today"]')
+      .first()
+      .getAttribute('href')
+      .catch(() => null);
+    assert(revenueLink, 'Home Sales revenue Today deep-link missing');
+    assert(/storeId=/i.test(revenueLink), 'Home deep-link missing store scope');
+    const homeText = await page.locator('body').innerText();
+    assert(/360\.00/.test(homeText), 'Home Sales revenue missing expected GH₵360.00');
+    checks.push({ name: 'home_today_deeplink', href: revenueLink });
+    console.log('PASS Home Today deep-link', revenueLink);
+
+    const tradingPath = relHref(base, revenueLink);
+    await page.goto(`${base}${tradingPath}`, {
+      waitUntil: 'networkidle',
+      timeout: 90000,
+    });
+    await page.getByText(/Sales revenue/i).first().waitFor({ timeout: 60000 });
+    assert(/period=today/i.test(page.url()), `Trading Report lost Today: ${page.url()}`);
+    let tradingText = await page.locator('body').innerText();
+    assert(/Sales revenue/i.test(tradingText), 'Missing Sales revenue label');
+    assert(/Money received/i.test(tradingText), 'Missing Money received label');
+    assert(/360\.00/.test(tradingText), 'Trading Sales revenue missing GH₵360.00');
+    assert(/360\.00/.test(tradingText), 'Trading Money received should include GH₵360.00 total receipts');
+    checks.push({ name: 'trading_today_scope', url: page.url() });
+    console.log('PASS Trading Report Today scope + terminology + totals');
+
+    await page.reload({ waitUntil: 'networkidle' });
+    await page.getByText(/Sales revenue/i).first().waitFor({ timeout: 60000 });
+    assert(/period=today/i.test(page.url()), `Refresh lost Today: ${page.url()}`);
+    checks.push({ name: 'refresh_preserves_today' });
+    console.log('PASS refresh preserves Today');
+
+    const momoHref = await page
+      .locator('a[href*="/reports/receipts"][href*="MOBILE_MONEY"]')
+      .first()
+      .getAttribute('href')
+      .catch(() => null);
+    assert(momoHref, 'MoMo receipts drill-down link missing');
+    await page.goto(`${base}${relHref(base, momoHref)}`, {
+      waitUntil: 'networkidle',
+      timeout: 90000,
+    });
+    await page.getByText(/Money received/i).first().waitFor({ timeout: 60000 });
+    let receiptsText = await page.locator('body').innerText();
+    assert(/Money received/i.test(receiptsText), 'Receipts page missing title');
+    assert(/Received at sale/i.test(receiptsText), 'Missing received-at-sale classification');
+    assert(/Later credit collection/i.test(receiptsText), 'Missing later collection classification');
+    assert(
+      !/OB-FOREIGN|999\.00/.test(receiptsText),
+      'Foreign tenant payment leaked into MoMo drill-down'
+    );
+    assert(/60\.00/.test(receiptsText), 'Expected MoMo component amounts missing');
+    assert(/40\.00/.test(receiptsText), 'Expected later MoMo collection amount missing');
+    assert(
+      /MOMO-REF-|LATER-MOMO-|OB-MOMO-|OB-SPLIT-/i.test(receiptsText),
+      'Expected MoMo payment references/rows not visible'
+    );
+    checks.push({ name: 'momo_drilldown', url: page.url() });
+    console.log('PASS MoMo payment drill-down + classification');
+
+    await page.goto(
+      `${base}/reports/receipts?period=today&method=CASH&storeId=ALL`,
+      { waitUntil: 'networkidle', timeout: 90000 }
+    );
+    await page.getByText(/Money received|Cash/i).first().waitFor({ timeout: 60000 });
+    const cashText = await page.locator('body').innerText();
+    assert(/Received at sale|Later credit collection/i.test(cashText), 'Cash receipts incomplete');
+    assert(/100\.00|40\.00|30\.00/.test(cashText), 'Expected cash component amounts missing');
+    assert(!/OB-FOREIGN/i.test(cashText), 'Foreign sale leaked into cash receipts');
+    checks.push({ name: 'cash_drilldown' });
+    console.log('PASS Cash payment drill-down');
+
+    await page.goto(`${base}/reports/cash-drawer`, {
+      waitUntil: 'networkidle',
+      timeout: 90000,
+    });
+    await page.waitForTimeout(2000);
+    const drawerText = await page.locator('body').innerText();
+    assert(/physical cash/i.test(drawerText), 'Cash Drawer missing physical-cash scope copy');
+    const electronicLink = await page
+      .locator(
+        'a[href*="/reports/dashboard"], a[href*="/reports/receipts"], a[href*="money-received"]'
+      )
+      .first()
+      .getAttribute('href')
+      .catch(() => null);
+    assert(electronicLink, 'Cash Drawer electronic receipts route missing');
+    checks.push({ name: 'cash_drawer_scope', electronicLink });
+    console.log('PASS Cash Drawer physical-cash scope + signpost');
+
+    await ownerLogin.browser.close();
+    browserHandles = [];
+
+    const managerLogin = await loginWithPlaywright(base, managerEmail, password, bypass);
+    assert(managerLogin.ok, `manager login failed url=${managerLogin.url}`);
+    browserHandles.push(managerLogin);
+    await managerLogin.page.goto(
+      `${base}/reports/dashboard?period=today&storeId=${ids.foreignStore}`,
+      { waitUntil: 'domcontentloaded', timeout: 90000 }
+    );
+    await managerLogin.page.waitForTimeout(3000);
+    const mgrText = await managerLogin.page.locator('body').innerText();
+    assert(!/999\.00|OB-FOREIGN/i.test(mgrText), 'Manager saw foreign branch/sale data');
+    checks.push({ name: 'manager_foreign_branch_blocked' });
+    console.log('PASS manager foreign branch parameter blocked');
+    await managerLogin.browser.close();
+    browserHandles = [];
+
+    const cashierLogin = await loginWithPlaywright(base, cashierEmail, password, bypass);
+    assert(cashierLogin.ok, `cashier login failed url=${cashierLogin.url}`);
+    browserHandles.push(cashierLogin);
+    await cashierLogin.page.goto(`${base}/reports/receipts?period=today`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 90000,
+    });
+    await cashierLogin.page.waitForTimeout(3000);
+    const cashierUrl = cashierLogin.page.url();
+    const cashierText = await cashierLogin.page.locator('body').innerText();
+    const cashierDenied =
+      /login|not authorised|not authorized|forbidden|access denied|don't have|do not have|restricted|home/i.test(
+        `${cashierUrl} ${cashierText}`
+      ) || !/Money received/i.test(cashierText);
+    assert(cashierDenied, 'Cashier unexpectedly accessed Money Received report');
+    checks.push({ name: 'cashier_receipts_restricted', url: cashierUrl });
+    console.log('PASS cashier receipts restricted');
+    await cashierLogin.browser.close();
+    browserHandles = [];
+
+    console.log(
+      JSON.stringify(
+        {
+          tag,
+          expectedRevenuePence: 36000,
+          expectedCashReceiptsPence: 20000,
+          expectedMomoReceiptsPence: 16000,
+          checks: checks.map((c) => c.name),
+        },
+        null,
+        2
+      )
+    );
+    console.log('PASS Option B Preview synthetic verification');
+  } catch (err) {
+    console.error('FAIL', err && err.message ? err.message : err);
+    if (err && err.cause) console.error('CAUSE', err.cause);
+    process.exit(err.exitCode || 1);
+  } finally {
+    for (const h of browserHandles) {
+      try {
+        await h.browser.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      if (db._connected || db._ending === false) {
+        /* best-effort cleanup of this run only */
+      }
+      await db.query(`DELETE FROM "SalesPayment" WHERE id = ANY($1::text[])`, [
+        [
+          ids.payCash,
+          ids.payMomo,
+          ids.paySplitCash,
+          ids.paySplitMomo,
+          ids.payCreditCash,
+          ids.payLaterMomo,
+          ids.payLaterCash,
+          ids.foreignPay,
+        ],
+      ]);
+      await db.query(`DELETE FROM "SalesInvoice" WHERE id = ANY($1::text[])`, [
+        [ids.saleCash, ids.saleMomo, ids.saleSplit, ids.saleCredit, ids.foreignSale],
+      ]);
+      await db.query(`DELETE FROM "Till" WHERE id = ANY($1::text[])`, [
+        [ids.till, ids.foreignTill],
+      ]);
+      await db.query(`DELETE FROM "User" WHERE id = ANY($1::text[])`, [
+        [ids.owner, ids.manager, ids.cashier, ids.foreignOwner],
+      ]);
+      await db.query(`DELETE FROM "Store" WHERE id = ANY($1::text[])`, [
+        [ids.store, ids.foreignStore],
+      ]);
+      await db.query(`DELETE FROM "Business" WHERE id = ANY($1::text[])`, [
+        [ids.business, ids.foreignBusiness],
+      ]);
+      console.log('CLEANUP removed synthetic Preview rows for', tag);
+    } catch (cleanupErr) {
+      console.error('CLEANUP warning', cleanupErr.message || cleanupErr);
+    }
+    try {
+      await db.end();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+main();

--- a/scripts/reporting-option-b-preview-probe.cjs
+++ b/scripts/reporting-option-b-preview-probe.cjs
@@ -580,16 +580,71 @@ async function main() {
     const managerLogin = await loginWithPlaywright(base, managerEmail, password, bypass);
     assert(managerLogin.ok, `manager login failed url=${managerLogin.url}`);
     browserHandles.push(managerLogin);
+
+    // Valid own store and explicit ALL remain authorised.
     await managerLogin.page.goto(
-      `${base}/reports/dashboard?period=today&storeId=${ids.foreignStore}`,
+      `${base}/reports/dashboard?period=today&storeId=${ids.store}`,
       { waitUntil: 'domcontentloaded', timeout: 90000 }
     );
-    await managerLogin.page.waitForTimeout(3000);
-    const mgrText = await managerLogin.page.locator('body').innerText();
-    assert(!/999\.00|OB-FOREIGN/i.test(mgrText), 'Manager saw foreign branch/sale data');
-    checks.push({ name: 'manager_foreign_branch_blocked' });
-    console.log('PASS manager foreign branch parameter blocked');
+    await managerLogin.page.waitForTimeout(2500);
+    const validStoreText = await managerLogin.page.locator('body').innerText();
+    assert(/Sales revenue|Money received/i.test(validStoreText), 'Valid store scope should render Trading Report');
+    assert(!/999\.00|OB-FOREIGN/i.test(validStoreText), 'Valid store must not leak foreign tenant');
+    checks.push({ name: 'manager_valid_store' });
+
+    await managerLogin.page.goto(
+      `${base}/reports/dashboard?period=today&storeId=ALL`,
+      { waitUntil: 'domcontentloaded', timeout: 90000 }
+    );
+    await managerLogin.page.waitForTimeout(2500);
+    const allStoreText = await managerLogin.page.locator('body').innerText();
+    assert(/Sales revenue|Money received/i.test(allStoreText), 'Explicit ALL should render Trading Report');
+    assert(!/999\.00|OB-FOREIGN/i.test(allStoreText), 'ALL scope must not leak foreign tenant');
+    checks.push({ name: 'manager_explicit_all' });
+
+    // Foreign / unknown / blank store must fail closed (404), never broaden to ALL.
+    for (const [label, storeParam] of [
+      ['foreign', ids.foreignStore],
+      ['unknown', 'store_does_not_exist_zzzz'],
+      ['blank', ''],
+    ]) {
+      const path =
+        storeParam === ''
+          ? `${base}/reports/dashboard?period=today&storeId=`
+          : `${base}/reports/dashboard?period=today&storeId=${storeParam}`;
+      await managerLogin.page.goto(path, { waitUntil: 'domcontentloaded', timeout: 90000 });
+      await managerLogin.page.waitForTimeout(2000);
+      const statusish = await managerLogin.page.locator('body').innerText();
+      const url = managerLogin.page.url();
+      const denied =
+        /not found|404|doesn.?t exist|page could not be found/i.test(statusish)
+        || /\/_not-found|404/i.test(url)
+        || !/Money received/i.test(statusish);
+      assert(denied, `${label} storeId must fail closed, got url=${url}`);
+      assert(!/999\.00|OB-FOREIGN/i.test(statusish), `${label} storeId must not reveal foreign totals`);
+      checks.push({ name: `manager_${label}_store_fail_closed` });
+    }
+    console.log('PASS manager store-scope fail-closed (foreign/unknown/blank)');
     await managerLogin.browser.close();
+    browserHandles = [];
+
+    // Receipts list must fail closed consistently with summary.
+    const owner2 = await loginWithPlaywright(base, ownerEmail, password, bypass);
+    assert(owner2.ok, `owner re-login failed url=${owner2.url}`);
+    browserHandles.push(owner2);
+    await owner2.page.goto(
+      `${base}/reports/receipts?period=today&storeId=${ids.foreignStore}&page=2`,
+      { waitUntil: 'domcontentloaded', timeout: 90000 }
+    );
+    await owner2.page.waitForTimeout(2000);
+    const receiptsDeniedText = await owner2.page.locator('body').innerText();
+    const receiptsDenied =
+      /not found|404|doesn.?t exist|page could not be found/i.test(receiptsDeniedText)
+      || !/Money received/i.test(receiptsDeniedText);
+    assert(receiptsDenied, 'Receipts foreign store must fail closed (including page>1)');
+    assert(!/999\.00|OB-FOREIGN/i.test(receiptsDeniedText), 'Receipts must not leak foreign rows via pagination');
+    checks.push({ name: 'receipts_foreign_store_fail_closed' });
+    await owner2.browser.close();
     browserHandles = [];
 
     const cashierLogin = await loginWithPlaywright(base, cashierEmail, password, bypass);

--- a/scripts/reporting-option-b-preview-probe.cjs
+++ b/scripts/reporting-option-b-preview-probe.cjs
@@ -269,12 +269,12 @@ async function main() {
       );
     }
 
-    async function insertPayment({ id, salesInvoiceId, method, amountPence, receivedAt, reference }) {
+    async function insertPayment({ id, salesInvoiceId, method, amountPence, receivedAt, reference, receiptOrigin }) {
       await db.query(
         `INSERT INTO "SalesPayment" (
-           id, "salesInvoiceId", method, "amountPence", "receivedAt", reference, status
-         ) VALUES ($1,$2,$3,$4,$5,$6,'CONFIRMED')`,
-        [id, salesInvoiceId, method, amountPence, receivedAt, reference || null]
+           id, "salesInvoiceId", method, "amountPence", "receivedAt", reference, status, "receiptOrigin"
+         ) VALUES ($1,$2,$3,$4,$5,$6,'CONFIRMED',$7)`,
+        [id, salesInvoiceId, method, amountPence, receivedAt, reference || null, receiptOrigin ?? null]
       );
     }
 
@@ -295,6 +295,7 @@ async function main() {
       method: 'CASH',
       amountPence: 10000,
       receivedAt: saleAt,
+      receiptOrigin: 'RECEIVED_AT_SALE',
     });
 
     await insertSale({
@@ -315,6 +316,7 @@ async function main() {
       amountPence: 6000,
       receivedAt: saleAt,
       reference: `MOMO-REF-${stamp}`,
+      receiptOrigin: 'RECEIVED_AT_SALE',
     });
 
     await insertSale({
@@ -334,6 +336,7 @@ async function main() {
       method: 'CASH',
       amountPence: 4000,
       receivedAt: saleAt,
+      receiptOrigin: 'RECEIVED_AT_SALE',
     });
     await insertPayment({
       id: ids.paySplitMomo,
@@ -341,6 +344,7 @@ async function main() {
       method: 'MOBILE_MONEY',
       amountPence: 6000,
       receivedAt: saleAt,
+      receiptOrigin: 'RECEIVED_AT_SALE',
     });
 
     await insertSale({
@@ -360,6 +364,7 @@ async function main() {
       method: 'CASH',
       amountPence: 3000,
       receivedAt: saleAt,
+      receiptOrigin: 'RECEIVED_AT_SALE',
     });
     await insertPayment({
       id: ids.payLaterMomo,
@@ -368,6 +373,7 @@ async function main() {
       amountPence: 4000,
       receivedAt: laterAt,
       reference: `LATER-MOMO-${stamp}`,
+      receiptOrigin: 'LATER_CREDIT_COLLECTION',
     });
     await insertPayment({
       id: ids.payLaterCash,
@@ -375,11 +381,33 @@ async function main() {
       method: 'CASH',
       amountPence: 3000,
       receivedAt: laterAt,
+      receiptOrigin: 'LATER_CREDIT_COLLECTION',
     });
     await db.query(
       `UPDATE "SalesInvoice" SET "paymentStatus" = 'PAID' WHERE id = $1`,
       [ids.saleCredit]
     );
+
+    // Historical NULL-origin row (same day) — must stay unclassified in UI.
+    await insertSale({
+      id: `${ids.saleCash}-hist`,
+      businessId: ids.business,
+      storeId: ids.store,
+      tillId: ids.till,
+      cashierUserId: ids.cashier,
+      paymentStatus: 'PAID',
+      totalPence: 1200,
+      createdAt: saleAt,
+      txn: `OB-HIST-${stamp}`,
+    });
+    await insertPayment({
+      id: `${ids.payCash}-hist`,
+      salesInvoiceId: `${ids.saleCash}-hist`,
+      method: 'CARD',
+      amountPence: 1200,
+      receivedAt: saleAt,
+      receiptOrigin: null,
+    });
 
     await insertSale({
       id: ids.foreignSale,
@@ -398,6 +426,7 @@ async function main() {
       method: 'MOBILE_MONEY',
       amountPence: 99900,
       receivedAt: saleAt,
+      receiptOrigin: 'RECEIVED_AT_SALE',
     });
 
     console.log('PASS seeded synthetic Preview dataset');
@@ -417,7 +446,7 @@ async function main() {
     assert(revenueLink, 'Home Sales revenue Today deep-link missing');
     assert(/storeId=/i.test(revenueLink), 'Home deep-link missing store scope');
     const homeText = await page.locator('body').innerText();
-    assert(/360\.00/.test(homeText), 'Home Sales revenue missing expected GH₵360.00');
+    assert(/372\.00/.test(homeText), 'Home Sales revenue missing expected GH₵372.00');
     checks.push({ name: 'home_today_deeplink', href: revenueLink });
     console.log('PASS Home Today deep-link', revenueLink);
 
@@ -431,8 +460,11 @@ async function main() {
     let tradingText = await page.locator('body').innerText();
     assert(/Sales revenue/i.test(tradingText), 'Missing Sales revenue label');
     assert(/Money received/i.test(tradingText), 'Missing Money received label');
-    assert(/360\.00/.test(tradingText), 'Trading Sales revenue missing GH₵360.00');
-    assert(/360\.00/.test(tradingText), 'Trading Money received should include GH₵360.00 total receipts');
+    assert(/372\.00/.test(tradingText), 'Trading Sales revenue missing GH₵372.00');
+    assert(/372\.00/.test(tradingText), 'Trading Money received should include GH₵372.00 total receipts');
+    assert(/Historical — not classified|Historical - not classified/i.test(tradingText), 'Missing unknown-origin bucket');
+    assert(/Received at sale/i.test(tradingText), 'Missing received-at-sale bucket');
+    assert(/Later credit collected/i.test(tradingText), 'Missing later-collection bucket');
     checks.push({ name: 'trading_today_scope', url: page.url() });
     console.log('PASS Trading Report Today scope + terminology + totals');
 
@@ -457,6 +489,22 @@ async function main() {
     assert(/Money received/i.test(receiptsText), 'Receipts page missing title');
     assert(/Received at sale/i.test(receiptsText), 'Missing received-at-sale classification');
     assert(/Later credit collection/i.test(receiptsText), 'Missing later collection classification');
+    // Origin filter for historical NULL rows
+    await page.goto(
+      `${base}/reports/receipts?period=today&origin=UNCLASSIFIED&storeId=ALL`,
+      { waitUntil: 'networkidle', timeout: 90000 }
+    );
+    const histText = await page.locator('body').innerText();
+    assert(/Historical — not classified|Historical - not classified/i.test(histText), 'NULL origin label missing');
+    assert(/12\.00/.test(histText), 'Historical NULL payment amount missing');
+    assert(!/OB-FOREIGN|999\.00/.test(histText), 'Foreign tenant leaked into origin filter');
+    checks.push({ name: 'unknown_origin_filter' });
+    console.log('PASS historical NULL origin filter');
+    await page.goto(`${base}${relHref(base, momoHref)}`, {
+      waitUntil: 'networkidle',
+      timeout: 90000,
+    });
+    receiptsText = await page.locator('body').innerText();
     assert(
       !/OB-FOREIGN|999\.00/.test(receiptsText),
       'Foreign tenant payment leaked into MoMo drill-down'
@@ -571,6 +619,7 @@ async function main() {
       await db.query(`DELETE FROM "SalesPayment" WHERE id = ANY($1::text[])`, [
         [
           ids.payCash,
+          `${ids.payCash}-hist`,
           ids.payMomo,
           ids.paySplitCash,
           ids.paySplitMomo,
@@ -581,7 +630,7 @@ async function main() {
         ],
       ]);
       await db.query(`DELETE FROM "SalesInvoice" WHERE id = ANY($1::text[])`, [
-        [ids.saleCash, ids.saleMomo, ids.saleSplit, ids.saleCredit, ids.foreignSale],
+        [ids.saleCash, `${ids.saleCash}-hist`, ids.saleMomo, ids.saleSplit, ids.saleCredit, ids.foreignSale],
       ]);
       await db.query(`DELETE FROM "Till" WHERE id = ANY($1::text[])`, [
         [ids.till, ids.foreignTill],

--- a/scripts/reporting-option-b-preview-probe.cjs
+++ b/scripts/reporting-option-b-preview-probe.cjs
@@ -586,9 +586,9 @@ async function main() {
       `${base}/reports/dashboard?period=today&storeId=${ids.store}`,
       { waitUntil: 'domcontentloaded', timeout: 90000 }
     );
-    await managerLogin.page.waitForTimeout(2500);
+    await managerLogin.page.getByText(/Sales revenue|Money received|Trading Report/i).first().waitFor({ timeout: 60000 });
     const validStoreText = await managerLogin.page.locator('body').innerText();
-    assert(/Sales revenue|Money received/i.test(validStoreText), 'Valid store scope should render Trading Report');
+    assert(/Sales revenue|Money received|Trading Report/i.test(validStoreText), 'Valid store scope should render Trading Report');
     assert(!/999\.00|OB-FOREIGN/i.test(validStoreText), 'Valid store must not leak foreign tenant');
     checks.push({ name: 'manager_valid_store' });
 
@@ -596,9 +596,9 @@ async function main() {
       `${base}/reports/dashboard?period=today&storeId=ALL`,
       { waitUntil: 'domcontentloaded', timeout: 90000 }
     );
-    await managerLogin.page.waitForTimeout(2500);
+    await managerLogin.page.getByText(/Sales revenue|Money received|Trading Report/i).first().waitFor({ timeout: 60000 });
     const allStoreText = await managerLogin.page.locator('body').innerText();
-    assert(/Sales revenue|Money received/i.test(allStoreText), 'Explicit ALL should render Trading Report');
+    assert(/Sales revenue|Money received|Trading Report/i.test(allStoreText), 'Explicit ALL should render Trading Report');
     assert(!/999\.00|OB-FOREIGN/i.test(allStoreText), 'ALL scope must not leak foreign tenant');
     checks.push({ name: 'manager_explicit_all' });
 


### PR DESCRIPTION
## Summary - Preserve Home **Sales revenue** drill-down scope: Trading Report opens with `period=today` (and matching `from`/`to`/`storeId`) using the business timezone (inclusive start / exclusive end). - Shared server contracts for sales revenue and money received; Trading Report separates **Sales revenue** from **Money received**. - New `/reports/receipts` payment-record drill-down (paginated `SalesPayment` rows ÔÇö not Sales History), with receipt-origin filter. - Cash Drawer remains physical-cash-only with clearer links to electronic receipts. - Consumes PR #85ÔÇÖs persisted `SalesPayment.receiptOrigin` ÔÇö **no PR #84 schema migration, no backfill, no payment-write changes**. - **Money received summary uses complete DB aggregation** (no `take: 20_000` in-memory truncation).  ## Payment origin (PR #85 dependency) - Authoritative forward origins: `RECEIVED_AT_SALE`, `LATER_CREDIT_COLLECTION`, `UNCLASSIFIED`. - Historical `NULL` remains explicitly unknown (`Historical ÔÇö not classified`); never inferred from timestamps. - The five-minute / timestamp-proximity heuristic has been **removed** from reporting. - Known-origin subtotals do not claim to represent all receipts when unknown rows exist; total Money received still reconciles including the unknown bucket.  ## Authoritative rebase / head | Item | Value | | --- | --- | | Rebase baseline / live master | `a3c0b3c10d138f31355e6b15eb7bc28226270a69` | | New immutable head | `2fb8e97f86c69ee96f46e3539121cf3ee7a4edfe` | | Production | `5809444614` / `dpl_4nE42hL3Zb4ioeJJRFsffd9uaQBG` @ `a3c0b3c1ÔÇª` ÔÇö **unchanged** | | Preview | GitHub `5810008073` / Vercel `dpl_4q1XfyeigqtLnwS3s74jKrmaqGiy` @ final head | | Schema / migration in this PR | **None** |  ## Same-SHA validation (head `2fb8e97f`) - CI: https://github.com/joshowusu-alt/TillFlow/actions/runs/31264227796 - Postgres Smoke (Money received + scale 20k/20,001/50k): https://github.com/joshowusu-alt/TillFlow/actions/runs/31264227812 - Preview synthetic probe: exit `0`  ## Human review **Eligible for a separate explicit human merge and Production-release decision.** This description does not authorise merge or Production deployment.

---

### Unknown method remediation (head `b1a7a207e94fd4707928342acb9213fcd0243727`)
- Explicit **Unknown/Other** bucket for every non-exact CASH/CARD/TRANSFER/MOBILE_MONEY value.
- Identities: `totalPence/totalCount = Σ method buckets including UNKNOWN`.
- Evidence: see latest remediation comment on this PR.