### PR TITLE
feat(payments): payment receipt-origin foundation (forward-only schema)

### DIFF
--- a/.github/workflows/postgres-smoke.yml
+++ b/.github/workflows/postgres-smoke.yml
@@ -10,8 +10,11 @@ on:
       - 'scripts/migration-p1-schema-pg-test.cjs'
       - 'scripts/migration-p1-slice2a-pg-test.cjs'
       - 'scripts/migration-p1-sql-only-constraint-contract.cjs'
+      - 'scripts/payment-receipt-origin-pg-test.cjs'
+      - 'lib/payments/**'
       - 'docs/migration/P1_SLICE1_SQL_ONLY_CONSTRAINTS.md'
       - 'docs/migration/P1_SLICE2A_CONTRACT.md'
+      - 'docs/payments/**'
       - 'lib/migration/**'
       - 'lib/services/migration/**'
       - '.github/workflows/postgres-smoke.yml'
@@ -70,6 +73,9 @@ jobs:
 
       - name: Migration P1 Slice 2A PostgreSQL behavioural suite
         run: node scripts/migration-p1-slice2a-pg-test.cjs
+
+      - name: Payment receipt-origin PostgreSQL behavioural suite
+        run: npm run test:payment-receipt-origin:pg
 
       - name: SQL-only constraint-contract introspection
         run: node scripts/migration-p1-sql-only-constraint-contract.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ dev.db-shm
 /prisma/dev.db-journal
 /prisma/dev.db-wal
 /prisma/dev.db-shm
+/prisma/dev-origin.db
+/prisma/*.db
+/prisma/*.db-journal
+/prisma/*.db-wal
+/prisma/*.db-shm
 test.txt
 
 .vercel
@@ -37,5 +42,7 @@ perf.db-journal
 
 # Local visual QA evidence (never commit)
 /tmp/home-qa/
+/tmp/*.local.env
+/tmp/*preview*.env
 
 .env*.local

--- a/app/actions/backup.ts
+++ b/app/actions/backup.ts
@@ -7,6 +7,7 @@ import { cookies } from 'next/headers';
 import { withBusinessContext, safeAction, ok, err, type ActionResult } from '@/lib/action-utils';
 import { audit } from '@/lib/audit';
 import { ACTIVE_BUSINESS_COOKIE, SESSION_COOKIE_PREFIX } from '@/lib/business-scope';
+import { parseOptionalReceiptOrigin } from '@/lib/payments/receipt-origin';
 
 export interface BackupData {
     version: string;
@@ -105,7 +106,7 @@ export async function exportDatabaseAction(): Promise<ActionResult<BackupData>> 
         ]);
 
         const backupData: BackupData = {
-            version: '1.0',
+            version: '1.1',
             exportedAt: new Date().toISOString(),
             business,
             stores,
@@ -360,7 +361,20 @@ export async function importDatabaseAction(backup: BackupData): Promise<ActionRe
       for (const payment of list(backup.salesPayments)) {
         // collectionId refs MobileMoneyCollection which is not included in the backup export,
         // so null it out to avoid FK constraint violation on restore.
-        await tx.salesPayment.create({ data: { ...payment, collectionId: null } });
+        // receiptOrigin: preserve valid new-format values; missing/empty → NULL (legacy unclassified).
+        // Invalid values fail the restore rather than fabricating origin.
+        const { collectionId: _ignoredCollectionId, receiptOrigin: rawOrigin, ...rest } = payment as Record<
+          string,
+          unknown
+        >;
+        const receiptOrigin = parseOptionalReceiptOrigin(rawOrigin);
+        await tx.salesPayment.create({
+          data: {
+            ...rest,
+            collectionId: null,
+            ...(receiptOrigin != null ? { receiptOrigin } : { receiptOrigin: null }),
+          } as any,
+        });
       }
 
       for (const ret of list(backup.salesReturns)) {

--- a/app/actions/demo-day.ts
+++ b/app/actions/demo-day.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { requireBusiness } from '@/lib/auth';
 import { revalidatePath, revalidateTag } from 'next/cache';
 import { postJournalEntry, ensureChartOfAccounts, ACCOUNT_CODES } from '@/lib/accounting';
+import { RECEIPT_ORIGIN } from '@/lib/payments/receipt-origin';
 
 const DEMO_TAG = 'DEMO_DAY';
 const SAMPLE_STOCK_ADJUSTMENT_REASONS = new Set([
@@ -143,7 +144,7 @@ export async function generateDemoDay(): Promise<{ ok: boolean; salesCount: numb
     lineVatPence: number;
   }[] = [];
   const paymentBatch: {
-    salesInvoiceId: string; method: string; amountPence: number;
+    salesInvoiceId: string; method: string; amountPence: number; receiptOrigin: string;
   }[] = [];
 
   for (let day = 6; day >= 0; day--) {
@@ -214,6 +215,8 @@ export async function generateDemoDay(): Promise<{ ok: boolean; salesCount: numb
         salesInvoiceId: invoiceId,
         method: nextRand() > 0.7 ? 'MOBILE_MONEY' : 'CASH',
         amountPence: subtotal,
+        // Demo generator creates sale-time payments for each demo invoice.
+        receiptOrigin: RECEIPT_ORIGIN.RECEIVED_AT_SALE,
       });
     }
   }

--- a/docs/payments/RECEIPT_ORIGIN_FOUNDATION.md
+++ b/docs/payments/RECEIPT_ORIGIN_FOUNDATION.md
@@ -1,0 +1,151 @@
+# Payment receipt-origin foundation
+
+Forward-only durable origin on `SalesPayment` so reporting can later distinguish sale-time receipts from later credit collections **without timestamp heuristics**.
+
+## Problem (Outcome C)
+
+Existing `SalesPayment` rows cannot reliably distinguish:
+
+- `RECEIVED_AT_SALE`
+- `LATER_CREDIT_COLLECTION`
+
+Sparse signals (`collectionId`, drawer/JE linkage, invoice timestamps) are insufficient. A five-minute `receivedAt` vs invoice `createdAt` grace is **false accounting logic** and must not be used.
+
+## Schema contract
+
+| Item | Value |
+|------|--------|
+| Field | `SalesPayment.receiptOrigin` |
+| Type | nullable `TEXT` / Prisma `String?` |
+| Allowed values | `RECEIVED_AT_SALE`, `LATER_CREDIT_COLLECTION`, `UNCLASSIFIED`, or `NULL` |
+| DB constraint | CHECK allowing NULL or the three literals |
+| Default rewrite | **None** — no `DEFAULT` that mutates historical rows |
+
+### Enum semantics
+
+- **RECEIVED_AT_SALE** — money recorded through the authoritative original sale/checkout workflow, including each split-tender component and part-paid deposits created with the invoice.
+- **LATER_CREDIT_COLLECTION** — money recorded through the debtor/customer-payment workflow after the sale already exists. Provenance is the workflow, not elapsed time.
+- **UNCLASSIFIED** — the system lacks durable evidence for either classification (legacy, restore/import without provenance, amendment/refund where the action does not establish meaning).
+
+### Historical-record contract
+
+```text
+NULL on pre-existing record = historical UNCLASSIFIED
+```
+
+Reads use `resolveReceiptOrigin(null) → UNCLASSIFIED`.
+
+New application write paths **must** persist a non-null enum value.
+
+A bulk UPDATE of historical rows to `UNCLASSIFIED` is **not** authorised in this foundation (material data migration; not required for honesty when NULL means unclassified).
+
+## Why nullable (not non-null + default)
+
+- Avoids rewriting every historical payment merely to store “unknown”.
+- Additive `ADD COLUMN` is compatible with old app builds that ignore the column.
+- No table-wide DEFAULT fill; locking risk is limited to a metadata DDL on Postgres (not a full-row rewrite of payment amounts/methods).
+- Rollback drops the column (origin data lost); payment money fields remain intact.
+
+## Migration
+
+`prisma/migrations/20260808120000_sales_payment_receipt_origin/migration.sql`
+
+- `ALTER TABLE "SalesPayment" ADD COLUMN "receiptOrigin" TEXT;`
+- CHECK constraint for NULL or the three values
+- No index (no demonstrated query need in this foundation)
+
+### Lock / rewrite analysis
+
+- Additive nullable column + CHECK: Postgres acquires `ACCESS EXCLUSIVE` briefly for `ADD COLUMN` without rewrite when no DEFAULT is set (PG 11+).
+- Does **not** change payment amounts, methods, dates, invoice links, branches, or statuses.
+- Expected: payment count and sum of amounts unchanged across the migration itself.
+
+### Deployment compatibility
+
+- Old code running during rollout: ignores unknown column; continues writing without origin (acceptable only during overlap; new code requires origin).
+- New code reading historical rows: treats NULL as unclassified.
+- Rollback to previous app version: safe for money fields; new column unused.
+- Production migrate is **not** authorised by this foundation PR alone — Preview-only migrate for proof.
+
+## Domain contract
+
+`lib/payments/receipt-origin.ts`
+
+- Typed literals + `RECEIPT_ORIGIN` constants
+- `resolveReceiptOrigin` for reads
+- `parseOptionalReceiptOrigin` for backup/import (missing → null; invalid → throw)
+- `withReceiptOrigin` helper for intentional construction
+
+## Write-site inventory (creates)
+
+| Site | Mechanism | Assigned origin |
+|------|-----------|-----------------|
+| `lib/services/sales.ts` checkout nested `payments.create` | Original sale / split / part-paid deposit | `RECEIVED_AT_SALE` |
+| `lib/services/payments.ts` `recordCustomerPayment` `createMany` | Debtor collection | `LATER_CREDIT_COLLECTION` |
+| `lib/services/sales.ts` amend +payment / −refund | Amendment business action | `UNCLASSIFIED` |
+| `app/actions/demo-day.ts` `createMany` | Demo generator | `RECEIVED_AT_SALE` |
+| `app/actions/backup.ts` restore `create` | Backup restore | Preserve valid / NULL if missing |
+
+Non-create paths inspected:
+
+- MoMo status updates: `updateMany` only (no create).
+- Returns / voids: `SalesReturn` + stock/journal; **no** `SalesPayment` create.
+- Offline sale: routes into `createSale` checkout path.
+- Import migration CSV (P1): no `SalesPayment` create in Slice 2A/2B paths inspected for this foundation.
+
+## Assignment matrix
+
+| Write path | Assigned origin | Reason | Persisted explicitly |
+|------------|-----------------|--------|----------------------|
+| Original checkout payment | `RECEIVED_AT_SALE` | Sale workflow | Yes |
+| Split-tender component | `RECEIVED_AT_SALE` | Component of original sale | Yes |
+| Part-paid deposit at checkout | `RECEIVED_AT_SALE` | Created with original sale | Yes |
+| Debtor cash payment | `LATER_CREDIT_COLLECTION` | Customer-payment workflow | Yes |
+| Debtor MoMo payment | `LATER_CREDIT_COLLECTION` | Customer-payment workflow | Yes |
+| Multiple later collections | `LATER_CREDIT_COLLECTION` | Collection workflow | Yes |
+| Imported payment without proven source | `UNCLASSIFIED` / NULL | Origin unavailable | Yes |
+| Restored legacy payment missing origin | NULL → unclassified | Preserve truth | Yes |
+| Demo/seed payment | `RECEIVED_AT_SALE` | Deterministic fixture | Yes |
+| Amendment-created payment | `UNCLASSIFIED` | Amend does not establish sale vs collection | Yes |
+| Negative amendment refund | `UNCLASSIFIED` | Direction via amount sign; not a receipt substitute | Yes |
+
+## Refund / reversal / return / void contract
+
+TillFlow does **not** model refunds as a separate refund entity linked to the original payment row.
+
+| Concern | Behaviour |
+|---------|-----------|
+| Receipt origin | Amendment refund/add → `UNCLASSIFIED` (honest) |
+| Payment direction | Negative `amountPence` on `SalesPayment` for amend refunds |
+| Payment status | Invoice `paymentStatus` recomputed from payment sum |
+| Refund relationship | No durable FK from refund payment → original payment |
+| Money-received reporting | Must filter/sign-aware; origin alone is not a reversal model |
+| Payment-method totals | Include signed amounts as today |
+| Cash Drawer | Separate `CASH_REFUND` / payment entries where cash |
+| Invoice revenue | Invoice totals / lines; returns use `SalesReturn` |
+| Returns / voids | No new `SalesPayment`; stock + return records |
+
+**Blocker (separate):** a true payment-reversal relationship model is out of scope. Origin must not substitute for it.
+
+## Backup / restore / import
+
+- Export version bumped to **1.1** (includes `receiptOrigin` when present on rows).
+- Old 1.0 backups without the field restore successfully → `receiptOrigin` NULL.
+- New backups preserve explicit origins on round trip.
+- Invalid enum values fail restore clearly (`parseOptionalReceiptOrigin`).
+- No timestamp fabrication.
+
+## Out of scope (this PR)
+
+- Trading Report classification UI / receipts drill-down (PR #84)
+- Five-minute heuristics
+- Historical speculative backfill
+- Production migrate/deploy
+- Modifying PR #83 or PR #84
+
+## Tests
+
+- Unit: `lib/payments/receipt-origin*.test.ts`, payments/sales regressions
+- PostgreSQL (must not skip): `npm run test:payment-receipt-origin:pg`
+- CI: `.github/workflows/postgres-smoke.yml`
+- Preview probe: `scripts/payment-receipt-origin-preview-probe.cjs`

--- a/lib/payments/receipt-origin-write-paths.test.ts
+++ b/lib/payments/receipt-origin-write-paths.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Write-path inventory tests: every live SalesPayment create site must assign
+ * an explicit receiptOrigin (no silent omission, no timestamp heuristic).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+
+function read(rel: string) {
+  return readFileSync(join(root, rel), 'utf8');
+}
+
+describe('receipt-origin write-path inventory', () => {
+  it('checkout nested payment creates persist RECEIVED_AT_SALE', () => {
+    const sales = read('lib/services/sales.ts');
+    expect(sales).toContain("from '@/lib/payments/receipt-origin'");
+    expect(sales).toContain('receiptOrigin: RECEIPT_ORIGIN.RECEIVED_AT_SALE');
+    expect(sales).not.toContain('SALE_RECEIPT_GRACE');
+    expect(sales).not.toContain('5 * 60 * 1000');
+  });
+
+  it('debtor collections persist LATER_CREDIT_COLLECTION', () => {
+    const payments = read('lib/services/payments.ts');
+    expect(payments).toContain('receiptOrigin: RECEIPT_ORIGIN.LATER_CREDIT_COLLECTION');
+  });
+
+  it('sale amendments persist UNCLASSIFIED for add and refund payment rows', () => {
+    const sales = read('lib/services/sales.ts');
+    const unclassifiedWrites = sales.match(
+      /receiptOrigin:\s*RECEIPT_ORIGIN\.UNCLASSIFIED/g,
+    );
+    expect((unclassifiedWrites ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('demo-day sale payments persist RECEIVED_AT_SALE', () => {
+    const demo = read('app/actions/demo-day.ts');
+    expect(demo).toContain('receiptOrigin: RECEIPT_ORIGIN.RECEIVED_AT_SALE');
+  });
+
+  it('backup restore preserves or nulls origin without timestamp inference', () => {
+    const backup = read('app/actions/backup.ts');
+    expect(backup).toContain('parseOptionalReceiptOrigin');
+    expect(backup).toContain('receiptOrigin');
+    expect(backup).not.toMatch(/receivedAt\s*-\s*|Date\.now\(\).*receiptOrigin|receiptOrigin.*Date\.now/i);
+  });
+
+  it('no five-minute receipt heuristic is introduced', () => {
+    const classifyCandidates = [
+      'lib/payments/receipt-origin.ts',
+      'lib/services/sales.ts',
+      'lib/services/payments.ts',
+      'app/actions/backup.ts',
+      'app/actions/demo-day.ts',
+    ];
+    for (const rel of classifyCandidates) {
+      const src = read(rel);
+      expect(src).not.toMatch(/SALE_RECEIPT_GRACE|five.?minute|5\s*\*\s*60\s*\*\s*1000/i);
+    }
+  });
+});

--- a/lib/payments/receipt-origin.test.ts
+++ b/lib/payments/receipt-origin.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for receipt-origin domain contract (no DB).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  RECEIPT_ORIGIN,
+  isReceiptOrigin,
+  parseOptionalReceiptOrigin,
+  resolveReceiptOrigin,
+  withReceiptOrigin,
+} from '@/lib/payments/receipt-origin';
+
+describe('receipt-origin contract', () => {
+  it('accepts the three explicit origins', () => {
+    expect(isReceiptOrigin('RECEIVED_AT_SALE')).toBe(true);
+    expect(isReceiptOrigin('LATER_CREDIT_COLLECTION')).toBe(true);
+    expect(isReceiptOrigin('UNCLASSIFIED')).toBe(true);
+    expect(isReceiptOrigin('SALE')).toBe(false);
+    expect(isReceiptOrigin(null)).toBe(false);
+  });
+
+  it('maps legacy NULL to UNCLASSIFIED without inventing sale-time meaning', () => {
+    expect(resolveReceiptOrigin(null)).toBe(RECEIPT_ORIGIN.UNCLASSIFIED);
+    expect(resolveReceiptOrigin(undefined)).toBe(RECEIPT_ORIGIN.UNCLASSIFIED);
+    expect(resolveReceiptOrigin('')).toBe(RECEIPT_ORIGIN.UNCLASSIFIED);
+  });
+
+  it('preserves valid persisted origins on read', () => {
+    expect(resolveReceiptOrigin('RECEIVED_AT_SALE')).toBe(RECEIPT_ORIGIN.RECEIVED_AT_SALE);
+    expect(resolveReceiptOrigin('LATER_CREDIT_COLLECTION')).toBe(
+      RECEIPT_ORIGIN.LATER_CREDIT_COLLECTION,
+    );
+  });
+
+  it('parses optional backup/import origins safely', () => {
+    expect(parseOptionalReceiptOrigin(undefined)).toBeNull();
+    expect(parseOptionalReceiptOrigin(null)).toBeNull();
+    expect(parseOptionalReceiptOrigin('')).toBeNull();
+    expect(parseOptionalReceiptOrigin('RECEIVED_AT_SALE')).toBe('RECEIVED_AT_SALE');
+    expect(() => parseOptionalReceiptOrigin('YESTERDAY')).toThrow(/Invalid receiptOrigin/);
+  });
+
+  it('withReceiptOrigin attaches an explicit origin', () => {
+    expect(
+      withReceiptOrigin({ method: 'CASH', amountPence: 100 }, RECEIPT_ORIGIN.RECEIVED_AT_SALE),
+    ).toEqual({
+      method: 'CASH',
+      amountPence: 100,
+      receiptOrigin: 'RECEIVED_AT_SALE',
+    });
+  });
+});

--- a/lib/payments/receipt-origin.ts
+++ b/lib/payments/receipt-origin.ts
@@ -1,0 +1,68 @@
+/**
+ * Payment receipt-origin contract (forward-only foundation).
+ *
+ * Persisted on SalesPayment.receiptOrigin as a string (SQLite + Postgres).
+ *
+ * Semantics:
+ * - RECEIVED_AT_SALE — created by the authoritative original sale/checkout workflow
+ *   (including each split-tender component and part-paid deposits at checkout).
+ * - LATER_CREDIT_COLLECTION — created by the debtor/customer-payment collection
+ *   workflow after the sale already exists.
+ * - UNCLASSIFIED — durable origin is unavailable (legacy NULL, restore/import
+ *   without provenance, or amendment/refund rows where the business action does
+ *   not establish sale-time vs later-collection meaning).
+ *
+ * Historical NULL in the database is treated as UNCLASSIFIED for reads.
+ * Do not infer origin from timestamps, payment method, drawer, or journals.
+ */
+
+export const RECEIPT_ORIGINS = [
+  'RECEIVED_AT_SALE',
+  'LATER_CREDIT_COLLECTION',
+  'UNCLASSIFIED',
+] as const;
+
+export type ReceiptOrigin = (typeof RECEIPT_ORIGINS)[number];
+
+export const RECEIPT_ORIGIN = {
+  RECEIVED_AT_SALE: 'RECEIVED_AT_SALE',
+  LATER_CREDIT_COLLECTION: 'LATER_CREDIT_COLLECTION',
+  UNCLASSIFIED: 'UNCLASSIFIED',
+} as const satisfies Record<ReceiptOrigin, ReceiptOrigin>;
+
+export function isReceiptOrigin(value: unknown): value is ReceiptOrigin {
+  return typeof value === 'string' && (RECEIPT_ORIGINS as readonly string[]).includes(value);
+}
+
+/**
+ * Map a persisted column value to the reporting/read contract.
+ * Legacy NULL (and empty) → UNCLASSIFIED.
+ */
+export function resolveReceiptOrigin(value: string | null | undefined): ReceiptOrigin {
+  if (value == null || value === '') return RECEIPT_ORIGIN.UNCLASSIFIED;
+  if (isReceiptOrigin(value)) return value;
+  return RECEIPT_ORIGIN.UNCLASSIFIED;
+}
+
+/**
+ * Validate a backup/import payload origin.
+ * Missing → null (legacy unclassified).
+ * Invalid non-empty → throws.
+ */
+export function parseOptionalReceiptOrigin(
+  value: unknown,
+): ReceiptOrigin | null {
+  if (value == null || value === '') return null;
+  if (isReceiptOrigin(value)) return value;
+  throw new Error(
+    `Invalid receiptOrigin "${String(value)}". Expected one of: ${RECEIPT_ORIGINS.join(', ')}.`,
+  );
+}
+
+/** Build payment create data with a required origin (live write paths). */
+export function withReceiptOrigin<T extends Record<string, unknown>>(
+  payment: T,
+  receiptOrigin: ReceiptOrigin,
+): T & { receiptOrigin: ReceiptOrigin } {
+  return { ...payment, receiptOrigin };
+}

--- a/lib/services/payments.test.ts
+++ b/lib/services/payments.test.ts
@@ -553,6 +553,7 @@ describe('payments service', () => {
         salesInvoiceId: 'sale-1',
         method: 'CASH',
         amountPence: 200000,
+        receiptOrigin: 'LATER_CREDIT_COLLECTION',
       })],
     });
     expect(recordCashDrawerEntryTxMock).toHaveBeenCalledWith(

--- a/lib/services/payments.ts
+++ b/lib/services/payments.ts
@@ -13,6 +13,7 @@ import { getOpenCashShiftForPayment, recordCashDrawerEntryTx } from './cash-draw
 import { measureServerOperation, PERFORMANCE_THRESHOLDS_MS } from '@/lib/observability';
 import { UserError } from '@/lib/action-utils';
 import type { Role } from '@/lib/auth';
+import { RECEIPT_ORIGIN } from '@/lib/payments/receipt-origin';
 
 const SUPPLIER_PAYMENT_ROLES: readonly Role[] = ['OWNER', 'MANAGER'];
 
@@ -199,7 +200,9 @@ async function recordCustomerPaymentImpl(
         salesInvoiceId: invoice.id,
         method: p.method,
         amountPence: p.amountPence,
-        reference: p.reference ?? null
+        reference: p.reference ?? null,
+        // Debtor / customer-receipt workflow after the sale already exists.
+        receiptOrigin: RECEIPT_ORIGIN.LATER_CREDIT_COLLECTION,
       }))
     });
 

--- a/lib/services/sales.ts
+++ b/lib/services/sales.ts
@@ -29,6 +29,7 @@ import { isDiscountReasonCode } from '@/lib/fraud/reason-codes';
 import { resolveBranchIdForStore } from './branches';
 import { measureServerOperation, PERFORMANCE_THRESHOLDS_MS } from '@/lib/observability';
 import { isSqliteDatabaseUrl } from '@/lib/database-runtime';
+import { RECEIPT_ORIGIN } from '@/lib/payments/receipt-origin';
 import { unstable_cache } from 'next/cache';
 
 // Account codes fetched on every checkout — extracted to module level so the
@@ -876,6 +877,9 @@ async function createSaleImpl(input: CreateSaleInput) {
           provider: payment.provider ?? null,
           status: payment.status ?? 'CONFIRMED',
           collectionId: payment.collectionId ?? null,
+          // Checkout / original sale workflow — including split-tender components
+          // and part-paid deposits created with the invoice.
+          receiptOrigin: RECEIPT_ORIGIN.RECEIVED_AT_SALE,
         }))
       }
     };
@@ -1512,6 +1516,9 @@ export async function amendSale(input: AmendSaleInput) {
             method: refundMethod,
             amountPence: -refundAmount, // negative = refund
             branchId: invoice.branchId ?? null,
+            // Amendment refund: direction is amount sign. Origin is UNCLASSIFIED —
+            // the amend workflow does not establish sale-time vs later-collection.
+            receiptOrigin: RECEIPT_ORIGIN.UNCLASSIFIED,
           },
         })
       );
@@ -1545,6 +1552,9 @@ export async function amendSale(input: AmendSaleInput) {
             method: additionalPaymentMethod,
             amountPence: additionalPaymentNeeded,
             branchId: invoice.branchId ?? null,
+            // Amendment add: sale already existed; action is amend, not checkout or
+            // debtor collection — persist UNCLASSIFIED rather than inventing meaning.
+            receiptOrigin: RECEIPT_ORIGIN.UNCLASSIFIED,
           },
         })
       );

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "db:reset": "del dev.db 2>nul & npm run db:setup",
     "generate:og": "node scripts/generate-tillflow-og-v2.mjs",
     "test:migration:p1-schema:pg": "node scripts/migration-p1-schema-pg-test.cjs",
+    "test:payment-receipt-origin:pg": "node scripts/payment-receipt-origin-pg-test.cjs",
+    "test:payment-receipt-origin:preview-probe": "node scripts/payment-receipt-origin-preview-probe.cjs",
     "test:migration:p1-slice2a:pg": "node scripts/migration-p1-slice2a-pg-test.cjs",
     "test:migration:p1-slice2a:preview-probe": "node scripts/migration-p1-slice2a-preview-probe.cjs",
     "test:migration:p1-sql-only-contract": "node scripts/migration-p1-sql-only-constraint-contract.cjs",

--- a/prisma/migrations/20260808120000_sales_payment_receipt_origin/migration.sql
+++ b/prisma/migrations/20260808120000_sales_payment_receipt_origin/migration.sql
@@ -1,0 +1,22 @@
+-- Forward-only SalesPayment.receiptOrigin foundation.
+--
+-- NULL on existing rows = historical UNCLASSIFIED (no speculative backfill).
+-- New application write paths must persist an explicit non-null value:
+--   RECEIVED_AT_SALE | LATER_CREDIT_COLLECTION | UNCLASSIFIED
+--
+-- Additive, nullable, no DEFAULT rewrite of historical rows.
+-- Compatible with old app builds that ignore the column.
+-- Rollback: DROP CONSTRAINT then DROP COLUMN (data in this column is lost on rollback).
+
+ALTER TABLE "SalesPayment" ADD COLUMN "receiptOrigin" TEXT;
+
+ALTER TABLE "SalesPayment"
+  ADD CONSTRAINT "SalesPayment_receiptOrigin_check"
+  CHECK (
+    "receiptOrigin" IS NULL
+    OR "receiptOrigin" IN (
+      'RECEIVED_AT_SALE',
+      'LATER_CREDIT_COLLECTION',
+      'UNCLASSIFIED'
+    )
+  );

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -1325,6 +1325,10 @@ model SalesPayment {
   payerMsisdn    String?
   provider       String?
   status         String   @default("CONFIRMED")
+  // Forward-only payment-origin contract. NULL = historical / legacy unclassified.
+  // New write paths must persist RECEIVED_AT_SALE | LATER_CREDIT_COLLECTION | UNCLASSIFIED.
+  // See lib/payments/receipt-origin.ts. Do not infer from timestamps.
+  receiptOrigin  String?
   collectionId   String?
   branchId       String?
   qaTag          String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1356,6 +1356,10 @@ model SalesPayment {
   payerMsisdn    String?
   provider       String?
   status         String   @default("CONFIRMED")
+  // Forward-only payment-origin contract. NULL = historical / legacy unclassified.
+  // New write paths must persist RECEIVED_AT_SALE | LATER_CREDIT_COLLECTION | UNCLASSIFIED.
+  // See lib/payments/receipt-origin.ts. Do not infer from timestamps.
+  receiptOrigin  String?
   collectionId   String?
   branchId       String?
   qaTag          String?

--- a/scripts/payment-receipt-origin-pg-test.cjs
+++ b/scripts/payment-receipt-origin-pg-test.cjs
@@ -1,0 +1,360 @@
+/**
+ * PostgreSQL behavioural suite for SalesPayment.receiptOrigin foundation.
+ *
+ * FATAL (exit 2) if no Postgres URL — this suite must not silently skip.
+ *
+ * Env: POSTGRES_URL_NON_POOLING | POSTGRES_PRISMA_URL | DATABASE_URL (postgres://)
+ */
+
+const { Client } = require('pg');
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const root = path.resolve(__dirname, '..');
+const schemaRel = 'prisma/schema.postgres.prisma';
+
+function requireUrl() {
+  const url =
+    process.env.POSTGRES_URL_NON_POOLING ||
+    process.env.POSTGRES_PRISMA_URL ||
+    process.env.DATABASE_URL;
+  if (!url || !String(url).startsWith('postgres')) {
+    console.error(
+      'FATAL: PostgreSQL URL required (POSTGRES_URL_NON_POOLING / POSTGRES_PRISMA_URL). Suite did not execute.',
+    );
+    process.exit(2);
+  }
+  return url;
+}
+
+function cuid() {
+  return 'c' + crypto.randomBytes(12).toString('hex');
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+async function main() {
+  const started = Date.now();
+  const url = requireUrl();
+  process.env.POSTGRES_PRISMA_URL = url;
+  process.env.POSTGRES_URL_NON_POOLING = url;
+
+  console.log('Deploying migrations…');
+  execSync(`npx prisma migrate deploy --schema=${schemaRel}`, {
+    cwd: root,
+    stdio: 'inherit',
+    env: process.env,
+    shell: true,
+  });
+
+  const db = new Client({
+    connectionString: url,
+    ssl: url.includes('localhost') || url.includes('127.0.0.1')
+      ? false
+      : { rejectUnauthorized: false },
+  });
+  await db.connect();
+
+  let passed = 0;
+  const tag = `RECEIPT_ORIGIN_PG_${Date.now()}`;
+
+  async function ok(label) {
+    passed += 1;
+    console.log(`  OK ${label}`);
+  }
+
+  try {
+    // Column exists and is nullable
+    const col = await db.query(`
+      SELECT is_nullable, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'SalesPayment' AND column_name = 'receiptOrigin'
+    `);
+    assert(col.rows.length === 1, 'receiptOrigin column missing');
+    assert(col.rows[0].is_nullable === 'YES', 'receiptOrigin must be nullable');
+    await ok('migration added nullable receiptOrigin');
+
+    // Seed minimal business graph
+    const businessId = cuid();
+    const foreignBusinessId = cuid();
+    const storeId = cuid();
+    const foreignStoreId = cuid();
+    const tillId = cuid();
+    const foreignTillId = cuid();
+    const userId = cuid();
+    const foreignUserId = cuid();
+
+    await db.query(
+      `INSERT INTO "Business" (id, name, currency, timezone, "subscriptionStatus", "updatedAt")
+       VALUES ($1,$2,'GHS','Africa/Accra','TRIAL_ACTIVE',NOW())`,
+      [businessId, `${tag} Biz`],
+    );
+    await db.query(
+      `INSERT INTO "Business" (id, name, currency, timezone, "subscriptionStatus", "updatedAt")
+       VALUES ($1,$2,'GHS','Africa/Accra','TRIAL_ACTIVE',NOW())`,
+      [foreignBusinessId, `${tag} Foreign`],
+    );
+    await db.query(`INSERT INTO "Store" (id,"businessId",name) VALUES ($1,$2,'Main')`, [
+      storeId,
+      businessId,
+    ]);
+    await db.query(`INSERT INTO "Store" (id,"businessId",name) VALUES ($1,$2,'Foreign')`, [
+      foreignStoreId,
+      foreignBusinessId,
+    ]);
+    await db.query(`INSERT INTO "Till" (id,"storeId",name) VALUES ($1,$2,'T1')`, [tillId, storeId]);
+    await db.query(`INSERT INTO "Till" (id,"storeId",name) VALUES ($1,$2,'FT')`, [
+      foreignTillId,
+      foreignStoreId,
+    ]);
+    await db.query(
+      `INSERT INTO "User" (id,"businessId",email,name,"passwordHash",role,active)
+       VALUES ($1,$2,$3,'Owner','x','OWNER',true)`,
+      [userId, businessId, `${tag}-owner@tillflow-test.invalid`],
+    );
+    await db.query(
+      `INSERT INTO "User" (id,"businessId",email,name,"passwordHash",role,active)
+       VALUES ($1,$2,$3,'Foreign','x','OWNER',true)`,
+      [foreignUserId, foreignBusinessId, `${tag}-foreign@tillflow-test.invalid`],
+    );
+
+    async function insertInvoice(id, biz, store, till, cashier, total) {
+      await db.query(
+        `INSERT INTO "SalesInvoice" (
+           id,"businessId","storeId","tillId","cashierUserId","paymentStatus",
+           "transactionNumber","subtotalPence","vatPence","totalPence"
+         ) VALUES ($1,$2,$3,$4,$5,'PAID',$6,$7,0,$7)`,
+        [id, biz, store, till, cashier, `TX-${id.slice(-8)}`, total],
+      );
+    }
+
+    // Historical payment WITHOUT receiptOrigin (simulate pre-migration row insert)
+    const histInvoice = cuid();
+    const histPayment = cuid();
+    await insertInvoice(histInvoice, businessId, storeId, tillId, userId, 5000);
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status)
+       VALUES ($1,$2,'CASH',5000,'CONFIRMED')`,
+      [histPayment, histInvoice],
+    );
+    const hist = await db.query(
+      `SELECT "receiptOrigin","amountPence" FROM "SalesPayment" WHERE id=$1`,
+      [histPayment],
+    );
+    assert(hist.rows[0].receiptOrigin === null, 'historical row must remain NULL');
+    assert(Number(hist.rows[0].amountPence) === 5000, 'historical amount unchanged');
+    await ok('historical payment survives as NULL unclassified');
+
+    // Pre/post migration amount invariant already satisfied for this DB;
+    // insert new classified payments and verify constraints.
+
+    const saleCash = cuid();
+    const payCash = cuid();
+    await insertInvoice(saleCash, businessId, storeId, tillId, userId, 10000);
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin")
+       VALUES ($1,$2,'CASH',10000,'CONFIRMED','RECEIVED_AT_SALE')`,
+      [payCash, saleCash],
+    );
+    await ok('RECEIVED_AT_SALE cash insert');
+
+    const saleMomo = cuid();
+    const payMomo = cuid();
+    await insertInvoice(saleMomo, businessId, storeId, tillId, userId, 6000);
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin")
+       VALUES ($1,$2,'MOBILE_MONEY',6000,'CONFIRMED','RECEIVED_AT_SALE')`,
+      [payMomo, saleMomo],
+    );
+    await ok('RECEIVED_AT_SALE MoMo insert');
+
+    const saleSplit = cuid();
+    const paySplitCash = cuid();
+    const paySplitMomo = cuid();
+    await insertInvoice(saleSplit, businessId, storeId, tillId, userId, 10000);
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin")
+       VALUES ($1,$2,'CASH',4000,'CONFIRMED','RECEIVED_AT_SALE'),
+              ($3,$2,'MOBILE_MONEY',6000,'CONFIRMED','RECEIVED_AT_SALE')`,
+      [paySplitCash, saleSplit, paySplitMomo],
+    );
+    await ok('split-tender components each RECEIVED_AT_SALE');
+
+    const salePart = cuid();
+    const payDeposit = cuid();
+    await insertInvoice(salePart, businessId, storeId, tillId, userId, 10000);
+    await db.query(
+      `UPDATE "SalesInvoice" SET "paymentStatus"='PART_PAID' WHERE id=$1`,
+      [salePart],
+    );
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin")
+       VALUES ($1,$2,'CASH',3000,'CONFIRMED','RECEIVED_AT_SALE')`,
+      [payDeposit, salePart],
+    );
+    await ok('part-paid deposit RECEIVED_AT_SALE');
+
+    const saleUnpaid = cuid();
+    await insertInvoice(saleUnpaid, businessId, storeId, tillId, userId, 8000);
+    await db.query(
+      `UPDATE "SalesInvoice" SET "paymentStatus"='UNPAID' WHERE id=$1`,
+      [saleUnpaid],
+    );
+    const unpaidPays = await db.query(
+      `SELECT COUNT(*)::int AS c FROM "SalesPayment" WHERE "salesInvoiceId"=$1`,
+      [saleUnpaid],
+    );
+    assert(unpaidPays.rows[0].c === 0, 'unpaid credit must have no payments');
+    await ok('unpaid credit creates no payment');
+
+    const laterCash = cuid();
+    const laterMomo = cuid();
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin")
+       VALUES ($1,$2,'CASH',3000,'CONFIRMED','LATER_CREDIT_COLLECTION'),
+              ($3,$2,'MOBILE_MONEY',4000,'CONFIRMED','LATER_CREDIT_COLLECTION')`,
+      [laterCash, salePart, laterMomo],
+    );
+    await ok('later collections LATER_CREDIT_COLLECTION');
+
+    const multi1 = cuid();
+    const multi2 = cuid();
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin")
+       VALUES ($1,$2,'CASH',1000,'CONFIRMED','LATER_CREDIT_COLLECTION'),
+              ($3,$2,'CASH',1000,'CONFIRMED','LATER_CREDIT_COLLECTION')`,
+      [multi1, salePart, multi2],
+    );
+    await ok('multiple later collections preserve origin independently');
+
+    const ambig = cuid();
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin")
+       VALUES ($1,$2,'CARD',500,'CONFIRMED','UNCLASSIFIED')`,
+      [ambig, saleCash],
+    );
+    await ok('ambiguous import UNCLASSIFIED');
+
+    // Invalid origin rejected by CHECK
+    let rejected = false;
+    try {
+      await db.query(
+        `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin")
+         VALUES ($1,$2,'CASH',100,'CONFIRMED','YESTERDAY')`,
+        [cuid(), saleCash],
+      );
+    } catch (err) {
+      rejected = err && err.code === '23514';
+    }
+    assert(rejected, 'invalid origin must fail CHECK');
+    await ok('invalid origin fails safely');
+
+    // Old-format restore = NULL origin allowed
+    const oldRestore = cuid();
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status)
+       VALUES ($1,$2,'CASH',250,'CONFIRMED')`,
+      [oldRestore, saleCash],
+    );
+    const oldRow = await db.query(`SELECT "receiptOrigin" FROM "SalesPayment" WHERE id=$1`, [
+      oldRestore,
+    ]);
+    assert(oldRow.rows[0].receiptOrigin === null, 'old restore leaves NULL');
+    await ok('old-format restore leaves NULL unclassified');
+
+    // New-format round trip preserves
+    const rt = await db.query(
+      `SELECT "receiptOrigin" FROM "SalesPayment" WHERE id=$1`,
+      [payMomo],
+    );
+    assert(rt.rows[0].receiptOrigin === 'RECEIVED_AT_SALE', 'new origin preserved');
+    await ok('new-format origin preserved');
+
+    // Tenant isolation: foreign payment not visible under business filter via invoice
+    const foreignSale = cuid();
+    const foreignPay = cuid();
+    await insertInvoice(
+      foreignSale,
+      foreignBusinessId,
+      foreignStoreId,
+      foreignTillId,
+      foreignUserId,
+      99900,
+    );
+    await db.query(
+      `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin")
+       VALUES ($1,$2,'MOBILE_MONEY',99900,'CONFIRMED','RECEIVED_AT_SALE')`,
+      [foreignPay, foreignSale],
+    );
+    const leak = await db.query(
+      `SELECT sp.id FROM "SalesPayment" sp
+       JOIN "SalesInvoice" si ON si.id = sp."salesInvoiceId"
+       WHERE si."businessId" = $1 AND sp.id = $2`,
+      [businessId, foreignPay],
+    );
+    assert(leak.rows.length === 0, 'foreign tenant payment leaked');
+    await ok('cross-tenant isolation');
+
+    // Branch integrity: payments join to store via invoice
+    const branchOk = await db.query(
+      `SELECT COUNT(*)::int AS c FROM "SalesPayment" sp
+       JOIN "SalesInvoice" si ON si.id = sp."salesInvoiceId"
+       WHERE si."storeId" = $1 AND sp.id = $2`,
+      [storeId, payCash],
+    );
+    assert(branchOk.rows[0].c === 1, 'branch join broken');
+    await ok('branch relationship intact');
+
+    // Amount invariant for tagged fixture: sum matches inserts
+    const sum = await db.query(
+      `SELECT COALESCE(SUM(sp."amountPence"),0)::bigint AS total
+       FROM "SalesPayment" sp
+       JOIN "SalesInvoice" si ON si.id = sp."salesInvoiceId"
+       WHERE si."businessId" = $1`,
+      [businessId],
+    );
+    // hist 5000 + cash 10000 + momo 6000 + split 10000 + deposit 3000 + later 7000 + multi 2000 + ambig 500 + old 250
+    assert(Number(sum.rows[0].total) === 43750, `unexpected sum ${sum.rows[0].total}`);
+    await ok('payment amount totals consistent for fixture');
+
+    console.log(`\nPASSED ${passed} assertions in ${Date.now() - started}ms`);
+    console.log('SUITE_EXECUTED=1 SKIPPED=0');
+  } finally {
+    // Cleanup tagged businesses only
+    try {
+      const biz = await db.query(
+        `SELECT id FROM "Business" WHERE name LIKE $1`,
+        [`${tag}%`],
+      );
+      const ids = biz.rows.map((r) => r.id);
+      if (ids.length) {
+        await db.query(
+          `DELETE FROM "SalesPayment" WHERE "salesInvoiceId" IN (
+             SELECT id FROM "SalesInvoice" WHERE "businessId" = ANY($1::text[])
+           )`,
+          [ids],
+        );
+        await db.query(`DELETE FROM "SalesInvoice" WHERE "businessId" = ANY($1::text[])`, [ids]);
+        await db.query(
+          `DELETE FROM "Till" WHERE "storeId" IN (SELECT id FROM "Store" WHERE "businessId" = ANY($1::text[]))`,
+          [ids],
+        );
+        await db.query(`DELETE FROM "User" WHERE "businessId" = ANY($1::text[])`, [ids]);
+        await db.query(`DELETE FROM "Store" WHERE "businessId" = ANY($1::text[])`, [ids]);
+        await db.query(`DELETE FROM "Business" WHERE id = ANY($1::text[])`, [ids]);
+        console.log('CLEANUP removed tagged businesses', ids.length);
+      }
+    } catch (cleanupErr) {
+      console.error('CLEANUP warning', cleanupErr.message || cleanupErr);
+    }
+    await db.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('FAIL', err);
+  process.exit(1);
+});

--- a/scripts/payment-receipt-origin-preview-probe.cjs
+++ b/scripts/payment-receipt-origin-preview-probe.cjs
@@ -42,18 +42,24 @@ function requireUrl() {
     ...loadEnvFile(path.join(root, 'tmp', 'payment-origin-preview.local.env')),
     ...loadEnvFile(path.join(root, 'tmp', 'slice2a-preview.env')),
   };
+  // Prefer explicit Preview file/env over ambient shell DATABASE URLs
+  // (local Docker URLs often linger in the agent shell).
   const url =
     process.env.PREVIEW_DATABASE_URL ||
-    process.env.POSTGRES_URL_NON_POOLING ||
-    process.env.POSTGRES_PRISMA_URL ||
     fileEnv.PREVIEW_DATABASE_URL ||
     fileEnv.POSTGRES_URL_NON_POOLING ||
-    fileEnv.POSTGRES_PRISMA_URL;
+    fileEnv.POSTGRES_PRISMA_URL ||
+    process.env.POSTGRES_URL_NON_POOLING ||
+    process.env.POSTGRES_PRISMA_URL;
   if (!url || !String(url).startsWith('postgres')) {
     console.error('FATAL: Preview Postgres URL required. Probe did not execute.');
     process.exit(2);
   }
-  if (/tillflow(?!_preview)|prod/i.test(url) && !/preview/i.test(url)) {
+  const looksPreview =
+    /preview/i.test(url) ||
+    /tillflow_preview/i.test(url) ||
+    process.env.ALLOW_PREVIEW_PROBE_URL === '1';
+  if (!looksPreview) {
     console.error('FATAL: Refusing URL that does not look like Preview.');
     process.exit(2);
   }

--- a/scripts/payment-receipt-origin-preview-probe.cjs
+++ b/scripts/payment-receipt-origin-preview-probe.cjs
@@ -1,0 +1,485 @@
+/**
+ * Preview-only payment receipt-origin foundation probe.
+ *
+ * Applies migration to the isolated Preview Postgres DB, captures baseline
+ * fingerprints, inserts tagged synthetic scenarios, verifies origins, then
+ * removes only tagged synthetic records and proves baseline restored.
+ *
+ * NEVER targets Production. Exit 2 = blocked/missing env. Exit 1 = fail.
+ *
+ * Env:
+ *   POSTGRES_URL_NON_POOLING | PREVIEW_DATABASE_URL | POSTGRES_PRISMA_URL
+ * Optional:
+ *   tmp/payment-origin-preview.local.env (gitignored)
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { Client } = require('pg');
+const { execSync } = require('node:child_process');
+
+const root = path.resolve(__dirname, '..');
+const TAG = `RECEIPT_ORIGIN_PREVIEW_${Date.now()}_${crypto.randomBytes(3).toString('hex')}`;
+
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  const o = {};
+  for (const raw of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    const m = raw.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    let v = m[2].trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1);
+    }
+    o[m[1]] = v;
+  }
+  return o;
+}
+
+function requireUrl() {
+  const fileEnv = {
+    ...loadEnvFile(path.join(root, 'tmp', 'payment-origin-preview.local.env')),
+    ...loadEnvFile(path.join(root, 'tmp', 'slice2a-preview.env')),
+  };
+  const url =
+    process.env.PREVIEW_DATABASE_URL ||
+    process.env.POSTGRES_URL_NON_POOLING ||
+    process.env.POSTGRES_PRISMA_URL ||
+    fileEnv.PREVIEW_DATABASE_URL ||
+    fileEnv.POSTGRES_URL_NON_POOLING ||
+    fileEnv.POSTGRES_PRISMA_URL;
+  if (!url || !String(url).startsWith('postgres')) {
+    console.error('FATAL: Preview Postgres URL required. Probe did not execute.');
+    process.exit(2);
+  }
+  if (/tillflow(?!_preview)|prod/i.test(url) && !/preview/i.test(url)) {
+    console.error('FATAL: Refusing URL that does not look like Preview.');
+    process.exit(2);
+  }
+  return url;
+}
+
+function cuid() {
+  return 'c' + crypto.randomBytes(12).toString('hex');
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+async function fingerprint(db) {
+  const pay = await db.query(`
+    SELECT COUNT(*)::bigint AS cnt,
+           COALESCE(SUM("amountPence"),0)::bigint AS sum_amt,
+           COALESCE(SUM(("amountPence"::bigint * 31) + LENGTH(id)),0)::bigint AS fp
+    FROM "SalesPayment"
+  `);
+  const inv = await db.query(`
+    SELECT COUNT(*)::bigint AS cnt,
+           COALESCE(SUM("totalPence"),0)::bigint AS sum_amt
+    FROM "SalesInvoice"
+  `);
+  return {
+    paymentCount: Number(pay.rows[0].cnt),
+    paymentSum: Number(pay.rows[0].sum_amt),
+    paymentFp: String(pay.rows[0].fp),
+    invoiceCount: Number(inv.rows[0].cnt),
+    invoiceSum: Number(inv.rows[0].sum_amt),
+  };
+}
+
+async function main() {
+  const started = Date.now();
+  const url = requireUrl();
+  process.env.POSTGRES_PRISMA_URL = url;
+  process.env.POSTGRES_URL_NON_POOLING = url;
+
+  const db = new Client({
+    connectionString: url,
+    ssl: { rejectUnauthorized: false },
+  });
+  await db.connect();
+
+  const matrix = [];
+  let passed = 0;
+  const ok = async (label) => {
+    passed += 1;
+    console.log(`  OK ${label}`);
+  };
+
+  try {
+    console.log(`TAG=${TAG}`);
+
+    // Baseline before migrate (column may be absent on older Preview DBs)
+    let baselineBeforeMigrate = null;
+    const colBefore = await db.query(`
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='SalesPayment' AND column_name='receiptOrigin'
+    `);
+    baselineBeforeMigrate = await fingerprint(db);
+    console.log('BASELINE_BEFORE_MIGRATE', JSON.stringify(baselineBeforeMigrate));
+    console.log('COLUMN_BEFORE_MIGRATE', colBefore.rows.length === 1 ? 'present' : 'absent');
+
+    console.log('Deploying migrations to Preview…');
+    execSync(`npx prisma migrate deploy --schema=prisma/schema.postgres.prisma`, {
+      cwd: root,
+      stdio: 'inherit',
+      env: process.env,
+      shell: true,
+    });
+
+    const afterMigrate = await fingerprint(db);
+    console.log('AFTER_MIGRATE', JSON.stringify(afterMigrate));
+    assert(
+      afterMigrate.paymentCount === baselineBeforeMigrate.paymentCount,
+      `payment count changed by migration: ${baselineBeforeMigrate.paymentCount} → ${afterMigrate.paymentCount}`,
+    );
+    assert(
+      afterMigrate.paymentSum === baselineBeforeMigrate.paymentSum,
+      `payment sum changed by migration: ${baselineBeforeMigrate.paymentSum} → ${afterMigrate.paymentSum}`,
+    );
+    await ok('migration left payment counts/amounts unchanged');
+
+    const baseline = afterMigrate;
+
+    const businessId = cuid();
+    const foreignBusinessId = cuid();
+    const storeId = cuid();
+    const foreignStoreId = cuid();
+    const tillId = cuid();
+    const foreignTillId = cuid();
+    const userId = cuid();
+    const foreignUserId = cuid();
+
+    await db.query(
+      `INSERT INTO "Business" (id, name, currency, timezone, "subscriptionStatus", "updatedAt")
+       VALUES ($1,$2,'GHS','Africa/Accra','TRIAL_ACTIVE',NOW())`,
+      [businessId, `${TAG} Biz`],
+    );
+    await db.query(
+      `INSERT INTO "Business" (id, name, currency, timezone, "subscriptionStatus", "updatedAt")
+       VALUES ($1,$2,'GHS','Africa/Accra','TRIAL_ACTIVE',NOW())`,
+      [foreignBusinessId, `${TAG} Foreign`],
+    );
+    await db.query(`INSERT INTO "Store" (id,"businessId",name) VALUES ($1,$2,'Main')`, [
+      storeId,
+      businessId,
+    ]);
+    await db.query(`INSERT INTO "Store" (id,"businessId",name) VALUES ($1,$2,'Foreign')`, [
+      foreignStoreId,
+      foreignBusinessId,
+    ]);
+    await db.query(`INSERT INTO "Till" (id,"storeId",name) VALUES ($1,$2,'T1')`, [tillId, storeId]);
+    await db.query(`INSERT INTO "Till" (id,"storeId",name) VALUES ($1,$2,'FT')`, [
+      foreignTillId,
+      foreignStoreId,
+    ]);
+    await db.query(
+      `INSERT INTO "User" (id,"businessId",email,name,"passwordHash",role,active)
+       VALUES ($1,$2,$3,'Owner','x','OWNER',true)`,
+      [userId, businessId, `${TAG}-owner@tillflow-test.invalid`],
+    );
+    await db.query(
+      `INSERT INTO "User" (id,"businessId",email,name,"passwordHash",role,active)
+       VALUES ($1,$2,$3,'Foreign','x','OWNER',true)`,
+      [foreignUserId, foreignBusinessId, `${TAG}-foreign@tillflow-test.invalid`],
+    );
+
+    async function insertInvoice(id, biz, store, till, cashier, total, status = 'PAID') {
+      await db.query(
+        `INSERT INTO "SalesInvoice" (
+           id,"businessId","storeId","tillId","cashierUserId","paymentStatus",
+           "transactionNumber","subtotalPence","vatPence","totalPence","qaTag"
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,0,$8,$9)`,
+        [id, biz, store, till, cashier, status, `TX-${id.slice(-8)}`, total, TAG],
+      );
+    }
+
+    async function insertPay(id, invoiceId, method, amount, origin) {
+      if (origin == null) {
+        await db.query(
+          `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"qaTag")
+           VALUES ($1,$2,$3,$4,'CONFIRMED',$5)`,
+          [id, invoiceId, method, amount, TAG],
+        );
+      } else {
+        await db.query(
+          `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin","qaTag")
+           VALUES ($1,$2,$3,$4,'CONFIRMED',$5,$6)`,
+          [id, invoiceId, method, amount, origin, TAG],
+        );
+      }
+      const row = await db.query(
+        `SELECT "receiptOrigin","amountPence" FROM "SalesPayment" WHERE id=$1`,
+        [id],
+      );
+      return row.rows[0];
+    }
+
+    function push(scenario, expected, actual, count, amount, result) {
+      matrix.push({
+        scenario,
+        expected,
+        actual,
+        paymentCount: count,
+        amount,
+        cashDrawer: 'n/a-db-probe',
+        journal: 'n/a-db-probe',
+        result,
+      });
+    }
+
+    // Immediate cash
+    {
+      const inv = cuid();
+      const pay = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 10000);
+      const row = await insertPay(pay, inv, 'CASH', 10000, 'RECEIVED_AT_SALE');
+      assert(row.receiptOrigin === 'RECEIVED_AT_SALE', 'cash origin');
+      push('Immediate cash sale', 'RECEIVED_AT_SALE', row.receiptOrigin, 1, 10000, 'PASS');
+      await ok('cash sale');
+    }
+
+    // MoMo provider-style
+    {
+      const inv = cuid();
+      const pay = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 6000);
+      const row = await insertPay(pay, inv, 'MOBILE_MONEY', 6000, 'RECEIVED_AT_SALE');
+      push('Immediate MoMo sale', 'RECEIVED_AT_SALE', row.receiptOrigin, 1, 6000, 'PASS');
+      await ok('momo sale');
+    }
+
+    // Manual electronic
+    {
+      const inv = cuid();
+      const pay = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 4500);
+      const row = await insertPay(pay, inv, 'CARD', 4500, 'RECEIVED_AT_SALE');
+      push('Manual electronic sale', 'RECEIVED_AT_SALE', row.receiptOrigin, 1, 4500, 'PASS');
+      await ok('electronic sale');
+    }
+
+    // Split
+    {
+      const inv = cuid();
+      const p1 = cuid();
+      const p2 = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 10000);
+      const r1 = await insertPay(p1, inv, 'CASH', 4000, 'RECEIVED_AT_SALE');
+      const r2 = await insertPay(p2, inv, 'MOBILE_MONEY', 6000, 'RECEIVED_AT_SALE');
+      push('Split-tender cash component', 'RECEIVED_AT_SALE', r1.receiptOrigin, 1, 4000, 'PASS');
+      push(
+        'Split-tender electronic component',
+        'RECEIVED_AT_SALE',
+        r2.receiptOrigin,
+        1,
+        6000,
+        'PASS',
+      );
+      await ok('split tender');
+    }
+
+    // Part-paid + later collections + multi
+    {
+      const inv = cuid();
+      const deposit = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 10000, 'PART_PAID');
+      const d = await insertPay(deposit, inv, 'CASH', 3000, 'RECEIVED_AT_SALE');
+      push('Part-paid sale', 'RECEIVED_AT_SALE', d.receiptOrigin, 1, 3000, 'PASS');
+
+      const c1 = cuid();
+      const c2 = cuid();
+      const m1 = cuid();
+      const m2 = cuid();
+      const laterCash = await insertPay(c1, inv, 'CASH', 2000, 'LATER_CREDIT_COLLECTION');
+      const laterMomo = await insertPay(c2, inv, 'MOBILE_MONEY', 2000, 'LATER_CREDIT_COLLECTION');
+      const multiA = await insertPay(m1, inv, 'CASH', 1500, 'LATER_CREDIT_COLLECTION');
+      const multiB = await insertPay(m2, inv, 'CASH', 1500, 'LATER_CREDIT_COLLECTION');
+      push('Later cash collection', 'LATER_CREDIT_COLLECTION', laterCash.receiptOrigin, 1, 2000, 'PASS');
+      push('Later MoMo collection', 'LATER_CREDIT_COLLECTION', laterMomo.receiptOrigin, 1, 2000, 'PASS');
+      push(
+        'Multiple later collections',
+        'LATER_CREDIT_COLLECTION each',
+        `${multiA.receiptOrigin},${multiB.receiptOrigin}`,
+        2,
+        3000,
+        'PASS',
+      );
+      await ok('part-paid + collections');
+    }
+
+    // Unpaid credit — no payment
+    {
+      const inv = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 8000, 'UNPAID');
+      const cnt = await db.query(
+        `SELECT COUNT(*)::int AS c FROM "SalesPayment" WHERE "salesInvoiceId"=$1`,
+        [inv],
+      );
+      assert(cnt.rows[0].c === 0, 'unpaid must have no payments');
+      push('Unpaid credit sale', 'No payment', 'none', 0, 0, 'PASS');
+      await ok('unpaid credit');
+    }
+
+    // Ambiguous import
+    {
+      const inv = cuid();
+      const pay = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 500);
+      const row = await insertPay(pay, inv, 'CARD', 500, 'UNCLASSIFIED');
+      push('Ambiguous import', 'UNCLASSIFIED', row.receiptOrigin, 1, 500, 'PASS');
+      await ok('ambiguous import');
+    }
+
+    // Old backup restore (null origin)
+    {
+      const inv = cuid();
+      const pay = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 250);
+      const row = await insertPay(pay, inv, 'CASH', 250, null);
+      assert(row.receiptOrigin === null, 'old restore null');
+      push('Old backup restore', 'Legacy unclassified (NULL)', 'NULL', 1, 250, 'PASS');
+      await ok('old backup restore');
+    }
+
+    // New backup preserve
+    {
+      const inv = cuid();
+      const pay = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 700);
+      await insertPay(pay, inv, 'CASH', 700, 'RECEIVED_AT_SALE');
+      const rt = await db.query(`SELECT "receiptOrigin" FROM "SalesPayment" WHERE id=$1`, [pay]);
+      assert(rt.rows[0].receiptOrigin === 'RECEIVED_AT_SALE', 'preserve');
+      push('New backup restore', 'Original value preserved', rt.rows[0].receiptOrigin, 1, 700, 'PASS');
+      await ok('new backup preserve');
+    }
+
+    // Amendment refund (negative UNCLASSIFIED)
+    {
+      const inv = cuid();
+      const pay = cuid();
+      await insertInvoice(inv, businessId, storeId, tillId, userId, 1000);
+      const row = await insertPay(pay, inv, 'CASH', -500, 'UNCLASSIFIED');
+      push(
+        'Amendment/refund/reversal',
+        'UNCLASSIFIED (documented)',
+        row.receiptOrigin,
+        1,
+        -500,
+        'PASS',
+      );
+      await ok('amendment refund');
+    }
+
+    // Foreign branch / tenant
+    {
+      const inv = cuid();
+      const pay = cuid();
+      await insertInvoice(inv, foreignBusinessId, foreignStoreId, foreignTillId, foreignUserId, 99900);
+      await insertPay(pay, inv, 'MOBILE_MONEY', 99900, 'RECEIVED_AT_SALE');
+      const leak = await db.query(
+        `SELECT sp.id FROM "SalesPayment" sp
+         JOIN "SalesInvoice" si ON si.id = sp."salesInvoiceId"
+         WHERE si."businessId"=$1 AND sp.id=$2`,
+        [businessId, pay],
+      );
+      assert(leak.rows.length === 0, 'tenant leak');
+      push('Foreign branch', 'Correctly isolated', 'isolated', 1, 99900, 'PASS');
+      push('Foreign tenant', 'No leak', 'no-leak', 1, 99900, 'PASS');
+      await ok('tenant/branch isolation');
+    }
+
+    // Invalid origin
+    {
+      let rejected = false;
+      try {
+        const inv = cuid();
+        await insertInvoice(inv, businessId, storeId, tillId, userId, 100);
+        await db.query(
+          `INSERT INTO "SalesPayment" (id,"salesInvoiceId",method,"amountPence",status,"receiptOrigin","qaTag")
+           VALUES ($1,$2,'CASH',100,'CONFIRMED','YESTERDAY',$3)`,
+          [cuid(), inv, TAG],
+        );
+      } catch (err) {
+        rejected = err && err.code === '23514';
+      }
+      assert(rejected, 'invalid origin must fail');
+      await ok('invalid origin rejected');
+    }
+
+    console.log('\nPREVIEW_EVIDENCE_MATRIX');
+    console.log(JSON.stringify(matrix, null, 2));
+
+    // Cleanup tagged synthetic only
+    const biz = await db.query(`SELECT id FROM "Business" WHERE name LIKE $1`, [`${TAG}%`]);
+    const ids = biz.rows.map((r) => r.id);
+    assert(ids.length >= 2, 'expected tagged businesses');
+
+    await db.query(
+      `DELETE FROM "SalesPayment" WHERE "qaTag"=$1 OR "salesInvoiceId" IN (
+         SELECT id FROM "SalesInvoice" WHERE "businessId" = ANY($2::text[]) OR "qaTag"=$1
+       )`,
+      [TAG, ids],
+    );
+    await db.query(
+      `DELETE FROM "SalesInvoice" WHERE "businessId" = ANY($1::text[]) OR "qaTag"=$2`,
+      [ids, TAG],
+    );
+    await db.query(
+      `DELETE FROM "Till" WHERE "storeId" IN (SELECT id FROM "Store" WHERE "businessId" = ANY($1::text[]))`,
+      [ids],
+    );
+    await db.query(`DELETE FROM "User" WHERE "businessId" = ANY($1::text[])`, [ids]);
+    await db.query(`DELETE FROM "Store" WHERE "businessId" = ANY($1::text[])`, [ids]);
+    await db.query(`DELETE FROM "Business" WHERE id = ANY($1::text[])`, [ids]);
+
+    const remaining = await db.query(
+      `SELECT COUNT(*)::int AS c FROM "SalesPayment" WHERE "qaTag"=$1`,
+      [TAG],
+    );
+    assert(remaining.rows[0].c === 0, 'tagged payments remain');
+
+    const afterCleanup = await fingerprint(db);
+    console.log('AFTER_CLEANUP', JSON.stringify(afterCleanup));
+    assert(
+      afterCleanup.paymentCount === baseline.paymentCount,
+      `cleanup payment count drift ${baseline.paymentCount} → ${afterCleanup.paymentCount}`,
+    );
+    assert(
+      afterCleanup.paymentSum === baseline.paymentSum,
+      `cleanup payment sum drift ${baseline.paymentSum} → ${afterCleanup.paymentSum}`,
+    );
+    assert(
+      afterCleanup.paymentFp === baseline.paymentFp,
+      `cleanup fingerprint drift ${baseline.paymentFp} → ${afterCleanup.paymentFp}`,
+    );
+    assert(
+      afterCleanup.invoiceCount === baseline.invoiceCount,
+      `cleanup invoice count drift`,
+    );
+
+    console.log(
+      JSON.stringify({
+        tag: TAG,
+        baseline,
+        afterCleanup,
+        taggedRemaining: 0,
+        unrelatedChanged: 0,
+        passed,
+        durationMs: Date.now() - started,
+        SUITE_EXECUTED: 1,
+        SKIPPED: 0,
+      }),
+    );
+    console.log(`\nPREVIEW_PROBE PASSED ${passed} in ${Date.now() - started}ms`);
+  } finally {
+    await db.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('FAIL', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Forward-only payment-origin foundation so TillFlow can persist durable receipt origin from authoritative workflows — without the five-minute timestamp heuristic investigated on PR #84 (Outcome C).

**This PR does not implement PR #84 reporting UI.** It prepares a safe schema + write-path contract for a later rebase of #84 under separate authorisation.

### Problem / Outcome C

Existing `SalesPayment` records cannot reliably distinguish `RECEIVED_AT_SALE` vs `LATER_CREDIT_COLLECTION`. Sparse signals (`collectionId`, drawer/JE, timestamps) are insufficient. Timestamp grace windows are false accounting logic and are **not** copied here.

### Schema contract

- Field: `SalesPayment.receiptOrigin` (`String?` / nullable TEXT)
- Values: `RECEIVED_AT_SALE` | `LATER_CREDIT_COLLECTION` | `UNCLASSIFIED` | `NULL`
- CHECK constraint; **no DEFAULT rewrite** of historical rows
- Historical `NULL` = unclassified (honest unknown)
- Domain: `lib/payments/receipt-origin.ts`
- Docs: `docs/payments/RECEIPT_ORIGIN_FOUNDATION.md`
- Migration: `prisma/migrations/20260808120000_sales_payment_receipt_origin/`

### Historical-data policy

No speculative classification. No bulk UPDATE to `UNCLASSIFIED`. Nullable column chosen so honesty does not require rewriting every historical payment.

### Write-path inventory + assignment

| Write path | Origin |
| --- | --- |
| Checkout / split / part-paid deposit (`sales.ts`) | `RECEIVED_AT_SALE` |
| Debtor/customer payment (`payments.ts`) | `LATER_CREDIT_COLLECTION` |
| Amendment +payment / −refund (`sales.ts`) | `UNCLASSIFIED` |
| Demo-day seed | `RECEIVED_AT_SALE` |
| Backup restore | Preserve valid / NULL if missing; invalid fails |
| Returns / voids | No `SalesPayment` create |

### Refund / reversal limitations

Amendment refunds are negative `SalesPayment` rows with `UNCLASSIFIED` origin. There is no durable FK to the reversed payment. Returns/voids use `SalesReturn` / stock paths — not payment creates. Origin is not a substitute for a missing reversal model.

### Backup / restore

Export version `1.1` preserves origin. Old backups without the field restore as NULL (unclassified). No timestamp fabrication.

### Migration safety

Additive nullable column + CHECK. Compatible with old app builds ignoring the column. Payment counts/amounts unchanged by migration itself. Rollback drops column (origin lost; money fields intact). **Production migrate not authorised by this PR.**

### PostgreSQL evidence (local)

- Command: `npm run test:payment-receipt-origin:pg`
- `SUITE_EXECUTED=1 SKIPPED=0` — 16 assertions
- CI: `postgres-smoke` workflow includes this suite

### Scope guards

- PR #83 remains open/separate/untouched
- PR #84 remains open/blocked/unmerged/untouched (not a base for this work)
- No Production deploy or Production data mutation
- No Trading Report / receipts UI / Home nav changes

### Human review required

Do **not** treat CI green as merge-ready. Schema and accounting review required before Production migrate.

## Test plan

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run test:pos-safety:unit`
- [ ] `npm run test:payment-receipt-origin:pg` (must not skip)
- [ ] `npm run build`
- [ ] CI `postgres-smoke` green on final SHA
- [ ] Preview deploy tied to final SHA; Preview-only migrate; synthetic probe + cleanup fingerprints
- [ ] Confirm PR #83 / #84 heads unchanged
